### PR TITLE
Remove required Vapor dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
             name: "FOSMVVM",
             dependencies: [
                 .byName(name: "FOSFoundation"),
-                .product(name: "Vapor", package: "Vapor"),
+                .product(name: "Vapor", package: "Vapor", condition: .when(platforms: [.macOS, .linux])),
                 .product(name: "Yams", package: "Yams")
             ],
             swiftSettings: [

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -51,7 +51,7 @@ let package = Package(
             name: "FOSMVVM",
             dependencies: [
                 .byName(name: "FOSFoundation"),
-                .product(name: "Vapor", package: "Vapor"),
+                .product(name: "Vapor", package: "Vapor", condition: .when(platforms: [.macOS, .linux])),
                 .product(name: "Yams", package: "Yams")
             ],
             swiftSettings: [
@@ -79,7 +79,7 @@ let package = Package(
                 .byName(name: "FOSFoundation"),
                 .byName(name: "FOSMVVM"),
                 .byName(name: "FOSTesting"),
-                .product(name: "Vapor", package: "Vapor"),
+                .product(name: "Vapor", package: "Vapor", condition: .when(platforms: [.macOS, .linux])),
                 .product(name: "Testing", package: "swift-testing")
             ],
             resources: [

--- a/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
+++ b/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
@@ -17,7 +17,9 @@
 
 import FOSFoundation
 import Foundation
+#if canImport(Vapor)
 import Vapor
+#endif
 import Yams
 
 public enum YamlStoreError: Error {
@@ -26,6 +28,7 @@ public enum YamlStoreError: Error {
     case fileError(path: URL, error: any Error)
 }
 
+#if canImport(Vapor)
 public extension Application {
     var localizationStore: LocalizationStore? {
         get {
@@ -57,9 +60,10 @@ public extension Application {
         lifecycle.use(YamlLocalizationInitializer(config: config))
     }
 }
+#endif
 
-/// An extension on Bundle to allow tests to initialize the YamlStore
-extension Bundle {
+/// An extension on Bundle to allow initialization of the YamlStore
+public extension Bundle {
     func yamlLocalization(resourceDirectoryName: String) async throws -> LocalizationStore {
         let config = yamlStoreConfig(
             resourceDirectoryName: resourceDirectoryName
@@ -99,6 +103,7 @@ private extension Bundle {
     }
 }
 
+#if canImport(Vapor)
 private struct YamlLocalizationInitializer: LifecycleHandler {
     let config: YamlStoreConfig
 
@@ -114,6 +119,7 @@ private struct YamlLocalizationInitializer: LifecycleHandler {
 private struct YamlLocalizationStore: StorageKey {
     typealias Value = LocalizationStore
 }
+#endif
 
 private struct YamlStore: LocalizationStore {
     let config: YamlStoreConfig

--- a/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
+++ b/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
@@ -217,7 +217,7 @@ private extension YamlStore {
         }
 
         // Try a 'base' locale
-        #if !os(Linux)
+        #if !os(Linux) && !os(Windows)
         if #available(macOS 15, iOS 16, tvOS 16, watchOS 9, visionOS 1, macCatalyst 16, *) {
             let localeComps = Locale.Language.Components(identifier: locale)
             let baseLocale = localeComps.languageCode?.identifier.lowercased() ?? "n/a"

--- a/Sources/FOSMVVM/Protocols/SystemVersion.swift
+++ b/Sources/FOSMVVM/Protocols/SystemVersion.swift
@@ -20,7 +20,9 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+#if canImport(Vapor)
 import Vapor
+#endif
 
 public enum SystemVersionError: Error {
     case invalidSystemVersionString(_ str: String)
@@ -156,6 +158,7 @@ public extension HTTPURLResponse {
     }
 }
 
+#if canImport(Vapor)
 public extension Vapor.Request {
     /// - Returns: the ``SystemVersion`` specified in the HTTPHeader
     ///
@@ -185,6 +188,7 @@ public extension Vapor.Request {
         }
     }
 }
+#endif
 
 private struct DefaultSystemVersion: SystemVersion {
     static let currentVersion = Self(majorVersion: 1, minorVersion: 2, patchVersion: 3)


### PR DESCRIPTION
Not all platforms can (or should) import/build Vapor.