### PR TITLE
Fixed issue where locales had an underscore instead of a dash

### DIFF
--- a/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
+++ b/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
@@ -306,6 +306,7 @@ private extension YamlStore {
     }
 
     private func polyfillLanguage(_ key: String, locale: String) -> Any? {
+        let locale = locale.replacingOccurrences(of: "_", with: "-")
         let localeComps = locale.split(separator: "-")
         let baseLocale = localeComps.first?.lowercased() ?? "n/a"
         return yamlTree[baseLocale]?[key]?.value

--- a/Tests/FOSMVVMTests/Localization/YamlLocalizationStoreTests.swift
+++ b/Tests/FOSMVVMTests/Localization/YamlLocalizationStoreTests.swift
@@ -63,6 +63,11 @@ struct YamlLocalizationStoreTests: LocalizableTestCase {
         #expect(locStore.t("carHood", locale: enGB) == "Bonnet")
     }
 
+    @Test func testFallbackTranslation() {
+        #expect(locStore.t("test", locale: enGB) == "Test")
+        #expect(locStore.t("test", locale: Locale(identifier: "en_gb")) == "Test")
+    }
+
     @Test func testCaseSensitiveKeyTranslation() {
         #expect(locStore.t("carHood", locale: enUS) == "Hood")
         #expect(locStore.t("carhood", locale: enUS) == nil)


### PR DESCRIPTION
- This was found when using Locale.current, which yielded an identifier of en_US on macOS