### PR TITLE
Fixed importing Apple's standalone Crypto library

### DIFF
--- a/Sources/FOSFoundation/String/String+Crypto.swift
+++ b/Sources/FOSFoundation/String/String+Crypto.swift
@@ -17,12 +17,12 @@
 
 import Foundation
 
-#if canImport(Crypto) || canImport(CryptoKit)
+#if (os(Linux) && canImport(Crypto)) || canImport(CryptoKit)
 
 #if canImport(CryptoKit)
 import CryptoKit
 #endif
-#if canImport(Crypto)
+#if os(Linux) && canImport(Crypto)
 import Crypto
 #endif
 

--- a/Tests/FOSFoundationTests/String/String+CryptoTests.swift
+++ b/Tests/FOSFoundationTests/String/String+CryptoTests.swift
@@ -15,12 +15,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(Crypto) || canImport(CryptoKit)
+#if (os(Linux) && canImport(Crypto)) || canImport(CryptoKit)
 
 #if canImport(CryptoKit)
 import CryptoKit
 #endif
-#if canImport(Crypto)
+#if os(Linux) && canImport(Crypto)
 import Crypto
 #endif
 


### PR DESCRIPTION
For some reason iOS doesn't like checking canImport(Crypto), so I added an os check as well.