### PR TITLE
View Model Factories and localization that are resolved on the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ For guides, articles, and API documentation see the
 
 [docs]: https://swiftpackageindex.com/foscomputerservices/FOSUtilities/documentation/fosfoundation
 
-## Alpha Stability Warning
-
-Please note that these libraries are currently a work in progress.  The APIs are rapidly evolving and while the overall architecture is set, breaking changes will occur until 1.0 is released.  The documentation is evolving, but the 'Getting Started' guidance is incomplete.  Nonetheless, the implementations are stable and unit tests are in place to ensure proper code coverage and stability of all publicly-facing APIs.  This warning will remain in place until I feel that these limitations are remedied.  Please log any issues that you might find or suggestions for improvements.
-
 ## FOSFoundation
 
 FOSFoundation is a library of protocols, patterns, types and routines that I have found generally useful in my projects.  Support areas include:
@@ -68,6 +64,7 @@ public struct LandingPageViewModel: RequestableViewModel {
 
 #### View
 
+```
 struct LandingPageView: ViewModelView {
     let viewModel: LandingPageViewModel
 
@@ -80,6 +77,7 @@ struct LandingPageView: ViewModelView {
         .padding()
     }
 }
+```
 
 #### Client Application Main
 
@@ -113,6 +111,7 @@ struct MyApp: App {
 
 #### Vapor Server Application
 
+```
 public func configure(_ app: Application) async throws {
     // uncomment to serve files from /Public folder
     // app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
@@ -128,8 +127,7 @@ public func configure(_ app: Application) async throws {
 func routes(_ app: Application) throws {
     app.routesregister(viewModel: LandingPageViewModel.self)
 }
-
-
+```
 
 ## FOSTesting
 

--- a/Sources/.VersionedTestJSON/LandingPageViewModel_1.0.1.json
+++ b/Sources/.VersionedTestJSON/LandingPageViewModel_1.0.1.json
@@ -1,0 +1,1 @@
+{"forgotPasswordButtonTitle":"Forgot Password?","loginButtonTitle":"Log In","usernameFieldTitle":"Username","forgotUsernameButtonTitle":"Forgot Username?","useTouchIDButtonTitle":"Use Touch ID","vmId":{"ts":1736361935.340149},"passwordFieldTitle":"Password"}

--- a/Sources/FOSMVVM/FOSMVVM.docc/ClientOverview.md
+++ b/Sources/FOSMVVM/FOSMVVM.docc/ClientOverview.md
@@ -34,9 +34,45 @@ struct MyApp: App {
         }
         .environment(
            MVVMEnvironment(
-// Add the following line if the application is not built from an xcodeproj
-//             currentVersion: .currentApplicationVersion,
+               // Add the following line **only** if the application
+               //  is not built from an xcodeproj
+               // currentVersion: .currentApplicationVersion,
                appBundle: Bundle.main,
+               deploymentURLs: [
+                  .production, .init(serverBaseURL: URL(string: "http://api.mywebserver.com")!),
+                  .staging, .init(serverBaseURL: URL(string: "http://staging-api.mywebserver.com")!),
+                  .debug, .init(serverBaseURL: URL(string: "http://localhost:8080")!)
+                ]
+           )
+        )
+    }
+}
+```
+
+#### Client-Hosted Localization
+
+If the client application (vs. the web service application) is hosting the localization (and thus contains
+all of the YAML files in the application's Bundle), the location of those resources can be specified
+in the ``MVVMEnvironment`` in the *resourceDirectoryName*.  If a value is not specified, the root
+directory of the [Bundle](https://developer.apple.com/documentation/foundation/bundle) will be used.
+
+These localizations will be used when a ``ClientHostedViewModelFactory`` is used to bind a ``ViewModel``. 
+
+```swift
+import FOSFoundation
+import FOSMVVM
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello World!")
+        }
+        .environment(
+           MVVMEnvironment(
+               appBundle: Bundle.main,
+               resourceDirectoryName: "Localization",
                deploymentURLs: [
                   .production, .init(serverBaseURL: URL(string: "http://api.mywebserver.com")!),
                   .staging, .init(serverBaseURL: URL(string: "http://staging-api.mywebserver.com")!),

--- a/Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md
+++ b/Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md
@@ -144,5 +144,3 @@ func routes(_ app: Application) throws {
     try app.routes.register(model: LandingPageViewModel.self)
 }
 ```
-
-

--- a/Sources/FOSMVVM/Localization/LocalizedProperty.swift
+++ b/Sources/FOSMVVM/Localization/LocalizedProperty.swift
@@ -223,6 +223,14 @@ public extension ViewModel {
 
     /// Initializes the ``LocalizedString`` property wrapper
     ///
+    /// # Example
+    ///
+    /// ```swift
+    /// struct MyViewModel: ViewModel {
+    ///     @LocalizedString var aLocalizedSting
+    /// }
+    /// ```
+    ///
     /// - Parameters:
     ///   - parentKeys: If provided, a set of keys that are appended to *propertyName*
     ///   - propertyName: The name of the key to look up in the ``LocalizationStore``

--- a/Sources/FOSMVVM/Protocols/LoginRequest.swift
+++ b/Sources/FOSMVVM/Protocols/LoginRequest.swift
@@ -1,0 +1,28 @@
+// LoginRequest.swift
+//
+// Created by David Hunt on 1/10/25
+// Copyright 2025 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+public protocol LoginRequest: ViewModelRequest {}
+
+public extension LoginRequest {
+    var action: ServerRequestAction {
+        .create // POST
+    }
+
+    var viewModel: ResponseBody {
+        responseBody ?? .stub()
+    }
+}

--- a/Sources/FOSMVVM/Protocols/ViewModelRequest.swift
+++ b/Sources/FOSMVVM/Protocols/ViewModelRequest.swift
@@ -52,7 +52,7 @@
 ///   }
 /// }
 /// ```
-public protocol ViewModelRequest: ServerRequest where ResponseBody: RequestableViewModel, Fragment == EmptyFragment, RequestBody == EmptyBody {}
+public protocol ViewModelRequest: ServerRequest where ResponseBody: RequestableViewModel {}
 
 public extension ViewModelRequest {
     var action: ServerRequestAction {

--- a/Sources/FOSMVVM/SwiftUI Support/PreviewHostingView.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/PreviewHostingView.swift
@@ -1,0 +1,106 @@
+// PreviewHostingView.swift
+//
+// Created by David Hunt on 1/10/25
+// Copyright 2025 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+#if canImport(SwiftUI)
+import Foundation
+import SwiftUI
+
+public extension ViewModelView {
+    /// Creates an instance of the ``ViewModelView`` and it's corresponding ``ViewModel`` that
+    /// will be bound with stub data and with all ``LocalizedString`` values bound to their localized
+    /// values
+    ///
+    /// ## Example:
+    ///
+    /// ```swift
+    /// public struct MyViewModel: ViewModel {
+    ///     @LocalizedString public var title
+    /// }
+    ///
+    ///  struct MyView: ViewModelView {
+    ///
+    ///     let viewModel: MyViewModel
+    ///
+    ///     var body: some View {
+    ///         Text(viewModel.title)
+    ///     }
+    /// }
+    ///
+    /// #Preview {
+    ///     MyView.previewHost()
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - resourceDirectoryName: The directory name that contains the resources (default: "")
+    ///   - locale: The locale to lookup the YAML bindings for (default: Locale.current)
+    static func previewHost(resourceDirectoryName: String = "", locale: Locale = .current) -> some View {
+        PreviewHostingView(
+            inner: Self.self,
+            resourceDirectoryName: resourceDirectoryName,
+            locale: locale
+        )
+    }
+}
+
+private struct PreviewHostingView<Inner: ViewModelView>: View {
+    @State private var localizationStore: LocalizationStore?
+
+    let inner: Inner.Type
+    let resourceDirectoryName: String
+    let locale: Locale
+
+    var body: some View {
+        if let localizationStore {
+            Inner(viewModel: viewModel(localizationStore: localizationStore))
+                .preferredColorScheme(ColorScheme.light)
+                .environment(mmEnv(resourceDirectoryName: resourceDirectoryName))
+        } else {
+            Text("Loading...")
+                .task {
+                    do {
+                        localizationStore = try await Bundle.main.yamlLocalization(
+                            resourceDirectoryName: resourceDirectoryName
+                        )
+                    } catch {
+                        fatalError("Unable to initialize the localization store: \(error)")
+                    }
+                }
+        }
+    }
+
+    private func mmEnv(resourceDirectoryName: String) -> MVVMEnvironment {
+        MVVMEnvironment(
+            appBundle: Bundle.main,
+            resourceDirectoryName: resourceDirectoryName,
+            deploymentURLs: [
+                .debug: .init(serverBaseURL: URL(string: "https://localhost:8080")!)
+            ]
+        )
+    }
+
+    private func viewModel(localizationStore: LocalizationStore) -> Inner.VM {
+        let encoder = JSONEncoder.localizingEncoder(locale: locale, localizationStore: localizationStore)
+        if let result: Inner.VM = try? Inner.VM.stub().toJSON(encoder: encoder).fromJSON() {
+            return result
+        } else {
+            return Inner.VM.stub()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
At times, the client application might need to resolve the localization itself or create ViewModel instances locally (e.g. from SwiftData).  Such factories can now conform to ClientHostedViewModelFactory.

Also added PreviewHostingView to support for previews resolving all localizations during preview.