### PR TITLE
Removed the swift-testing dependency from FOSTesting libraries

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "e048c8ee94967e8d8a1c2ec0e1156d6f7fa34d31",
-        "version" : "1.20.0"
+        "revision" : "6f3615ccf2ac3c2ae0c8087d527546e9544a43dd",
+        "version" : "1.21.0"
       }
     },
     {

--- a/Sources/FOSMVVM/SwiftUI Support/TestDataTransporter.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/TestDataTransporter.swift
@@ -94,7 +94,6 @@ import SwiftUI
 /// import FOSTesting
 /// import Foundation
 /// @testable import NewAccelPlus
-/// import Testing
 /// import XCTest
 ///
 /// final class LandingPageViewUITests: MyViewModelViewTestCase<MyViewModel, MyViewModelStubOps> {

--- a/Sources/FOSTesting/Expectations.swift
+++ b/Sources/FOSTesting/Expectations.swift
@@ -17,7 +17,6 @@
 import FOSFoundation
 import FOSMVVM
 import Foundation
-import Testing
 
 /// Performs tests to ensure that the **Codable**s implementation can encode and decode properly
 ///

--- a/Sources/FOSTestingUI/ViewModelViewTestCase.swift
+++ b/Sources/FOSTestingUI/ViewModelViewTestCase.swift
@@ -62,7 +62,6 @@ import XCTest
 /// import FOSMVVM
 /// import FOSTesting
 /// import Foundation
-/// import Testing
 /// import XCTest
 ///
 /// final class MyViewUITests: MyViewModelViewTestCase<MyViewModel, MyViewModelStubOperations>, @unchecked Sendable {

--- a/Sources/FOSTestingVapor/LocalizableTestCase.swift
+++ b/Sources/FOSTestingVapor/LocalizableTestCase.swift
@@ -19,7 +19,6 @@ import FOSFoundation
 import FOSMVVM
 import FOSTesting
 import Foundation
-import Testing
 import Vapor
 
 public extension LocalizableTestCase {


### PR DESCRIPTION
Surfacing libraries that were dependent upon swift-testing was causing obscure linking problems for clients.  Thus, converted all swift-testing calls into throws; for now, at least.