### PR TITLE
Removed the async loading of Client-hosted Views/View Models

### DIFF
--- a/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
+++ b/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
@@ -50,17 +50,17 @@ public enum YamlStoreError: Error {
 
 /// An extension on Bundle to allow initialization of the YamlStore
 public extension Bundle {
-    func yamlLocalization(resourceDirectoryName: String) async throws -> LocalizationStore {
+    func yamlLocalization(resourceDirectoryName: String) throws -> LocalizationStore {
         let config = try yamlStoreConfig(
             resourceDirectoryName: resourceDirectoryName
         )
 
-        return try await YamlStore(config: config)
+        return try YamlStore(config: config)
     }
 }
 
 public extension Collection<Bundle> {
-    func yamlLocalization(resourceDirectoryName: String) async throws -> LocalizationStore {
+    func yamlLocalization(resourceDirectoryName: String) throws -> LocalizationStore {
         let searchPaths = reduce(into: Set<URL>()) { result, next in
             result.formUnion(next.yamlSearchPaths(resourceDirectoryName: resourceDirectoryName))
         }
@@ -69,15 +69,15 @@ public extension Collection<Bundle> {
             searchPaths: searchPaths
         )
 
-        return try await YamlStore(config: config)
+        return try YamlStore(config: config)
     }
 }
 
 package struct YamlStoreConfig: Sendable { // Internal for testing
     let searchPaths: [URL]
 
-    fileprivate func localizationStore() async throws -> LocalizationStore {
-        try await YamlStore(config: self)
+    fileprivate func localizationStore() throws -> LocalizationStore {
+        try YamlStore(config: self)
     }
 
     init(searchPaths: some Collection<URL>) {
@@ -138,7 +138,7 @@ package struct YamlStore: LocalizationStore {
         return translation
     }
 
-    package init(config: YamlStoreConfig) async throws {
+    package init(config: YamlStoreConfig) throws {
         self.config = config
         self.yamlTree = try Self.loadFlattenedYAML(config: config)
     }

--- a/Sources/FOSMVVM/Protocols/ViewModelFactory.swift
+++ b/Sources/FOSMVVM/Protocols/ViewModelFactory.swift
@@ -106,8 +106,13 @@ public extension ClientHostedViewModelFactory where Self == Request.ResponseBody
 }
 
 public extension ClientHostedViewModelFactory where Self == Request.ResponseBody {
-    static func model(context: ClientHostedModelFactoryContext<Request, AppState>, vmRequest: Request) async throws -> Self where AppState: Sendable {
-        let model = try await Self.model(context: context)
+    static func model(
+        context: ClientHostedModelFactoryContext<Request, AppState>,
+        vmRequest: Request
+    ) throws -> Self where AppState: Sendable {
+        let model: Self = Task.synchronous {
+            try await Self.model(context: context)
+        }
 
         // Now localize the model
         let encoder = JSONEncoder.localizingEncoder(

--- a/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
@@ -114,12 +114,12 @@ public final class MVVMEnvironment: @unchecked Sendable {
     /// > in the application as opposed on the server.
     @MainActor
     public var clientLocalizationStore: LocalizationStore? {
-        get async throws {
+        get throws {
             if let store = _clientLocalizationStore {
                 return store
             }
 
-            let locStore = try await resolveClientLocalizationStore()
+            let locStore = try resolveClientLocalizationStore()
             _clientLocalizationStore = locStore
             return locStore
         }
@@ -131,11 +131,11 @@ public final class MVVMEnvironment: @unchecked Sendable {
     /// > in the application as opposed on the server.
     ///
     /// > The result of this function is **uncached** as opposed to ``clientLocalizationStore``
-    public func resolveClientLocalizationStore() async throws -> LocalizationStore {
+    public func resolveClientLocalizationStore() throws -> LocalizationStore {
         let locStore: LocalizationStore = if let localizationStore {
             localizationStore
         } else {
-            try await resourceBundles.yamlLocalization(
+            try resourceBundles.yamlLocalization(
                 resourceDirectoryName: resourceDirectoryName ?? ""
             )
         }

--- a/Sources/FOSMVVM/SwiftUI Support/PreviewHostingView.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/PreviewHostingView.swift
@@ -139,9 +139,9 @@ private struct PreviewHostingView<Inner: ViewModelView>: View {
             .environment(mmEnv(localizationStore: localizationStore))
         } else {
             Text(loadingText)
-                .task {
+                .onAppear {
                     do {
-                        localizationStore = try await bundle.yamlLocalization(
+                        localizationStore = try bundle.yamlLocalization(
                             resourceDirectoryName: resourceDirectoryName
                         )
                     } catch {

--- a/Sources/FOSMVVM/SwiftUI Support/Text.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/Text.swift
@@ -65,8 +65,8 @@ private struct LocalizableResolverView<L: Localizable>: View {
             Text(value)
         } else {
             Text("")
-                .task {
-                    if let store = try? await mvvmEnv.clientLocalizationStore {
+                .onAppear {
+                    if let store = try? mvvmEnv.clientLocalizationStore {
                         resolve(locale: locale, store: store)
                     } else {
                         // TODO: Error handling

--- a/Sources/FOSMVVMVapor/Extensions/Application+FOS.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Application+FOS.swift
@@ -68,10 +68,10 @@ public extension Application {
 private struct YamlLocalizationInitializer: LifecycleHandler {
     let config: YamlStoreConfig
 
-    fileprivate func willBootAsync(_ app: Application) async throws {
+    fileprivate func willBoot(_ app: Application) async throws {
         app.logger.info("Begin: Loading YAML files")
 
-        app.localizationStore = try await YamlStore(config: config)
+        app.localizationStore = try YamlStore(config: config)
 
         app.logger.info("End: Loading YAML files")
     }

--- a/Sources/FOSTesting/FOSTesting.docc/ViewModelTesting.md
+++ b/Sources/FOSTesting/FOSTesting.docc/ViewModelTesting.md
@@ -16,8 +16,8 @@ struct MyViewModelTests: LocalizableTestCase {
 
     let locStore: LocalizationStore
     var locales: Set<Locale> {[Self.en, Self.es]}
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(bundle: .module)
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(bundle: .module)
     }
 }
 ```
@@ -43,8 +43,8 @@ struct MyViewModelTests: LocalizableTestCase {
 
     let locStore: LocalizationStore
     var locales: Set<Locale> {[Self.en, Self.es]}
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(bundle: .module)
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(bundle: .module)
     }
 }
 ```

--- a/Sources/FOSTesting/LocalizableTestCase.swift
+++ b/Sources/FOSTesting/LocalizableTestCase.swift
@@ -33,8 +33,8 @@ import Foundation
 ///
 ///      let locStore: LocalizationStore
 ///      var locales: Set<Locale> {[Self.en, Self.es]}
-///      init() async throws {
-///          self.locStore = try await Self.loadLocalizationStore(bundle: .module)
+///      init() throws {
+///          self.locStore = try Self.loadLocalizationStore(bundle: .module)
 ///      }
 ///  }
 ///  ```
@@ -51,8 +51,8 @@ public extension LocalizableTestCase {
     /// - Parameter resourceDirectoryName: The name of a resource directory
     ///    in the application's bundle (default: Localizations)
     /// - Parameter bundle: The *Bundle* to use to load the YAML store
-    static func loadLocalizationStore(bundle: Bundle, resourceDirectoryName: String = "Resources") async throws -> LocalizationStore {
-        try await bundle.yamlLocalization(
+    static func loadLocalizationStore(bundle: Bundle, resourceDirectoryName: String = "Resources") throws -> LocalizationStore {
+        try bundle.yamlLocalization(
             resourceDirectoryName: resourceDirectoryName
         )
     }

--- a/Sources/FOSTestingUI/ViewModelViewTestCase.swift
+++ b/Sources/FOSTestingUI/ViewModelViewTestCase.swift
@@ -202,7 +202,7 @@ import XCTest
     public func setUp(bundle: Bundle, resourceDirectoryName: String = "", appBundleIdentifier: String, locales: Set<Locale>? = nil) async throws {
         try await super.setUp()
 
-        locStore = try await bundle.yamlLocalization(
+        locStore = try bundle.yamlLocalization(
             resourceDirectoryName: resourceDirectoryName
         )
         self.locales = locales ?? [Self.en]

--- a/Tests/FOSMVVMTests/Extensions/JSONEncoderTests.swift
+++ b/Tests/FOSMVVMTests/Extensions/JSONEncoderTests.swift
@@ -64,8 +64,8 @@ struct JSONEncoderTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: .module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/EmbeddedViewModelTests.swift
+++ b/Tests/FOSMVVMTests/Localization/EmbeddedViewModelTests.swift
@@ -39,8 +39,8 @@ struct EmbeddedViewModelTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/LocalizableArrayTests.swift
+++ b/Tests/FOSMVVMTests/Localization/LocalizableArrayTests.swift
@@ -203,8 +203,8 @@ struct LocalizableArrayTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/LocalizableCompoundValueTests.swift
+++ b/Tests/FOSMVVMTests/Localization/LocalizableCompoundValueTests.swift
@@ -171,8 +171,8 @@ struct LocalizableCompoundValueTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/LocalizableIntTests.swift
+++ b/Tests/FOSMVVMTests/Localization/LocalizableIntTests.swift
@@ -201,8 +201,8 @@ struct LocalizableIntTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/LocalizablePropertyTests.swift
+++ b/Tests/FOSMVVMTests/Localization/LocalizablePropertyTests.swift
@@ -91,8 +91,8 @@ struct LocalizablePropertyTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/LocalizableStringTests.swift
+++ b/Tests/FOSMVVMTests/Localization/LocalizableStringTests.swift
@@ -194,8 +194,8 @@ struct LocalizableStringTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/LocalizableSubstitutionsTests.swift
+++ b/Tests/FOSMVVMTests/Localization/LocalizableSubstitutionsTests.swift
@@ -163,8 +163,8 @@ struct LocalizableSubstitutionsTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Localization/YamlLocalizationStoreTests.swift
+++ b/Tests/FOSMVVMTests/Localization/YamlLocalizationStoreTests.swift
@@ -88,8 +88,8 @@ struct YamlLocalizationStoreTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMTests/Versioning/VersionedViewModelTests.swift
+++ b/Tests/FOSMVVMTests/Versioning/VersionedViewModelTests.swift
@@ -32,8 +32,8 @@ struct VersionedViewModelTests: LocalizableTestCase {
         .localizingEncoder(locale: Self.en, localizationStore: locStore)
     }
 
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: Bundle.module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMVaporTests/Extensions/Application+FOSTests.swift
+++ b/Tests/FOSMVVMVaporTests/Extensions/Application+FOSTests.swift
@@ -68,8 +68,8 @@ struct ApplicationFOSAdditionTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: .module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMVaporTests/Extensions/JSONEncoderVaporTests.swift
+++ b/Tests/FOSMVVMVaporTests/Extensions/JSONEncoderVaporTests.swift
@@ -38,8 +38,8 @@ struct JSONEncoderVaporTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: .module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMVaporTests/Extensions/Request+FOSTests.swift
+++ b/Tests/FOSMVVMVaporTests/Extensions/Request+FOSTests.swift
@@ -130,8 +130,8 @@ struct RequestFOSAdditionTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: .module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSMVVMVaporTests/Protocols/ServerRequestActionTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/ServerRequestActionTests.swift
@@ -47,8 +47,8 @@ struct ServerRequestActionTests: LocalizableTestCase {
     }
 
     let locStore: LocalizationStore
-    init() async throws {
-        self.locStore = try await Self.loadLocalizationStore(
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
             bundle: .module,
             resourceDirectoryName: "TestYAML"
         )

--- a/Tests/FOSReportingTests/PDFRendererTests.swift
+++ b/Tests/FOSReportingTests/PDFRendererTests.swift
@@ -1,6 +1,6 @@
 // PDFRendererTests.swift
 //
-// Copyright 2025 FOS Computer Services, LLC
+// Copyright 2024 FOS Computer Services, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the  License);
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The main impetus of this change was to enable .bind() when generating reports.  Nonetheless, this change also reduces the repaint churn that could occur when presenting client-hosted views.