### PR TITLE
Make app-bundle YAMLs deterministically override embedded package YAMLs

### DIFF
--- a/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
+++ b/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
@@ -61,12 +61,23 @@ public extension Bundle {
 
 public extension Collection<Bundle> {
     func yamlLocalization(resourceDirectoryName: String) throws -> LocalizationStore {
-        let searchPaths = reduce(into: Set<URL>()) { result, next in
-            result.formUnion(next.yamlSearchPaths(resourceDirectoryName: resourceDirectoryName))
+        // Collect every bundle's search paths, de-duplicating, then sort so that
+        // embedded Swift Package .bundle/ paths come first and main bundle paths
+        // come last. YamlStore.loadFlattenedYAML is last-write-wins on duplicate
+        // keys, so app-level YAMLs override package YAMLs deterministically.
+        var seenPaths = Set<URL>()
+        var collected = [URL]()
+
+        for bundle in self {
+            for path in bundle.yamlSearchPaths(resourceDirectoryName: resourceDirectoryName) {
+                if seenPaths.insert(path).inserted {
+                    collected.append(path)
+                }
+            }
         }
 
         let config = YamlStoreConfig(
-            searchPaths: searchPaths
+            searchPaths: collected.sortedByBundlePrecedence()
         )
 
         return try YamlStore(config: config)
@@ -100,7 +111,7 @@ package extension Bundle {
         return .init(searchPaths: searchPaths)
     }
 
-    func yamlSearchPaths(resourceDirectoryName: String) -> Set<URL> {
+    func yamlSearchPaths(resourceDirectoryName: String) -> [URL] {
         let resourceURLs = [
             /* Packages */ bundleURL
                 .appending(path: "Contents/Resources")
@@ -117,7 +128,25 @@ package extension Bundle {
             }
         }
 
-        return result
+        return Array(result).sortedByBundlePrecedence()
+    }
+}
+
+package extension Array<URL> {
+    /// Sort YAML search paths so that embedded Swift Package `.bundle/` paths
+    /// come first and main bundle paths come last, with alphabetical tie-break
+    /// for determinism. Combined with `YamlStore.loadFlattenedYAML`'s
+    /// last-write-wins semantics, this guarantees app-level YAMLs override
+    /// package YAMLs on duplicate keys.
+    func sortedByBundlePrecedence() -> [URL] {
+        sorted { a, b in
+            let aIsEmbedded = a.path.contains(".bundle/")
+            let bIsEmbedded = b.path.contains(".bundle/")
+            if aIsEmbedded != bIsEmbedded {
+                return aIsEmbedded
+            }
+            return a.path < b.path
+        }
     }
 }
 

--- a/Tests/FOSMVVMTests/Localization/YamlLocalizationStoreTests.swift
+++ b/Tests/FOSMVVMTests/Localization/YamlLocalizationStoreTests.swift
@@ -86,6 +86,41 @@ struct YamlLocalizationStoreTests: LocalizableTestCase {
         #expect(locStore.v("int", locale: Locale(identifier: "fred")) == nil)
     }
 
+    /// When two bundles define the same key, the main app bundle's YAML must
+    /// override an embedded Swift Package bundle's YAML, regardless of the
+    /// order in which the bundles are passed.
+    @Test func appBundleOverridesEmbeddedPackageBundle() throws {
+        let fixture = try OverrideFixture()
+        defer { fixture.cleanup() }
+
+        for bundles in [
+            [fixture.appBundle, fixture.packageBundle],
+            [fixture.packageBundle, fixture.appBundle]
+        ] {
+            let store = try bundles.yamlLocalization(resourceDirectoryName: "Localizations")
+            #expect(
+                store.t("greeting", locale: Locale(identifier: "en")) == "main-app",
+                "App bundle YAML must override embedded package YAML on duplicate keys."
+            )
+            #expect(
+                store.t("packageOnly", locale: Locale(identifier: "en")) == "package-only",
+                "Package-only keys remain available."
+            )
+        }
+    }
+
+    @Test func yamlSearchPathsDistinguishesEmbeddedBundlePaths() throws {
+        let fixture = try OverrideFixture()
+        defer { fixture.cleanup() }
+
+        let appPaths = fixture.appBundle.yamlSearchPaths(resourceDirectoryName: "Localizations")
+        let pkgPaths = fixture.packageBundle.yamlSearchPaths(resourceDirectoryName: "Localizations")
+
+        #expect((appPaths + pkgPaths).allSatisfy { $0.hasDirectoryPath })
+        #expect(pkgPaths.contains { $0.path.contains(".bundle/") })
+        #expect(appPaths.allSatisfy { !$0.path.contains(".bundle/") })
+    }
+
     let locStore: LocalizationStore
     init() throws {
         self.locStore = try Self.loadLocalizationStore(
@@ -93,4 +128,54 @@ struct YamlLocalizationStoreTests: LocalizableTestCase {
             resourceDirectoryName: "TestYAML"
         )
     }
+}
+
+private struct OverrideFixture {
+    let root: URL
+    let appBundle: Bundle
+    let packageBundle: Bundle
+
+    init() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("YamlOverrideTest-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+
+        // Main app bundle — no ".bundle/" in its path.
+        let appBundleDir = root.appendingPathComponent("MainApp.app", isDirectory: true)
+        let appYamlDir = appBundleDir
+            .appendingPathComponent("Contents/Resources/Localizations", isDirectory: true)
+        try fm.createDirectory(at: appYamlDir, withIntermediateDirectories: true)
+        try """
+        en:
+          greeting: "main-app"
+        """.write(to: appYamlDir.appendingPathComponent("test.yml"), atomically: true, encoding: .utf8)
+
+        // Embedded Swift Package resource bundle — ".bundle/" in its path.
+        let pkgBundleDir = root.appendingPathComponent("EmbeddedPkg.bundle", isDirectory: true)
+        let pkgYamlDir = pkgBundleDir
+            .appendingPathComponent("Contents/Resources/Localizations", isDirectory: true)
+        try fm.createDirectory(at: pkgYamlDir, withIntermediateDirectories: true)
+        try """
+        en:
+          greeting: "package"
+          packageOnly: "package-only"
+        """.write(to: pkgYamlDir.appendingPathComponent("test.yml"), atomically: true, encoding: .utf8)
+
+        guard let appBundle = Bundle(url: appBundleDir),
+              let packageBundle = Bundle(url: pkgBundleDir) else {
+            try? fm.removeItem(at: root)
+            throw FixtureError.bundleInitFailed
+        }
+
+        self.root = root
+        self.appBundle = appBundle
+        self.packageBundle = packageBundle
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    enum FixtureError: Error { case bundleInitFailed }
 }


### PR DESCRIPTION
Swift Set iteration order is non-deterministic, so when two bundles defined the same localization key, whichever bundle the Set happened to yield last won under YamlStore.loadFlattenedYAML's last-write-wins semantics