### PR TITLE
fix(vapor): Serve FOSMVVM React resources from correct bundle root

### DIFF
--- a/Sources/FOSMVVMVapor/Extensions/Application+FOS.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Application+FOS.swift
@@ -131,7 +131,20 @@ private extension Application {
         // Access the FOSMVVMVapor module bundle
         let bundle = Bundle.module
 
-        let reactResourceURL = bundle.bundleURL.appending(path: "Contents/Resources")
+        // The resource-bundle layout differs by build system: SwiftPM (`swift build`/`swift test`)
+        // produces a shallow bundle with resources at the bundle root, while Xcode nests them
+        // under `Contents/Resources`. Probe both (mirroring `Bundle.yamlSearchPaths`) and serve
+        // from whichever root actually contains the `fosmvvm` resource directory.
+        let candidateRoots = [
+            bundle.bundleURL.appending(path: "Contents/Resources"),
+            bundle.bundleURL
+        ]
+        guard let reactResourceURL = candidateRoots.first(where: { root in
+            FileManager.default.fileExists(atPath: root.appending(path: "fosmvvm").path)
+        }) else {
+            logger.warning("FOSMVVM client resources not found in bundle \(bundle.bundleURL.path); /fosmvvm/react/* will not be served")
+            return
+        }
 
         logger.info("Serving FOSMVVM client resources from: \(reactResourceURL.path)")
 


### PR DESCRIPTION
configureFOSMVVMReactResources() pointed FileMiddleware's publicDirectory at bundleURL/Contents/Resources, which only exists in Xcode-built bundles. Under SwiftPM (swift build / swift test) the resource bundle is shallow — resources live at the bundle root — so every /fosmvvm/react/* request 404'd, failing ApplicationFOSAdditionTests.reactResourcesServed().

Probe both roots (Contents/Resources, then bundleURL) and serve from whichever actually contains the fosmvvm directory, mirroring Bundle.yamlSearchPaths which already handles this layout difference. If neither is present, log a warning and skip instead of registering a middleware that serves nothing.