### PR TITLE
FOSMVVM improvements + fosmvvm-* skill/tooling updates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,6 +22,27 @@ swiftlint
 
 FOSUtilities is a Swift Package providing MVVM infrastructure for binding SwiftUI apps to Vapor web services, plus foundation utilities and testing support.
 
+### SOLID Is the Foundation
+
+FOSUtilities and every `fosmvvm-*` generator skill are built on the SOLID principles.
+**Deviations from SOLID cause catastrophic failures** — they surface far from their cause
+(runtime type-identity mismatches, leaked persistence types, SwiftUI identity churn), so
+treat a SOLID violation as a hard stop, not a style nit.
+
+- **Source-of-truth ordering when guidance conflicts:** SOLID → the architecture docs
+  (`.claude/docs/FOSMVVMArchitecture.md`) → code. If a request or an existing pattern
+  conflicts with SOLID, SOLID wins.
+- **Generator skills must remind their user of SOLID.** When authoring or editing a
+  `fosmvvm-*` skill, don't just show the API — state *which SOLID principle the pattern
+  protects and what breaks on deviation*, so a builder tempted to "simplify" sees the red
+  flag inline.
+- SOLID in FOSUtilities' terms: **SRP** (one file/type/responsibility; a ViewModel is a
+  *projection of* data, never the data); **OCP** (extend via protocols + macros, don't
+  patch the core); **LSP** (type identity must hold across target boundaries — the
+  `SPMLibraries` umbrella); **ISP** (the module *is* the namespace; small composable
+  protocols, not one fat contract); **DIP** (the ViewModel module never imports the
+  domain/wire module — the Factory adapts).
+
 ### Library Hierarchy
 
 ```

--- a/.claude/skills/fosmvvm-serverrequest-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-serverrequest-generator/SKILL.md
@@ -93,12 +93,12 @@ try await request.processRequest(mvvmEnv: mvvmEnv)
 let user = request.responseBody
 
 // ✅ RIGHT - Create operation
-let createRequest = CreateIdeaRequest(requestBody: .init(content: content))
+let createRequest = IdeaCreateRequest(requestBody: .init(content: content))
 try await createRequest.processRequest(mvvmEnv: mvvmEnv)
 let newId = createRequest.responseBody?.id
 
 // ✅ RIGHT - Update operation
-let updateRequest = MoveIdeaRequest(requestBody: .init(ideaId: id, newStatus: status))
+let updateRequest = IdeaMoveRequest(requestBody: .init(ideaId: id, newStatus: status))
 try await updateRequest.processRequest(mvvmEnv: mvvmEnv)
 ```
 
@@ -121,7 +121,7 @@ try await updateRequest.processRequest(mvvmEnv: mvvmEnv)
 
 | Concern | How ServerRequest Handles It |
 |---------|------------------------------|
-| URL Path | Derived from type name via `Self.path` (e.g., `MoveIdeaRequest` → `/move_idea`) |
+| URL Path | Derived from type name via `Self.path` (e.g., `IdeaMoveRequest` → `/idea_move`) |
 | HTTP Method | Determined by `action.httpMethod` (ShowRequest=GET, CreateRequest=POST, etc.) |
 | Request Body | `RequestBody` type, automatically JSON encoded via `requestBody?.toJSONData()` |
 | Response Body | `ResponseBody` type, automatically JSON decoded into `responseBody` |
@@ -145,6 +145,31 @@ Choose based on the operation:
 | Replace entity | (use `.replace` action) | PUT | Yes |
 | Soft delete | `DeleteRequest` | DELETE | No |
 | Hard delete | `DestroyRequest` | DELETE | No |
+
+> The left column is the **protocol** you conform to (`CreateRequest`, `UpdateRequest`, …).
+> That is NOT the name of your concrete type — see naming below.
+
+---
+
+## Naming the Concrete Request Type
+
+**Concrete write/action requests are noun-first: `<Noun><Verb>Request`.**
+
+| Operation | ✅ Concrete type | ❌ Not |
+|-----------|-----------------|--------|
+| Create a User | `UserCreateRequest` | `CreateUserRequest` |
+| Update a User | `UserUpdateRequest` | `UpdateUserRequest` |
+| Replace a User (PUT) | `UserReplaceRequest` | `ReplaceUserRequest` |
+| Delete a User | `UserDeleteRequest` | `DeleteUserRequest` |
+| Semantic action | `IdeaMoveRequest` | `MoveIdeaRequest` |
+| Raw-data read | `UserShowRequest` | — |
+
+Noun-first keeps an entity's whole request family cohesive and sortable
+(`UserCreateRequest`/`UserDeleteRequest`/`UserShowRequest`/`UserUpdateRequest` group
+together) — an **SRP** win, and it matches the already-noun-first `ShowRequest` form.
+ViewModel *read* requests drop the verb entirely (`DocksRequest`, not `DocksShowRequest`).
+
+**Full rules and rationale:** [Naming Dictionary](../shared/NAMES.md).
 
 ---
 
@@ -465,7 +490,7 @@ When processing a response:
 **ResponseError MUST be nested inside the request class**, just like RequestBody and ResponseBody:
 
 ```swift
-public final class CreateIdeaRequest: CreateRequest, @unchecked Sendable {
+public final class IdeaCreateRequest: CreateRequest, @unchecked Sendable {
     public typealias Query = EmptyQuery
     public typealias Fragment = EmptyFragment
     // No typealias needed - ResponseError is nested
@@ -484,8 +509,8 @@ public final class CreateIdeaRequest: CreateRequest, @unchecked Sendable {
 
 **Why nesting matters:**
 - Consistent with RequestBody/ResponseBody pattern
-- Avoids namespace pollution (no `CreateIdeaError`, `MoveIdeaError`, etc. at top level)
-- YAML localization keys are scoped: `CreateIdeaRequest.ResponseError.ErrorCode.quotaExceeded`
+- Avoids namespace pollution (no `IdeaCreateError`, `IdeaMoveError`, etc. at top level)
+- YAML localization keys are scoped: `IdeaCreateRequest.ResponseError.ErrorCode.quotaExceeded`
 - No need for unique type names like `GovernanceLessonCreateError` - nesting provides uniqueness
 
 ### Pattern 1: Errors with Associated Values
@@ -493,7 +518,7 @@ public final class CreateIdeaRequest: CreateRequest, @unchecked Sendable {
 For errors that need dynamic data in their messages, use `LocalizableSubstitutions`:
 
 ```swift
-public final class CreateIdeaRequest: CreateRequest, @unchecked Sendable {
+public final class IdeaCreateRequest: CreateRequest, @unchecked Sendable {
     // ... other typealiases and properties ...
 
     public struct ResponseError: ServerRequestError {
@@ -541,7 +566,7 @@ public final class CreateIdeaRequest: CreateRequest, @unchecked Sendable {
 
 ```yaml
 en:
-  CreateIdeaRequest:
+  IdeaCreateRequest:
     ResponseError:
       ErrorCode:
         duplicateContent: "The requested content is a duplicate of an existing idea."
@@ -554,7 +579,7 @@ en:
 For simpler errors without associated values, use a `String` raw value enum:
 
 ```swift
-public final class MoveIdeaRequest: UpdateRequest, @unchecked Sendable {
+public final class IdeaMoveRequest: UpdateRequest, @unchecked Sendable {
     // ... other typealiases and properties ...
 
     public struct ResponseError: ServerRequestError {
@@ -580,7 +605,7 @@ public final class MoveIdeaRequest: UpdateRequest, @unchecked Sendable {
 
 ```yaml
 en:
-  MoveIdeaRequest:
+  IdeaMoveRequest:
     ResponseError:
       ErrorCode:
         ideaNotFound: "The idea was not found"
@@ -595,18 +620,18 @@ This isn't JavaScript. The type system tells you everything at compile time:
 
 ```swift
 // When you write this request...
-let request = MoveIdeaRequest(requestBody: body)
+let request = IdeaMoveRequest(requestBody: body)
 
 // ...you KNOW:
-// - MoveIdeaRequest.ResponseError exists (it's declared in the type)
+// - IdeaMoveRequest.ResponseError exists (it's declared in the type)
 // - It has exactly the cases you defined (ideaNotFound, invalidTransition)
 // - Each case has whatever properties you gave it
 
 // So when you catch, you catch THE SPECIFIC TYPE:
 do {
     try await request.processRequest(mvvmEnv: mvvmEnv)
-} catch let error as MoveIdeaRequest.ResponseError {
-    // I KNOW this is MoveIdeaRequest.ResponseError
+} catch let error as IdeaMoveRequest.ResponseError {
+    // I KNOW this is IdeaMoveRequest.ResponseError
     // I KNOW it has .code
     // I KNOW .code is ErrorCode enum with ideaNotFound, invalidTransition
     // No mystery. No runtime discovery. No "what if?"
@@ -625,7 +650,7 @@ catch let error as ServerRequestError {
 **The pattern (Swift brain):**
 ```swift
 // ✅ RIGHT - you know the exact type
-catch let error as MoveIdeaRequest.ResponseError {
+catch let error as IdeaMoveRequest.ResponseError {
     switch error.code {
     case .ideaNotFound: // I know this exists
     case .invalidTransition: // I know this exists
@@ -642,7 +667,7 @@ The primary pattern is try/catch at the call site:
 ```swift
 do {
     try await request.processRequest(mvvmEnv: mvvmEnv)
-} catch let error as CreateIdeaError {
+} catch let error as IdeaCreateError {
     switch error.code {
     case .duplicateContent:
         showDuplicateWarning(message: error.message)
@@ -668,7 +693,7 @@ if requestBody.email.isEmpty {
     validations.validations.append(.init(
         status: .error,
         fieldId: "email",
-        message: .localized(for: CreateUserRequest.self, propertyName: "emailRequired")
+        message: .localized(for: UserCreateRequest.self, propertyName: "emailRequired")
     ))
 }
 
@@ -703,7 +728,7 @@ See [fosmvvm-serverrequest-test-generator](../fosmvvm-serverrequest-test-generat
 
 ```swift
 // ✅ RIGHT - tests the actual client code path
-let request = Update{Entity}Request(
+let request = {Entity}UpdateRequest(
     query: .init(entityId: id),
     requestBody: .init(name: "New Name")
 )
@@ -718,6 +743,7 @@ try await app.sendRequest(.PATCH, "/entity/\(id)", body: json)
 
 ## See Also
 
+- [Naming Dictionary](../shared/NAMES.md) - Canonical rules for naming requests (noun-first) and types
 - [Architecture Patterns](../shared/architecture-patterns.md) - Mental models (errors are data, type safety, etc.)
 - [FOSMVVMArchitecture.md](../../docs/FOSMVVMArchitecture.md) - Full architecture, especially "Core Principle: ServerRequest Is THE Way"
 - [fosmvvm-serverrequest-test-generator](../fosmvvm-serverrequest-test-generator/SKILL.md) - For testing ServerRequest types
@@ -743,3 +769,4 @@ try await app.sendRequest(.PATCH, "/entity/\(id)", body: json)
 | 2.7 | 2026-01-20 | ResponseError MUST be nested inside request class (like RequestBody/ResponseBody). Updated patterns to show nesting with correct YAML key paths. |
 | 2.8 | 2026-01-20 | Added "Type Safety Means You Already Know" section - explicit mental model that Swift's type system means you catch concrete error types, not protocols. Prevents JavaScript-brain panic about runtime type discovery. |
 | 2.9 | 2026-01-24 | Update to context-aware approach (remove file-parsing/Q&A). Skill references conversation context instead of asking questions or accepting file paths. |
+| 2.10 | 2026-07-02 | Concrete request types are noun-first (`<Noun><Verb>Request`); added "Naming the Concrete Request Type" section + [Naming Dictionary](../shared/NAMES.md) cross-ref; flipped all verb-first examples (`CreateIdeaRequest`→`IdeaCreateRequest`, `MoveIdeaRequest`→`IdeaMoveRequest`, etc.). (backlog A1) |

--- a/.claude/skills/fosmvvm-swiftui-app-setup/SKILL.md
+++ b/.claude/skills/fosmvvm-swiftui-app-setup/SKILL.md
@@ -95,7 +95,23 @@ This makes the environment available to all views in the hierarchy.
 
 The test infrastructure enables UI testing with specific configurations:
 
-**`.testHost { }` modifier:**
+**Baseline: `.testHost()` (no-arg) for display-only apps.** If the app has **no typed
+`TestConfiguration`** and nothing reads an `underTest` flag, the minimal wiring is the
+no-arg form — the FOSTestingUI harness swaps the registered view in on `onAppear`
+regardless:
+
+```swift
+WindowGroup {
+    LandingPageView()
+        .testHost()          // display-only: no decorator, no underTest needed
+}
+```
+
+Adopt the `.testHost { testConfiguration, testView in … }` **closure** form (below) only
+when a view must branch on a specific test scenario or seed the environment for a typed
+config — not as the default.
+
+**`.testHost { }` modifier (typed-config opt-in):**
 ```swift
 var body: some Scene {
     WindowGroup {
@@ -109,7 +125,7 @@ var body: some Scene {
             default:
                 testView
                     .onAppear {
-                        underTest = ProcessInfo.processInfo.arguments.count > 1
+                        underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
                     }
         }
         #endif
@@ -121,7 +137,12 @@ var body: some Scene {
 - **Apply to the top-level view** in WindowGroup (the outermost view in your hierarchy)
 - This ensures the modifier wraps the entire view hierarchy to intercept test configurations
 - Always include the `default:` case
-- The default case detects test mode via process arguments
+- **Detect test mode via `launchEnvironment`, not process arguments.** The FOSTestingUI
+  harness (`ViewModelDisplayTestCase.presentView`) passes the target VM via
+  `app.launchEnvironment` (`__FOS_ViewModelType` / `__FOS_ViewModel` /
+  `__FOS_TestConfiguration`) and sets **no** launch *arguments* — so
+  `ProcessInfo.processInfo.arguments.count > 1` stays false under `presentView` and is
+  unreliable. Read `ProcessInfo.processInfo.environment["__FOS_ViewModel"]` instead.
 - Sets `@State private var underTest = false` flag
 - Optional: Add specific test configurations for advanced scenarios
 
@@ -158,6 +179,31 @@ private extension MyApp {
 | Main App struct | `Sources/App/{AppName}.swift` | Entry point with MVVMEnvironment setup |
 | MVVMEnvironment configuration | Computed property in App struct | Bundles and deployment URLs |
 | Test infrastructure | DEBUG blocks in App struct | UI testing support |
+| Project conventions doc | `CLAUDE.md` / `AGENTS.md` at the app repo root | Anchors the app on SOLID (see below) |
+
+## Seed the App's `CLAUDE.md` (project conventions)
+
+When setting up a **new FOSMVVM app**, seed (or extend) a `CLAUDE.md`/`AGENTS.md` at the app
+repo root with a short **"SOLID Is the Foundation"** entry, mirroring FOSUtilities' own. A
+FOSMVVM app inherits FOSMVVM's SOLID contract — deviations (a domain type in a ViewModel,
+per-target SPM linking, `.grouped("string")` routes, throwaway `vmId`s) break in baffling
+ways — so every future session on the app should read this before touching code. Drop-in:
+
+```markdown
+## SOLID Is the Foundation
+
+This app is built on **FOSMVVM**, which is built on the **SOLID principles** — deviations
+cause catastrophic failures (runtime type-identity mismatches, leaked domain types, SwiftUI
+identity churn) that surface far from their cause. Treat a SOLID violation as a hard stop.
+
+- Source-of-truth ordering: SOLID → FOSMVVM architecture → this app's code.
+- Add ViewModels / Requests / Fields / Views / tests via the `fosmvvm-*` generator skills
+  rather than hand-rolling — they encode the SOLID patterns (noun-first requests, one file
+  per ViewModel, the domain-free ViewModel boundary, the `SPMLibraries` umbrella, …).
+- Key rules: a ViewModel is a *projection of* data, never the data (the Factory adapts);
+  the ViewModel module never imports the domain/wire module; consume SPM products through
+  the one `SPMLibraries` umbrella; `vmId` is stable data identity, never a throwaway.
+```
 
 ## Project Structure Configuration
 
@@ -256,7 +302,7 @@ testView
     .onAppear {
         // Right now there's no other way to detect if the app is under test.
         // This is only debug code, so we can proceed for now.
-        underTest = ProcessInfo.processInfo.arguments.count > 1
+        underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
     }
 ```
 
@@ -337,7 +383,7 @@ You can add specific test configurations in `.testHost`:
     default:
         testView
             .onAppear {
-                underTest = ProcessInfo.processInfo.arguments.count > 1
+                underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
             }
     }
 }
@@ -355,7 +401,7 @@ The App struct does not stand alone. It is one consumer of a shared module that 
 | Resource bundle | `Bundle(for: ResourceAccessClass.self)` | `Bundle.module` |
 | macOS signing | Frameworks sign with app's Team ID — no entitlement workaround needed | Hardened-runtime + ad-hoc-signed `PackageFrameworks` requires `com.apple.security.cs.disable-library-validation` (see "Code Signing for SPMLibraries Umbrella Frameworks" above) |
 | Info.plist / entitlements | App target `Sources/{AppTarget}/` or `Resources/` | App target's resource directory |
-| SPMLibraries umbrella | Optional `Sources/SPMLibraries/SPMLibraries.swift` umbrella to keep SPM dependency wiring out of the app target | N/A |
+| SPMLibraries umbrella | **Required** `Sources/SPMLibraries/SPMLibraries.swift` umbrella when multiple targets consume SPM products — one canonical type identity across targets (see "The SPMLibraries umbrella") | N/A |
 
 Default to **Xcode project** for app projects unless there is a specific reason to use SPM at the top level. The Xcode layout sidesteps the PackageFrameworks signing trap and gives natural homes for `Info.plist`, `Assets.xcassets`, and `.entitlements`.
 
@@ -367,19 +413,27 @@ Default to **Xcode project** for app projects unless there is a specific reason 
 │
 ├── Sources/
 │   ├── ViewModels/                  # SHARED MODULE (framework target)
-│   │   ├── ViewModels/              # @ViewModel structs
+│   │   ├── ViewModels/              # @ViewModel structs — ONE type per file,
+│   │   │   └── Docks/               #   grouped in a dir named for the container VM
+│   │   │       ├── DocksViewModel.swift       # top-level (composite)
+│   │   │       ├── DockViewModel.swift        # child — its own file
+│   │   │       ├── BerthViewModel.swift       # grandchild — its own file
+│   │   │       ├── HarbormasterSummary.swift  # display type — its own file
+│   │   │       └── BerthLiveness.swift        # display enum — its own file
 │   │   ├── Operations/              # Op protocols + StubOps (no live impls)
 │   │   ├── Fields/                  # Fields protocols + FieldsMessages
 │   │   ├── Errors/                  # ServerRequestError types
 │   │   ├── Versioning/
-│   │   │   └── SystemVersion+App.swift
-│   │   ├── Resources/ViewModels/    # *.yml localization
+│   │   │   └── SystemVersion+App.swift   # extension on SystemVersion — name for the
+│   │   │                                 #   TYPE (+ matching header), NOT <Module>Version.swift
+│   │   ├── Resources/ViewModels/    # *.yml — client-hosted apps ONLY;
+│   │   │                            #   server-hosted → sibling Sources/Resources/ (see Contract Wiring)
 │   │   └── ViewModelsResourceAccess.swift   # exposes localizationBundle
 │   │
 │   ├── Models/                      # OPTIONAL framework — @Model classes
 │   │
-│   ├── SPMLibraries/                # OPTIONAL umbrella — keeps SPM wiring
-│   │   └── SPMLibraries.swift       #   out of the app target (Xcode only)
+│   ├── SPMLibraries/                # umbrella — REQUIRED for one type identity
+│   │   └── SPMLibraries.swift       #   across targets (Xcode; see below)
 │   │
 │   └── {AppTarget}/                 # APP TARGET
 │       ├── App/
@@ -387,16 +441,52 @@ Default to **Xcode project** for app projects unless there is a specific reason 
 │       │   ├── TestConfiguration.swift   # if .testHost uses typed configs
 │       │   └── Assets.xcassets
 │       ├── Views/
+│       │   └── Docks/               # Views mirror the same container grouping
+│       │       ├── DocksView.swift
+│       │       └── DockView.swift
 │       ├── Operations/              # Live op implementations
 │       ├── AppState/                # @Observable session state
 │       ├── Info.plist
 │       └── {AppName}.entitlements
 │
-└── Tests/
+└── Tests/                          # mirrors Sources/ one-to-one
     ├── UnitTests/
+    │   ├── Docks/                   # same grouping again
+    │   │   └── DocksViewModelTests.swift
     │   └── TestYAML/                # FOSMVVM test fixtures
     └── UITests/
 ```
+
+### File Organization Conventions
+
+Three rules govern how ViewModel code is laid out. They apply to **every** layer, and
+the generators scaffold to them by default.
+
+1. **One type per file, named for the type.** Each `@ViewModel` type — the top-level
+   composite **and** every composed child — lives in its **own file** named for the type
+   (`DocksViewModel.swift`, `DockViewModel.swift`, `BerthViewModel.swift`). Display
+   structs and display enums the ViewModels use get their own files too
+   (`HarbormasterSummary.swift`, `BerthLiveness.swift`). **Never chain several
+   `@ViewModel` types into one file.** A long multi-type file hides the model and fights
+   reviewability; one-file-per-type keeps each display snapshot independently readable,
+   diffable, and testable — this is **Single Responsibility applied to the file**.
+
+2. **Group a collection in a directory named for its container.** A composite ViewModel
+   and its children live in a directory named after the containing top-level VM **minus
+   the `ViewModel` suffix**: `ViewModels/Docks/`. The directory name (`Docks`) signals
+   which VM owns the collection.
+
+3. **The same grouping repeats across every layer.** `Views/Docks/`,
+   `Tests/UnitTests/Docks/`, and — server-side — `ViewModelFactories/Docks/` and
+   `Controllers/Docks/` all use the identical `Docks/` folder, so a screen's ViewModel,
+   View, Factory, and tests sit in parallel folders. **`Tests/` mirrors `Sources/`
+   one-to-one.** (Factories/Controllers/DataModels are server-only and live in the server
+   target, not the shared module — see the contract-wiring section for which side owns
+   the shared module. The shared module carries only what both client and server must
+   agree on: ViewModels, Requests, Fields, Versioning.)
+
+Other skills reference these rules rather than restating them (e.g. the
+[viewmodel-generator](../fosmvvm-viewmodel-generator/SKILL.md) scaffolds one file per VM).
 
 ### ResourceAccess.swift — the two forms
 
@@ -448,9 +538,77 @@ import {SharedModule}              // typically `ViewModels`
 
 If the App struct references types from `Models` or other implementation-side targets at top level, that is a smell — App-level wiring should go through the shared module.
 
+## Server-Hosted ViewModel Contract Wiring (Both Sides)
+
+**How a client reaches a server-hosted ViewModel.** Mainstream REST instincts —
+"namespace the API under `/admin`", "make the client URL match the server route" — **fight
+the FOSMVVM model and cause 404s.** FOSMVVM derives the path from the request **type** on
+both sides, so neither side invents a URL. Four rules:
+
+**Rule 1 — A `ViewModelRequest`'s path is derived from its TYPE and is globally unique.**
+You never need `.grouped("string")` to namespace ViewModels — there are no collisions to
+avoid. Register on `app.routes`; the client points at a clean host, and the two paths agree
+automatically because neither side invents one. Canonical — FOSShowcase
+`Sources/WebServer/routes.swift`:
+
+```swift
+let unauthGroup = app.routes
+try unauthGroup.register(viewModel: LandingPageViewModel.self)   // served at the type-derived path
+```
+
+**Rule 2 — Middleware ≠ path.** Auth (mTLS client-cert, etc.) is applied with
+`.grouped(SomeMiddleware())`, which adds **no** path segment — **never** `.grouped("admin")`
+(a string), which adds a path the type-derived client resolver cannot reproduce. To gate a
+ViewModel behind an admin contract:
+
+```swift
+app.grouped(AdminClientCertMiddleware()).register(viewModel: AdminInfoViewModel.self)  // gate, NO prefix
+```
+
+**Rule 3 — Base URLs are clean hosts, never `…/path`.** The client `MVVMEnvironment` base
+URL is scheme + host + port only. FOSShowcase `Sources/SwiftUIApp/FOSShowcaseApp.swift`:
+
+```swift
+deploymentURLs: [.debug: URL(string: "http://localhost:8080")!]   // no path
+```
+
+`requestURL` derives the path from the request type and **discards any base-URL path** —
+that is **correct by design, not a bug**.
+
+**Rule 4 — File structure: one folded tree, a shared contract module, resources as a
+server-side sibling.** The whole system (server + every client + shared contract +
+resources + mirrored tests) lives in ONE directory (see "File Organization Conventions"
+and the canonical tree above). Placements that matter for the contract:
+
+- The **shared contract module** (`ViewModels`) holds only what both sides must agree on —
+  `ViewModels/`, `Requests/`, `Fields/`, `Versioning/` — **pure Swift, no resources.**
+- Localization `*.yml` are **server-only resources** in a **sibling `Sources/Resources/`**
+  tree (mirroring the module), `.copy`'d by the **server** target (and any server-rendered
+  web client, and tests) — FOSShowcase `.copy("../Resources")`. Deferred localization means
+  the server resolves all strings at encode time, so a release native client decodes an
+  **already-localized** ViewModel and needs no strings. The `*.yml` therefore **must NOT
+  live in the shared contract module** — the client links that module and would ship the
+  strings. *(A **wholly** client-hosted app with no server is the exception: it resolves
+  localization itself and legitimately bundles the resources — see "Wholly client-hosted
+  apps" above.)*
+- `ViewModelFactories` / `Controllers` / `DataModels` are **server-only**; `Views` are
+  **client-only**.
+- The native app is a **target in the one tree's root `.xcodeproj`** (apps require Xcode),
+  sharing the contract module directly — not a separate bolted-on XcodeGen project.
+- **`Tests/` mirrors `Sources/` one-to-one**; version baselines commit under
+  `Tests/.../.VersionedTestJSON/`.
+
+Fuller treatment: [FOSMVVMArchitecture.md](../../docs/FOSMVVMArchitecture.md) "Project
+Structure", "What Belongs Where", "File Organization Conventions".
+
+> **Anti-drift callout.** Do **not** `.grouped("string")` a ViewModel route; do **not** put
+> a path on the client base URL; if a fetch 404s, you added a stray path segment — **do not
+> change FOSMVVM**. The server path and client path agree automatically because neither side
+> invents one.
+
 ## Generating the Xcode Project (XcodeGen)
 
-The Xcode-project layout has many easy-to-forget settings that must be set on **every** target: `SWIFT_VERSION = 6.0`, `BUILD_LIBRARIES_FOR_DISTRIBUTION = NO`, embed-and-sign vs. link-only on the app target, `SPMLibraries` umbrella wiring, signing identity, deployment targets, entitlements path, Info.plist path. Configuring these by hand is repetitive and drifts.
+The Xcode-project layout has many easy-to-forget settings that must be set on **every** target: `SWIFT_VERSION = 6.0`, `BUILD_LIBRARY_FOR_DISTRIBUTION = NO`, embed-and-sign vs. link-only on the app target, `SPMLibraries` umbrella wiring, signing identity, deployment targets, entitlements path, Info.plist path. Configuring these by hand is repetitive and drifts.
 
 **Recommendation:** declare the project in [XcodeGen](https://github.com/yonaskolb/XcodeGen) (`project.yml`) and regenerate the `.xcodeproj` from it. Commit `project.yml`; treat the `.xcodeproj` as derived.
 
@@ -468,16 +626,41 @@ The Xcode-project layout has many easy-to-forget settings that must be set on **
 3. Run `xcodegen generate` — produces/updates `{ProjectName}.xcodeproj`.
 4. Open in Xcode normally. Re-run the command after every `project.yml` change.
 
-### The SPMLibraries umbrella, declaratively
+### The SPMLibraries umbrella, declaratively — REQUIRED for type identity
 
-`SPMLibraries` exists to keep external SPM dependency wiring out of the app target — it's a thin framework that depends on FOSFoundation/FOSMVVM/etc. and re-vends them. In XcodeGen this is one stanza: `SPMLibraries` is a framework target whose dependencies list every external package product, and the app target depends on `SPMLibraries` (plus `ViewModels` and `Models`).
+**When more than one Xcode target consumes SPM package products (app + unit tests + UI
+tests …), vend them through a SINGLE `SPMLibraries` umbrella framework that every target
+depends on — never link the SPM products directly into each target.** `SPMLibraries` is a
+thin framework whose dependencies list every external package product (FOSFoundation,
+FOSMVVM, …); the app target depends on `SPMLibraries` (plus `ViewModels` and `Models`). In
+XcodeGen this is one stanza.
+
+**Why (a generic Xcode + SPM bug — not FOS-specific):** linking an SPM library statically
+into multiple targets compiles a **separate copy of its types into each target**, and
+Swift's mangled type name carries the linking context — so the "same" type has a
+**different runtime identity per target**. An instance crossing a target boundary then
+fails `is` / `as?` / `==` / `===` against the same type on the other side: **`TypeA != TypeA`.**
+It **compiles clean and breaks at runtime in baffling ways, far from the cause.** One
+umbrella *dynamic* framework = one canonical copy = one shared type identity everywhere.
+
+**Why it matters ESPECIALLY for FOSMVVM:** FOSMVVM leans hard on **comparing types** —
+type-derived request paths, ViewModel/Request resolution, versioning. A FOS app that skips
+the umbrella breaks exactly where those comparisons happen. The umbrella *looks* like
+redundant re-vending to a mainstream eye — which is precisely why it must be stated, not
+emitted silently.
+
+> **Do NOT "simplify" by linking SPM products directly per-target.** `TypeA != TypeA`
+> across target boundaries at runtime (a generic Xcode packaging bug); FOS relies on type
+> comparison, so this **WILL** break in baffling ways. Every target depends on the one
+> `SPMLibraries` framework. (UI-test targets are the one exception — they run in a separate
+> process and link FOS products directly; see the ui-tests generator.)
 
 ### What `project.yml` settles in one place
 
 | Setting | Applied to | Why |
 |---|---|---|
 | `SWIFT_VERSION: 6.0` | All targets via `settings.base` | Must match across the project |
-| `BUILD_LIBRARIES_FOR_DISTRIBUTION: NO` | All targets | App is not a library; setting YES bloats build & breaks `@_spi` |
+| `BUILD_LIBRARY_FOR_DISTRIBUTION: NO` | All targets | App is not a library; setting YES bloats build & breaks `@_spi` |
 | `ENABLE_HARDENED_RUNTIME: YES` | App + tests | macOS notarization |
 | `GENERATE_INFOPLIST_FILE: YES` | Frameworks + tests | Saves writing empty Info.plists |
 | `INFOPLIST_FILE: Sources/{App}/Info.plist` | App target only | Carries `FOS-DEPLOYMENT`, `NS*UsageDescription` |
@@ -486,6 +669,59 @@ The Xcode-project layout has many easy-to-forget settings that must be set on **
 | Package dependencies on `SPMLibraries` only | App imports just `import {AppModule}` shape | One place to add/remove SPM deps |
 
 See [reference.md](reference.md) Template 7 for the complete `project.yml`.
+
+### Verified, build-tested `project.yml` (Option A — source inclusion)
+
+For a **one-shot, build-verified** setup, use
+[`docs/work/fosmvvm-app-project-template.md`](../../docs/work/fosmvvm-app-project-template.md)
+— reverse-engineered from a real hand-built `.xcodeproj` and confirmed with
+`xcodebuild … build-for-testing → ** TEST BUILD SUCCEEDED **` (app + app-hosted unit-test
+bundle + UI-test bundle all compile and link). It refines Template 7 with these load-bearing
+corrections — apply them whichever template you start from:
+
+- **Option A (source inclusion).** The app target `sources:` **include the folders** of the
+  shared contract module and the Views layer (they compile *into* the app; Views reference
+  ViewModels with no cross-module `import`). The app links **only** `SPMLibraries`. (Template
+  7 is Option B — a separate `ViewModels` framework; both are valid.)
+- **Singular `BUILD_LIBRARY_FOR_DISTRIBUTION: NO`** — the plural `…LIBRARIES…` is a no-op typo.
+- **Test-target names `{Base}UnitTests` / `{Base}UITests`**, where `{Base}` strips a trailing
+  `UI` from the app name. Never bare `{AppName}Tests` (a unit target should say "Unit") or
+  `{AppName}UITests` when `{AppName}` already ends in `UI` (→ doubled `…UIUITests`).
+- **Pin `TEST_HOST` when the app target name ≠ `PRODUCT_NAME`** — XcodeGen otherwise derives
+  it from the target name and the unit test fails to link (`ld: library '…' not found`):
+  `TEST_HOST: "$(BUILT_PRODUCTS_DIR)/{ProductName}.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/{ProductName}"` + `BUNDLE_LOADER: "$(TEST_HOST)"`.
+- **App-hosted tests** (unit test depends on the app target) so the tests share the app's
+  exact FOS type identity — the real proof the `SPMLibraries` umbrella works.
+- **Multi-platform → `supportedDestinations: [macOS, iOS]`**, NOT `platform: [macOS, iOS]`
+  (the latter splits into per-platform targets and breaks a single-name scheme entry).
+- **`.xctestplan` caveat:** a committed plan pins targets by UUID, which XcodeGen re-mints on
+  generate → dangling references. Either drop the plan and list `test.targets:` in the scheme
+  (regenerable default), or reconcile the plan's UUIDs once in Xcode after the first generate.
+
+### Lifecycle: XcodeGen scaffolds, it does not maintain
+
+The generator is a **one-shot scaffolder**, not a lifetime project manager. It earns its keep
+once — nailing the hard, easy-to-forget setup (umbrella, source-inclusion, app-hosted tests,
+`TEST_HOST`, Swift 6 + strict concurrency). Once the project is stable, the few tweaks it
+accrues (a setting, a destination, a folder) are better made **in Xcode by hand** — a regen
+clobbers them. The workflow:
+
+1. **Scaffold once** from the template.
+2. **Do the two things XcodeGen structurally can't**, once, in Xcode after the final generate:
+   - **Synchronized folders** (`PBXFileSystemSynchronizedRootGroup`). XcodeGen (≤ 2.45.4)
+     emits classic enumerated groups, not the Xcode-16 folders that auto-mirror the
+     filesystem. The build is identical, but auto-mirroring is lost — re-add the source
+     folders as synchronized folders.
+   - Add **iOS/iPadOS destinations** if needed (destinations-only under source-inclusion — no
+     package change, provided the included source is iOS-clean).
+3. **Commit the `.xcodeproj`** (stop git-ignoring it) — it becomes the hand-maintained source
+   of truth; keep `project.yml` as a documented **seed**, not a live regen target.
+
+**Keep the strict-concurrency win.** Verify the generated project has `SWIFT_VERSION 6.0` +
+`SWIFT_STRICT_CONCURRENCY complete` and **no** `SWIFT_APPROACHABLE_CONCURRENCY` /
+`SWIFT_DEFAULT_ACTOR_ISOLATION` keys. A fresh Xcode 26 app turns on Approachable Concurrency
+(`@MainActor`-by-default) by default; XcodeGen sets only what `project.yml` declares, so you
+keep clean strict-complete concurrency the IDE would otherwise relax.
 
 ## File Templates
 
@@ -563,4 +799,8 @@ Expect `Signature=adhoc`, `TeamIdentifier=not set` — that is the trigger condi
 | 1.1 | 2026-01-24 | Update to context-aware approach (remove file-parsing/Q&A). Skill references conversation context instead of asking questions or accepting file paths. |
 | 1.2 | 2026-04-27 | Add "Code Signing for SPMLibraries Umbrella Frameworks" section documenting the macOS hardened-runtime + ad-hoc-signed PackageFrameworks Team ID mismatch and the `com.apple.security.cs.disable-library-validation` entitlement fix. |
 | 1.3 | 2026-05-03 | Add "Project File Structure" section covering Xcode-project vs. SPM layout, the two `ResourceAccess` forms (`Bundle(for:)` vs. `Bundle.module`), wholly client-hosted apps with empty `deploymentURLs`, and canonical app-target imports. Add Template 6 to reference.md for a wholly client-hosted Xcode-project app. |
-| 1.4 | 2026-05-03 | Add "Generating the Xcode Project (XcodeGen)" section with declarative project setup (`SWIFT_VERSION`, `BUILD_LIBRARIES_FOR_DISTRIBUTION = NO`, signing, `SPMLibraries` umbrella wiring) so the `.xcodeproj` is regenerable from a committed `project.yml`. Add Template 7 to reference.md with a complete `project.yml`. |
+| 1.4 | 2026-05-03 | Add "Generating the Xcode Project (XcodeGen)" section with declarative project setup (`SWIFT_VERSION`, `BUILD_LIBRARY_FOR_DISTRIBUTION = NO`, signing, `SPMLibraries` umbrella wiring) so the `.xcodeproj` is regenerable from a committed `project.yml`. Add Template 7 to reference.md with a complete `project.yml`. |
+| 1.5 | 2026-07-02 | Add "File Organization Conventions" (canonical owner): one type per file, collection grouped in a container-named directory (`ViewModels/Docks/`), the same grouping repeated across Views/Factories/Tests, and `Tests/` mirrors `Sources/`. Canonical tree now demonstrates the grouping. (backlog B2/L59; other skills reference this.) |
+| 1.6 | 2026-07-02 | **BLOCKERS.** Add "Server-Hosted ViewModel Contract Wiring (Both Sides)": type-derived globally-unique paths (no `.grouped("string")`), middleware≠path, clean-host base URLs, resources server-only in sibling `Sources/Resources/`, native app in root `.xcodeproj`, Tests mirror Sources; anti-drift callout; grounded in FOSShowcase `routes.swift`/`FOSShowcaseApp.swift` (C1). Add the SPMLibraries **type-identity** rationale (`TypeA != TypeA` across targets; FOS relies on type comparison) + "do not link per-target" callout; retitled umbrella REQUIRED (was "Optional") (C2). |
+| 1.7 | 2026-07-02 | Fold in the build-verified [`fosmvvm-app-project-template.md`](../../docs/work/fosmvvm-app-project-template.md) (copied into this repo): Option-A source inclusion, singular `BUILD_LIBRARY_FOR_DISTRIBUTION` (fixed the plural no-op typo throughout), `{Base}UnitTests`/`{Base}UITests` naming, `TEST_HOST` pin, app-hosted tests, `supportedDestinations`, `.xctestplan` caveat (C3). `.testHost()` no-arg baseline + `underTest` detection via `launchEnvironment` (`__FOS_ViewModel`) not `arguments.count` — verified against `ViewModelViewTestCase.presentView` (C4). "Lifecycle: scaffolds not maintains" — synchronized folders, commit the `.xcodeproj`, keep strict-concurrency (C5). Reinforced `SystemVersion+<App>.swift` naming (C6). |
+| 1.8 | 2026-07-02 | Add "Seed the App's `CLAUDE.md`": recommend the scaffolded app repo adopt a "SOLID Is the Foundation" project-conventions entry (drop-in template) so downstream apps inherit FOSMVVM's SOLID discipline and point future sessions at the `fosmvvm-*` skills. |

--- a/.claude/skills/fosmvvm-swiftui-app-setup/reference.md
+++ b/.claude/skills/fosmvvm-swiftui-app-setup/reference.md
@@ -121,7 +121,7 @@ struct {AppName}App: App {
                 //
                 // default:
                 //     testView.onAppear {
-                //         underTest = ProcessInfo.processInfo.arguments.count > 1
+                //         underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
                 //     }
                 // }
 
@@ -132,7 +132,7 @@ struct {AppName}App: App {
                             // Right now there's no other way to detect if the app is under test.
                             // This is only debug code, so we can
                             // proceed for now.
-                            underTest = ProcessInfo.processInfo.arguments.count > 1
+                            underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
                         }
             }
             #endif
@@ -219,7 +219,7 @@ struct {AppName}App: App {
                 default:
                     testView
                         .onAppear {
-                            underTest = ProcessInfo.processInfo.arguments.count > 1
+                            underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
                         }
             }
             #endif
@@ -384,7 +384,7 @@ struct MyApp: App {
                 default:
                     testView
                         .onAppear {
-                            underTest = ProcessInfo.processInfo.arguments.count > 1
+                            underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
                         }
                 }
             }
@@ -548,7 +548,7 @@ struct {AppName}App: App {
                 default:
                     testView
                         .onAppear {
-                            underTest = ProcessInfo.processInfo.arguments.count > 1
+                            underTest = ProcessInfo.processInfo.environment["__FOS_ViewModel"] != nil
                         }
                 }
             }
@@ -626,7 +626,7 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     SWIFT_STRICT_CONCURRENCY: complete
-    BUILD_LIBRARIES_FOR_DISTRIBUTION: NO
+    BUILD_LIBRARY_FOR_DISTRIBUTION: NO
     DEVELOPMENT_TEAM: {TeamId}
     ENABLE_USER_SCRIPT_SANDBOXING: YES
     SWIFT_TREAT_WARNINGS_AS_ERRORS: YES
@@ -773,7 +773,7 @@ schemes:
 **Notes:**
 - **`embed: true` on the app target only.** Frameworks must be embedded-and-signed by exactly one consumer (the app); intermediate frameworks (`ViewModels` linking `SPMLibraries`, `Models` linking `ViewModels`) use `embed: false` to link without re-embedding.
 - **`SPMLibraries` is the only target that lists external `package:` dependencies.** Add a new SPM dep here once; downstream targets just `import` from `SPMLibraries`.
-- **`BUILD_LIBRARIES_FOR_DISTRIBUTION: NO`** is in `settings.base` so it applies to all targets — setting YES enables module stability you don't need for an in-tree app and breaks `@_spi`/`package` access modifiers.
+- **`BUILD_LIBRARY_FOR_DISTRIBUTION: NO`** is in `settings.base` so it applies to all targets — setting YES enables module stability you don't need for an in-tree app and breaks `@_spi`/`package` access modifiers.
 - **Hardened runtime + Team ID** flow from `settings.base` to all targets, so the SPM `PackageFrameworks` ad-hoc-signing trap (see SKILL.md) does not arise here. Do **not** add `com.apple.security.cs.disable-library-validation` to entitlements unless you specifically need it.
 - **Two-platform builds** (`platform: [iOS, macOS]`) generate one target per platform under the hood; XcodeGen handles the multiplexing. Drop `iOS` or `macOS` if you only ship one.
 

--- a/.claude/skills/fosmvvm-ui-tests-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-ui-tests-generator/SKILL.md
@@ -52,8 +52,16 @@ UI tests must follow a strict hierarchy for finding and matching elements. **Nev
 
 Use `.uiTestingIdentifier()` on the view and match via `XCUIApplication` extension accessors:
 
+> **`.uiTestingIdentifier(_:)` is a FOSMVVM `View` modifier — `import FOSMVVM`.** It ships
+> in FOSMVVM (`SwiftUI Support/View+Testing.swift`); you do **not** define it yourself and
+> you must **not** copy a private version into your app. It is **DEBUG-only** — in a
+> release build it compiles to a no-op (`self`), so tagging carries **no** test scaffolding
+> into shipping binaries. Because it self-gates, apply it **unconditionally** (do not wrap
+> it in `#if DEBUG` — only `.testDataTransporter` needs that guard). Pair each identifier
+> with an `XCUIApplication` accessor keyed on the **same** string.
+
 ```swift
-// View
+// View  (import FOSMVVM)
 Text(viewModel.title)
     .uiTestingIdentifier("dashboardTitle")
 
@@ -109,6 +117,15 @@ FOSTestingUI provides two parallel base classes that align with the two kinds of
 | **Interactive** | `ViewModelViewTestCase<VM, VMO>` | View dispatches to Operations — test verifies operation calls |
 
 Every project should have a **pair** of project-level base classes — one for each path — that pin `setUp` for the app bundle. Both paths are needed because most apps have both kinds of views.
+
+> **Version floor for `ViewModelDisplayTestCase<VM>`.** The single-generic display base
+> class ships in recent FOSTestingUI — the release where `ViewModelViewTestCase<VM, VMO>`
+> was refactored to **inherit from** `ViewModelDisplayTestCase<VM>`
+> (`Sources/FOSTestingUI/ViewModelViewTestCase.swift`). **If your FOS ref predates it**
+> (older refs expose only the two-generic `ViewModelViewTestCase<VM, VMO>`), the clean
+> display-only path doesn't exist yet — fall back to subclassing the two-generic base with
+> a file-scoped **no-op `ViewModelOperations`** for the `VMO` slot. On a current ref, use
+> `ViewModelDisplayTestCase<VM>` directly and do **not** invent the empty ops type.
 
 **Display-only base class:**
 
@@ -433,6 +450,28 @@ func testNavigationToDetailView() async throws {
 
 **Note:** Views without user interactions use an empty operations file with just the protocol and minimal stub.
 
+### UI-Test Target Wiring (Xcode project)
+
+For the Xcode-project layout the app-setup skill recommends, wire the **UI-test target**
+differently from the app-hosted unit tests — three points:
+
+1. **Link `FOSFoundation` / `FOSMVVM` / `FOSTestingUI` DIRECTLY — NOT via `SPMLibraries`.**
+   UI tests run in a **separate process** and drive the app over the XCUI proxy (JSON over
+   `launchEnvironment`, never live objects). So the `SPMLibraries` type-identity trap — which
+   *forces* the umbrella for app-hosted **unit** tests — **does not apply here**; the UI-test
+   bundle links the FOS products directly. Do **not** add them to `SPMLibraries` (that
+   framework is embedded in the shipping app, and a testing framework must not ride along).
+2. **Source-include the shared contract module.** Under Option A the app has no separate
+   ViewModels framework to import, so the UI-test target must **also source-include**
+   `Sources/{ViewModelsModule}` to get the ViewModel type + its `.stub()` in-process (the
+   test encodes the stub before handing it to the app).
+3. **Copy the server-side localization tree into the test bundle.**
+   `presentView` localizes the stub *before* handing it to the app (which decodes an
+   already-localized VM). Since release client apps don't bundle `*.yml`, the UI-test target
+   copies `Sources/Resources` in as a folder reference and `setUp` passes
+   `resourceDirectoryName:` accordingly (mirrors the SPM unit test's
+   `.copy("../../Sources/Resources")` + `resourceDirectoryName: "Resources"`).
+
 ## Project Structure Configuration
 
 | Placeholder | Description | Example |
@@ -584,7 +623,7 @@ override func setUp() async throws {
 - [ ] No `repaintToggle` needed
 - [ ] No `.testDataTransporter()` needed
 - [ ] No `operations` property needed
-- [ ] `operations` stored from `viewModel.operations` in init
+- [ ] Subclass `ViewModelDisplayTestCase<VM>` (not the two-generic interactive base)
 
 ## Common Test Patterns
 
@@ -662,3 +701,5 @@ See [reference.md](reference.md) for complete file templates.
 | 1.0 | 2026-01-23 | Initial skill for UI tests |
 | 1.1 | 2026-01-24 | Update to context-aware approach (remove file-parsing/Q&A). Skill references conversation context instead of asking questions or accepting file paths. |
 | 1.2 | 2026-03-30 | Add Element Matching Rules section (identifier > localizedViewModel > never hardcoded strings). Fix hardcoded string in error state example. |
+| 1.3 | 2026-07-02 | Note that `.uiTestingIdentifier(_:)` is a FOSMVVM `View` modifier (`import FOSMVVM`, `SwiftUI Support/View+Testing.swift`), DEBUG-only (no-op in release), applied unconditionally; don't define/copy it yourself. (backlog D1) |
+| 1.4 | 2026-07-02 | Version-floor note for `ViewModelDisplayTestCase<VM>` (recent FOSTestingUI where `ViewModelViewTestCase` inherits it) + older-ref no-op-ops fallback (D2). Added "UI-Test Target Wiring (Xcode project)": link FOS directly NOT via `SPMLibraries` (separate process — trap doesn't apply), source-include the shared contract module, copy the localization tree + `resourceDirectoryName:` (D3). Fixed a copy-paste bug in the View Testing Checklist (display-only list wrongly required `operations` stored from `viewModel.operations`). |

--- a/.claude/skills/fosmvvm-viewmodel-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-viewmodel-generator/SKILL.md
@@ -817,12 +817,20 @@ public struct SettingsViewModel {
 
 ### Stubbable Pattern
 
-All ViewModels must satisfy the `Stubbable` witness `stub()` for testing and SwiftUI previews. With `@ViewModel` you rarely hand-write the zero-arg `stub()`: write a **fully-defaulted parameterized** `stub(...)` and the macro synthesizes the zero-arg witness, forwarding the defaults.
+All ViewModels must satisfy the `Stubbable` witness `stub()` for testing and SwiftUI previews. With `@ViewModel` you rarely hand-write the zero-arg `stub()`: write a **fully-defaulted parameterized** `stub(...)` **in the type's body** and the macro synthesizes the zero-arg witness, forwarding the defaults.
 
 ```swift
-public extension MyViewModel {
-    // @ViewModel synthesizes `stub()` from this fully-defaulted stub.
-    static func stub(
+@ViewModel
+public struct MyViewModel: RequestableViewModel {
+    public let id: ModelIdType
+    @LocalizedString public var title
+    public let vmId: ViewModelId
+
+    public init(id: ModelIdType, /* … */) { /* … */ }
+
+    // The fully-defaulted parameterized stub lives IN THE TYPE BODY so `@ViewModel`
+    // can see it and synthesize the zero-arg `stub()` Stubbable witness from it.
+    public static func stub(
         id: ModelIdType = .init(),
         title: String = "Sample"
     ) -> Self {
@@ -830,6 +838,13 @@ public extension MyViewModel {
     }
 }
 ```
+
+> **The parameterized `stub(...)` must be in the type's body — NOT in an `extension`.**
+> `@ViewModel` is a member macro: Swift hands it only the struct declaration, so a
+> `stub(...)` sitting in `extension MyViewModel { … }` is invisible to it and **no witness
+> is synthesized** → `does not conform to 'Stubbable'`. (A hand-written zero-arg `stub()`
+> *may* live in an extension — it's a real witness — but a `stub(...)` you expect the macro
+> to forward to cannot.)
 
 Hand-write the zero-arg `stub()` yourself only when the macro has nothing to forward to: a no-argument `init()` (`stub() { .init() }`), an interactive VM whose stub routes through a private `init(isStub:)`, or a **nested type that is plain `Stubbable` without `@ViewModel`** (see Two-Tier Stubbable Pattern). A parameterized `stub(...)` with any non-defaulted parameter is also not forwardable — the macro leaves such types to surface the normal `Stubbable` conformance error.
 

--- a/.claude/skills/fosmvvm-viewmodel-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-viewmodel-generator/SKILL.md
@@ -727,15 +727,21 @@ public struct SettingsViewModel {
 
 ### Stubbable Pattern
 
-All ViewModels must support `stub()` for testing and SwiftUI previews:
+All ViewModels must satisfy the `Stubbable` witness `stub()` for testing and SwiftUI previews. With `@ViewModel` you rarely hand-write the zero-arg `stub()`: write a **fully-defaulted parameterized** `stub(...)` and the macro synthesizes the zero-arg witness, forwarding the defaults.
 
 ```swift
 public extension MyViewModel {
-    static func stub() -> Self {
-        .init(/* default values */)
+    // @ViewModel synthesizes `stub()` from this fully-defaulted stub.
+    static func stub(
+        id: ModelIdType = .init(),
+        title: String = "Sample"
+    ) -> Self {
+        .init(id: id, title: title)
     }
 }
 ```
+
+Hand-write the zero-arg `stub()` yourself only when the macro has nothing to forward to: a no-argument `init()` (`stub() { .init() }`), an interactive VM whose stub routes through a private `init(isStub:)`, or a **nested type that is plain `Stubbable` without `@ViewModel`** (see Two-Tier Stubbable Pattern). A parameterized `stub(...)` with any non-defaulted parameter is also not forwardable — the macro leaves such types to surface the normal `Stubbable` conformance error.
 
 ### Identity: vmId
 
@@ -886,9 +892,9 @@ public struct GovernancePrincipleCardViewModel: Codable, Sendable, Identifiable 
 - `Identifiable` - for SwiftUI ForEach if used in arrays
 - `Stubbable` - for testing/previews
 
-**Two-Tier Stubbable Pattern:**
+**Two-Tier Stubbable Pattern (nested, non-`@ViewModel` types):**
 
-Nested types use fully qualified names in their extensions:
+Nested child types are plain `Stubbable` structs — they have **no `@ViewModel` macro**, so nothing synthesizes their `stub()`. Hand-write both tiers. (An `@ViewModel` parent, by contrast, hand-writes only the fully-defaulted parameterized `stub(...)`; its zero-arg `stub()` is macro-synthesized.) Nested types use fully qualified names in their extensions:
 
 ```swift
 public extension GovernancePrincipleCardViewModel.GovernancePrincipleVersionSummary {
@@ -1031,3 +1037,4 @@ See [reference.md](reference.md) for complete file templates.
 | 2.6 | 2026-01-24 | Update to context-aware approach (remove file-parsing/Q&A). Skill references conversation context instead of asking questions or accepting file paths. |
 | 2.7 | 2026-01-25 | Added Nested Child Types Pattern section with two-tier Stubbable pattern, placement rules, conformances, and decision criteria for when to nest vs keep top-level. |
 | 2.8 | 2026-04-22 | Added Third Decision (Interactive vs Display-Only) — Operations trio generation for interactive VMs. Full server-hosted and client-hosted interactive examples with `isStub` flag, `operations` property, private init. Documented client-hosted `output storage:` convention and server-backed no-output convention. Added Templates 10 and 11 to reference.md (interactive VM + Operations file pairs). |
+| 2.9 | 2026-07-02 | Fold in `@ViewModel` synthesized `Stubbable` witness: `@ViewModel` types now scaffold only the fully-defaulted parameterized `stub(...)` (macro synthesizes zero-arg `stub()`). Nested non-`@ViewModel` types still hand-write both tiers. Updated Templates 2, 4, and the full example in reference.md plus the Stubbable/Two-Tier sections here. |

--- a/.claude/skills/fosmvvm-viewmodel-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-viewmodel-generator/SKILL.md
@@ -66,16 +66,16 @@ When data is local to the device:
 Error display is a classic client-hosted scenario. You already have the data from `ResponseError` - just wrap it in a **specific** ViewModel for that error:
 
 ```swift
-// Specific ViewModel for MoveIdeaRequest errors
+// Specific ViewModel for IdeaMoveRequest errors
 @ViewModel(options: [.clientHostedFactory])
-struct MoveIdeaErrorViewModel {
+struct IdeaMoveErrorViewModel {
     let message: LocalizableString
     let errorCode: String
 
-    public var vmId = ViewModelId()
+    public var vmId: ViewModelId = .init(type: Self.self)  // shown once — singleton
 
     // Takes the specific ResponseError
-    init(responseError: MoveIdeaRequest.ResponseError) {
+    init(responseError: IdeaMoveRequest.ResponseError) {
         self.message = responseError.message
         self.errorCode = responseError.code.rawValue
     }
@@ -84,14 +84,14 @@ struct MoveIdeaErrorViewModel {
 
 Usage:
 ```swift
-catch let error as MoveIdeaRequest.ResponseError {
-    let vm = MoveIdeaErrorViewModel(responseError: error)
+catch let error as IdeaMoveRequest.ResponseError {
+    let vm = IdeaMoveErrorViewModel(responseError: error)
     return try await req.view.render("Shared/ToastView", vm)
 }
 ```
 
 **Each error scenario gets its own ViewModel:**
-- `MoveIdeaErrorViewModel` for `MoveIdeaRequest.ResponseError`
+- `IdeaMoveErrorViewModel` for `IdeaMoveRequest.ResponseError`
 - `CreateIdeaErrorViewModel` for `CreateIdeaRequest.ResponseError`
 - `SettingsValidationErrorViewModel` for settings form errors
 
@@ -112,7 +112,7 @@ Many apps use both:
 ├───────────────────────────────────────────────┤
 │ SettingsViewModel           → Client-Hosted   │
 │ OnboardingViewModel         → Client-Hosted   │
-│ MoveIdeaErrorViewModel      → Client-Hosted   │  ← Error display
+│ IdeaMoveErrorViewModel      → Client-Hosted   │  ← Error display
 │ SignInViewModel             → Server-Hosted   │
 │ UserProfileViewModel        → Server-Hosted   │
 └───────────────────────────────────────────────┘
@@ -142,7 +142,16 @@ A ViewModel answers: **"What does the View need to display?"**
 | Formatted dates | `LocalizableDate` | `createdAt: LocalizableDate` |
 | Formatted numbers | `LocalizableInt` | `totalCount: LocalizableInt` |
 | Dynamic data | Plain properties | `content: String`, `count: Int` |
+| **Locale-independent value** (version, hostname, identity) | **Typed property — NOT localized** | `version: SystemVersion` (View renders via `.versionString`), `host: String` |
 | Nested components | Child ViewModels | `cards: [CardViewModel]` |
+
+> **A version or an identity/hostname is NOT localizable text — do not wrap it in
+> `LocalizableString`.** A contract/release version is a `SystemVersion` (the View renders
+> it with `.versionString`); a hostname or other machine identity is a plain `String`.
+> These values are the *same in every locale*, so localizing them is a category error —
+> it adds a translation key that can never legitimately differ, and (for a version) throws
+> away the typed comparison FOSMVVM relies on. The default reflex to "localize every
+> string-ish field" is wrong here: **localize human-facing text; type everything else.**
 
 ### What a ViewModel Does NOT Contain
 
@@ -150,6 +159,52 @@ A ViewModel answers: **"What does the View need to display?"**
 - Business logic or validation (that's in Fields protocols)
 - Raw database IDs exposed to templates (use typed properties)
 - Unlocalized strings that Views must look up
+- **Domain / wire types** (a `DataModel`/`Channel` type as a property or init param) — see below
+
+### The ViewModel Module Must NOT Depend on Domain Types (Dependency Inversion) — HARD RULE
+
+**The ViewModel module never imports the domain/wire module.** A ViewModel target
+(`{App}ViewModels`, client-facing) depends on **FOSMVVM + Foundation + simple or
+ViewModel-owned types only** — *not* on the DataModel/`Channel` module. A domain type as a
+ViewModel field is a **category error**, not merely an unwanted dependency: **a ViewModel
+is a _projection of_ the data, never the data itself.** A field like `guestOS: Platform`
+(where `Platform` is a `Channel` domain type) is wrong on its face — and once the domain
+import is correctly absent, it won't even compile.
+
+This is **Dependency Inversion**: the high-level projection (ViewModel) does not depend on
+the low-level wire detail (`Channel`). Get it wrong and FOSMVVM breaks in the ways the
+firm principles warn about — leaked persistence types, existential-shaped seams, and a
+client module that drags server/host-only code onto iOS.
+
+**How to model a domain value correctly:**
+
+1. **The ViewModel init takes simple types** (`String`, `Int`, a ViewModel-owned enum) —
+   never a domain type.
+2. **For a value the View switches on, define a ViewModel-owned display enum** (raw-less,
+   per the Enum Localization Pattern) — e.g. a `BerthLiveness` in the ViewModel module,
+   *distinct from* any same-named domain type (see [Naming Dictionary](../shared/NAMES.md)).
+3. **The `ViewModelFactory` performs the projection.** It is the **one** component that
+   imports *both* the domain module and the ViewModel module, and it maps
+   domain → display (`Channel.Platform → GuestPlatform`) when building the VM. Factories
+   are **server-side**; the ViewModel module stays domain-free.
+
+**SOLID ergonomic (optional).** The Factory's *own* library may add a `private`/`internal`
+**extension on the ViewModel with a domain-typed initializer** that maps domain → simple
+and calls the public simple `init`:
+
+```swift
+// In the SERVER/Factory module only — never in the ViewModel module:
+extension NodeViewModel {
+    init(_ node: Channel.Node) {                 // domain-typed convenience init
+        self.init(host: node.hostname,           // → public simple init
+                  guestOS: GuestPlatform(node.platform))
+    }
+}
+```
+
+The adaptation lives **with the adapter**; the ViewModel's public API stays domain-free.
+This is the dual of keeping wire types FOSMVVM-free — the boundary is clean in **both**
+directions.
 
 ### Anti-Pattern: Composition in Views
 
@@ -200,9 +255,20 @@ public struct DashboardViewModel: RequestableViewModel {
 
     @LocalizedString public var pageTitle
     public let cards: [CardViewModel]  // Children
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton — one per screen
 }
 ```
+
+> **One top-level VM per page/screen, composing children — never a mega-VM.** A
+> multi-section surface (dashboard, dock detail, settings) is a top-level
+> `RequestableViewModel` that **composes child VMs** (`cards: [CardViewModel]`), one child
+> per section. Do **not** flatten a many-section screen into a single giant ViewModel:
+> that fuses independent concerns into one type (an **SRP** violation) and makes every
+> section share one localization/versioning/identity surface.
+>
+> **Scaffold one file per VM type** — the top-level VM and every composed child each in
+> its own file, grouped in a container-named directory. Full rules:
+> [app-setup → File Organization Conventions](../fosmvvm-swiftui-app-setup/SKILL.md#file-organization-conventions).
 
 ### 2. Child (plain ViewModel)
 
@@ -210,13 +276,29 @@ Nested components built by their parent's factory. No Request type.
 
 ```swift
 @ViewModel
-public struct CardViewModel: Codable, Sendable {
+public struct CardViewModel {
     public let id: ModelIdType
     public let title: String
     public let createdAt: LocalizableDate
-    public var vmId: ViewModelId = .init()
+    public let vmId: ViewModelId       // instance (list row) — stable id from data
+
+    // Init takes PLAIN Swift types; the init wraps them + owns formatting.
+    public init(id: ModelIdType, title: String, createdAt: Date) {
+        self.id = id
+        self.title = title
+        self.createdAt = LocalizableDate(value: createdAt)
+        self.vmId = .init(id: id)      // per-row stable — NEVER .init() on a list row
+    }
 }
 ```
+
+> **Don't restate `Codable`/`Sendable` — the macro adds them.** `@ViewModel`
+> synthesizes `ViewModel` conformance, which *already* provides `Codable` **and**
+> `Sendable`. A child VM is just `@ViewModel public struct X { … }` — **no conformance
+> clause**. Only add a clause for a conformance the macro does *not* supply: a **top-level**
+> requestable VM adds `: RequestableViewModel`, a form VM adds its `Fields` protocol, and
+> a genuinely-needed extra like `: Identifiable` stays. Restating `Codable, Sendable` is
+> redundant noise (**DRY** — don't repeat what the macro guarantees).
 
 ---
 
@@ -240,7 +322,15 @@ public struct UserCardViewModel {
     public let name: String
     @LocalizedString public var roleDisplayName
     public let createdAt: LocalizableDate
-    public var vmId: ViewModelId = .init()
+    public let vmId: ViewModelId       // instance (list row) — stable id from data
+
+    public init(id: ModelIdType, name: String, createdAt: Date) {
+        self.id = id
+        self.name = name
+        self.createdAt = LocalizableDate(value: createdAt)  // init wraps the plain Date
+        self.vmId = .init(id: id)
+        // roleDisplayName is @LocalizedString — bound by the macro, not set here
+    }
 }
 ```
 
@@ -263,7 +353,7 @@ public struct UserFormViewModel: UserFields {  // ← Adopts Fields!
     public var lastName: String
 
     public let userValidationMessages: UserFieldsMessages
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // one form per screen — singleton
 }
 ```
 
@@ -491,7 +581,7 @@ public struct PreferencesViewModel {
     }
     #endif
 
-    public var vmId = ViewModelId()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton page VM
 
     // MARK: Initialization
 
@@ -699,7 +789,7 @@ Always use the `@ViewModel` macro - it generates the `propertyNames()` method re
 public struct MyViewModel: RequestableViewModel {
     public typealias Request = MyRequest
     @LocalizedString public var title
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
     public init() {}
 }
 ```
@@ -709,7 +799,7 @@ public struct MyViewModel: RequestableViewModel {
 @ViewModel(options: [.clientHostedFactory])
 public struct SettingsViewModel {
     @LocalizedString public var pageTitle
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
 
     public init(theme: Theme, notifications: NotificationSettings) {
         // Init parameters become AppState properties
@@ -743,12 +833,53 @@ public extension MyViewModel {
 
 Hand-write the zero-arg `stub()` yourself only when the macro has nothing to forward to: a no-argument `init()` (`stub() { .init() }`), an interactive VM whose stub routes through a private `init(isStub:)`, or a **nested type that is plain `Stubbable` without `@ViewModel`** (see Two-Tier Stubbable Pattern). A parameterized `stub(...)` with any non-defaulted parameter is also not forwardable — the macro leaves such types to surface the normal `Stubbable` conformance error.
 
-### Identity: vmId
+### Identity: vmId — stable data identity, never a throwaway
 
-Every ViewModel needs a `vmId` for SwiftUI's identity system:
+`vmId` parameterizes SwiftUI's `.id()` on the view that renders the ViewModel, so it
+governs view stabilization (whether SwiftUI reuses or tears down the view on refresh). It
+must be **stable across re-fetches of the same logical thing** — never a fresh random
+value. A bare `ViewModelId()` / `.init()` is **random** (`isRandom`, `String.unique()`
+under the hood) and is correct *only* when identity genuinely doesn't matter.
 
-**Singleton** (one per page): `vmId = .init(type: Self.self)`
-**Instance** (multiple per page): `vmId = .init(id: id)` where `id: ModelIdType`
+**Singleton — one instance per screen** (a top-level page VM, or a once-only child such as
+a header/summary panel). Constant per type = maximally stable:
+
+```swift
+public var vmId: ViewModelId = .init(type: Self.self)
+```
+
+A VM that already has an `init` may equivalently declare `public let vmId: ViewModelId`
+and assign `self.vmId = .init(type: Self.self)` **in the init**. Do **not** write
+`let vmId: ViewModelId = .init(type: Self.self)` as a property *default* — an immutable
+property with a default is excluded from `Codable` decoding (the compiler warns); use `var`
+with a default, or `let` assigned in `init`.
+
+**Instance — many per screen, ESPECIALLY `List`/`ForEach` rows.** The `vmId` MUST carry the
+row's **stable data identity**, assigned in `init`:
+
+```swift
+public let vmId: ViewModelId
+public init(id: SomeId, /* … */) {
+    // …
+    self.vmId = .init(id: id)   // id may be ModelIdType, String, Int, or UUID
+}
+```
+
+Use the data's own id when it has one (`user.id`, a `nodeId: String`, …). `ViewModelId`
+accepts a plain `String`/`Int`/`UUID`/`ModelIdType` — the id is **not** required to be a
+`ModelIdType`. When there is **no single natural id**, merge stable init args into one:
+
+```swift
+self.vmId = .init(id: "\(version.versionString)-\(host)")
+```
+
+> **Two failure modes on `List` rows — both churn identity / tear the view down on every
+> refresh:**
+> - a **bare `.init()`** → a new *random* id each fetch, so SwiftUI treats every row as new;
+> - a **constant `.init(type: Self.self)`** on a repeated row → every row shares one id and
+>   they collide.
+>
+> A row needs a **per-row stable** id: `.init(id: <the row's data id>)`.
 
 ### Localization
 
@@ -776,6 +907,25 @@ public let itemCount: LocalizableInt     // NOT String
 
 The client formats these according to user's locale and timezone.
 
+**The stored property is `Localizable*`; the init PARAMETER is the plain Swift type.** The
+initializer takes `Int`/`Date`/`String`, and the init **body wraps it** and **owns the
+formatting policy** — declared once, in the ViewModel:
+
+```swift
+public let totalBerths: LocalizableInt          // stored — self-localizes on encode
+public let lastSeen: LocalizableDate
+
+public init(totalBerths: Int, lastSeen: Date) {  // params are plain Swift types
+    self.totalBerths = .init(value: totalBerths, showGroupingSeparator: true)  // policy lives here
+    self.lastSeen = .init(value: lastSeen)
+}
+```
+
+Callers — the Factory, stubs, previews — pass **plain values** (`.stub(totalBerths: 12)`)
+and **never construct a `Localizable*` themselves**. This is **Single Responsibility**:
+formatting policy is the ViewModel's job, stated in one place, not smeared across every
+call site.
+
 ### Enum Localization Pattern
 
 For dynamic enum values (status, state, category), use a **stored `LocalizableString`** - NOT `@LocalizedString`.
@@ -783,12 +933,13 @@ For dynamic enum values (status, state, category), use a **stored `LocalizableSt
 `@LocalizedString` always looks up the same key (the property name). A stored `LocalizableString` carries the dynamic key from the enum case.
 
 ```swift
-// Enum provides localizableString
-public enum SessionState: String, CaseIterable, Codable, Sendable {
+// Enum provides localizableString.
+// NO `: String` raw backing — the case name IS the key (via String(describing:)).
+public enum SessionState: CaseIterable, Codable, Sendable {
     case pending, running, completed, failed
 
     public var localizableString: LocalizableString {
-        .localized(for: Self.self, propertyName: rawValue)
+        .localized(for: Self.self, propertyName: String(describing: self))
     }
 }
 
@@ -817,6 +968,16 @@ en:
 
 **Constraint:** `LocalizableString` only works in ViewModels encoded with `localizingEncoder()`. Do not use in Fluent JSONB fields or other persisted types.
 
+> **ViewModel enums carry no `String`/`Int` raw backing when avoidable.** Write
+> `enum BerthLiveness: Codable, Sendable, CaseIterable`, **not** `: String`. `Codable`
+> synthesizes for a raw-value-less enum (it encodes by case name), and the localization
+> key is the case name via `String(describing:)` — so a raw type buys nothing. A
+> `String`/`Int` raw backing actively invites mayhem: `init?(rawValue:)` from arbitrary
+> input, a `.rawValue` that tempts stringly-typed comparisons, and it silently couples the
+> wire format to the case spelling. **Model the vocabulary; don't back it with a
+> primitive.** (A View-switched discriminator enum — one the View renders per case, with
+> no localized text — is likewise raw-less and needs no `localizableString` at all.)
+
 ### Child ViewModels
 
 Top-level ViewModels contain their children:
@@ -837,7 +998,7 @@ When a child type is **only used by one parent** and represents a summary or ref
 
 ```swift
 @ViewModel
-public struct GovernancePrincipleCardViewModel: Codable, Sendable, Identifiable {
+public struct GovernancePrincipleCardViewModel: Identifiable {  // macro adds Codable+Sendable; only Identifiable is extra
     // Properties come first
     public let versionHistory: [GovernancePrincipleVersionSummary]?
     public let referencingDecisions: [GovernanceDecisionReference]?
@@ -1010,12 +1171,28 @@ See [reference.md](reference.md) for complete file templates.
 | Concept | Convention | Example |
 |---------|------------|---------|
 | ViewModel struct | `{Name}ViewModel` | `DashboardViewModel` |
-| Request class | `{Name}Request` | `DashboardRequest` |
+| Request class (screen read) | `{Name}Request` — **no verb** | `DashboardRequest`, `DocksRequest` |
 | Factory extension | `{Name}ViewModel+Factory.swift` | `DashboardViewModel+Factory.swift` |
 | YAML file | `{Name}ViewModel.yml` | `DashboardViewModel.yml` |
 
+A screen/page ViewModel's read request drops the verb — the noun alone *is* the read
+(`DocksRequest`, not `DocksShowRequest`). Write/action requests are noun-first with a
+verb (`UserCreateRequest`). Full rules: [Naming Dictionary](../shared/NAMES.md).
+
+**Duplicate type names across modules are fine — the module *is* the namespace.** Don't
+contort a ViewModel display type's name to avoid colliding with a same-named domain type.
+`HarborChannel.Tier` (domain) and a ViewModel `Tier` (display projection) coexist as
+distinct types; the `ViewModelFactory` maps between them. The display type is a
+*projection of* the data, not the data — a same-named-but-distinct type is correct, not a
+smell. Name a display type for what it **means**, not to dodge a collision. (This is the
+naming corollary of Dependency Inversion — see "The ViewModel Module Must NOT Depend on
+Domain Types" above: the ViewModel module never imports the domain module, so the two
+same-named types can't actually clash in one file.) See
+[Naming Dictionary → Duplicate type names](../shared/NAMES.md).
+
 ## See Also
 
+- [Naming Dictionary](../shared/NAMES.md) - Canonical naming rules (read requests, duplicate type names across modules)
 - [Architecture Patterns](../shared/architecture-patterns.md) - Mental models (errors are data, type safety, etc.)
 - [FOSMVVMArchitecture.md](../../docs/FOSMVVMArchitecture.md) - Full FOSMVVM architecture
 - [fosmvvm-fields-generator](../fosmvvm-fields-generator/SKILL.md) - For form validation
@@ -1038,3 +1215,6 @@ See [reference.md](reference.md) for complete file templates.
 | 2.7 | 2026-01-25 | Added Nested Child Types Pattern section with two-tier Stubbable pattern, placement rules, conformances, and decision criteria for when to nest vs keep top-level. |
 | 2.8 | 2026-04-22 | Added Third Decision (Interactive vs Display-Only) — Operations trio generation for interactive VMs. Full server-hosted and client-hosted interactive examples with `isStub` flag, `operations` property, private init. Documented client-hosted `output storage:` convention and server-backed no-output convention. Added Templates 10 and 11 to reference.md (interactive VM + Operations file pairs). |
 | 2.9 | 2026-07-02 | Fold in `@ViewModel` synthesized `Stubbable` witness: `@ViewModel` types now scaffold only the fully-defaulted parameterized `stub(...)` (macro synthesizes zero-arg `stub()`). Nested non-`@ViewModel` types still hand-write both tiers. Updated Templates 2, 4, and the full example in reference.md plus the Stubbable/Two-Tier sections here. |
+| 2.10 | 2026-07-02 | Naming Conventions: screen read requests are verb-less (`DocksRequest`); added duplicate-type-names-across-modules guidance + [Naming Dictionary](../shared/NAMES.md) cross-ref. (backlog A2/A3) |
+| 2.11 | 2026-07-02 | Quick conventions: child VMs drop redundant `: Codable, Sendable` (macro adds them) — B9; ViewModel enums are raw-value-less (`String(describing:)` key, not `: String rawValue`) — B6; added `SystemVersion`/locale-independent field-type row + anti-pattern (version/hostname are typed, never `LocalizableString`) — B8. |
+| 2.12 | 2026-07-02 | Conceptual set: one top-level VM per screen composing children, never a mega-VM + one-file-per-VM pointer to app-setup — B1/B2; `Localizable*` init takes the plain Swift type and wraps it (formatting policy owned by init) — B3; **rewrote Identity: vmId** — stable data identity, singleton `.init(type: Self.self)` vs list-row `.init(id:)` (String/Int/UUID/merged), List-churn warning; reconciled all `.init()` throwaways in SKILL.md + reference.md (verified against `ViewModelId`) — B4; added **"ViewModel Module Must NOT Depend on Domain Types (Dependency Inversion)"** hard-rule section with Factory-adapter ergonomic — B5. |

--- a/.claude/skills/fosmvvm-viewmodel-generator/reference.md
+++ b/.claude/skills/fosmvvm-viewmodel-generator/reference.md
@@ -94,7 +94,7 @@ import Foundation
 /// This is a child ViewModel - built by its parent's Factory.
 /// Each instance represents a different data entity.
 @ViewModel
-public struct {Name}ViewModel: Codable, Sendable {
+public struct {Name}ViewModel {
     // MARK: - Data Identity
 
     /// The database entity ID - enables round-trip to server
@@ -111,7 +111,7 @@ public struct {Name}ViewModel: Codable, Sendable {
 
     // MARK: - Identity
 
-    public var vmId: ViewModelId
+    public let vmId: ViewModelId
 
     // MARK: - Initialization
 
@@ -125,14 +125,13 @@ public struct {Name}ViewModel: Codable, Sendable {
         self.createdAt = LocalizableDate(value: createdAt)
         self.vmId = .init(id: id)  // Instance identity from data ID
     }
-}
 
-// MARK: - Stubbable
+    // MARK: - Stubbable
 
-public extension {Name}ViewModel {
-    // Hand-write only the fully-defaulted parameterized stub.
-    // `@ViewModel` synthesizes the zero-arg `stub()` Stubbable witness from it.
-    static func stub(
+    // The fully-defaulted parameterized stub lives IN THE BODY so `@ViewModel`
+    // synthesizes the zero-arg `stub()` witness from it. A member macro cannot
+    // see a stub declared in an `extension`.
+    public static func stub(
         id: ModelIdType = .init(),
         title: String = "Sample Title",
         createdAt: Date = .now
@@ -277,14 +276,12 @@ public struct {Name}ViewModel: Codable, Sendable, Identifiable {
         self.childSummaries = childSummaries
         self.relatedItems = relatedItems
     }
-}
 
-// MARK: - Parent Stubbable
-
-public extension {Name}ViewModel {
-    // Parent is `@ViewModel`: hand-write only this fully-defaulted parameterized
-    // stub. The macro synthesizes the zero-arg `stub()` witness from it.
-    static func stub(
+    // MARK: - Parent Stubbable
+    // Parent is `@ViewModel`: the fully-defaulted parameterized stub lives IN THE
+    // BODY so the macro synthesizes the zero-arg `stub()` witness from it (a member
+    // macro cannot see a stub declared in an extension).
+    public static func stub(
         id: ModelIdType = .init(),
         title: String = "A Title",
         description: String = "A Description",
@@ -887,13 +884,13 @@ import FOSMVVM
 import Foundation
 
 @ViewModel
-public struct CardViewModel: Codable, Sendable {
+public struct CardViewModel {
     public let id: ModelIdType
     public let title: String
     public let description: String
     public let createdAt: LocalizableDate
 
-    public var vmId: ViewModelId
+    public let vmId: ViewModelId
 
     public init(
         id: ModelIdType,
@@ -907,12 +904,11 @@ public struct CardViewModel: Codable, Sendable {
         self.createdAt = LocalizableDate(value: createdAt)
         self.vmId = .init(id: id)
     }
-}
 
-public extension CardViewModel {
-    // `@ViewModel` synthesizes the zero-arg `stub()` witness from this
-    // fully-defaulted parameterized stub — do not hand-write `stub()`.
-    static func stub(
+    // `@ViewModel` synthesizes the zero-arg `stub()` witness from this fully-defaulted
+    // parameterized stub — which must be IN THE BODY (a member macro can't see an
+    // extension). Do not hand-write `stub()`.
+    public static func stub(
         id: ModelIdType = .init(),
         title: String = "Sample Card",
         description: String = "This is a sample card for previews.",

--- a/.claude/skills/fosmvvm-viewmodel-generator/reference.md
+++ b/.claude/skills/fosmvvm-viewmodel-generator/reference.md
@@ -130,10 +130,8 @@ public struct {Name}ViewModel: Codable, Sendable {
 // MARK: - Stubbable
 
 public extension {Name}ViewModel {
-    static func stub() -> Self {
-        .stub(id: .init())
-    }
-
+    // Hand-write only the fully-defaulted parameterized stub.
+    // `@ViewModel` synthesizes the zero-arg `stub()` Stubbable witness from it.
     static func stub(
         id: ModelIdType = .init(),
         title: String = "Sample Title",
@@ -194,7 +192,7 @@ public extension {Name}ViewModel {
 
 ## Template 4: ViewModel with Nested Child Types
 
-For ViewModels that contain child types used only by this parent. Shows proper placement, conformances, and two-tier Stubbable pattern.
+For ViewModels that contain child types used only by this parent. Shows proper placement, conformances, and the Stubbable pattern: the `@ViewModel` parent's zero-arg `stub()` is macro-synthesized from its parameterized stub, while nested non-`@ViewModel` types hand-write both stub tiers.
 
 **Reference:** `Sources/KairosModels/Governance/GovernancePrincipleCardViewModel.swift`
 
@@ -284,12 +282,8 @@ public struct {Name}ViewModel: Codable, Sendable, Identifiable {
 // MARK: - Parent Stubbable
 
 public extension {Name}ViewModel {
-    // Tier 1: Zero-arg (delegates to tier 2)
-    static func stub() -> Self {
-        .stub(id: .init())
-    }
-
-    // Tier 2: Parameterized with defaults
+    // Parent is `@ViewModel`: hand-write only this fully-defaulted parameterized
+    // stub. The macro synthesizes the zero-arg `stub()` witness from it.
     static func stub(
         id: ModelIdType = .init(),
         title: String = "A Title",
@@ -308,9 +302,11 @@ public extension {Name}ViewModel {
 }
 
 // MARK: - Nested Type Stubbable Extensions (fully qualified names)
+// Nested types are plain `Stubbable` (no `@ViewModel`), so nothing synthesizes
+// their witness — hand-write both tiers: zero-arg delegates to parameterized.
 
 public extension {Name}ViewModel.ChildSummary {
-    // Tier 1: Zero-arg (delegates to tier 2)
+    // Tier 1: Zero-arg witness (delegates to tier 2)
     static func stub() -> Self {
         .stub(id: .init())
     }
@@ -347,7 +343,8 @@ public extension {Name}ViewModel.RelatedItemReference {
 - Nested types placed BEFORE `vmId` and parent init
 - Each nested type conforms to: `Codable, Sendable, Identifiable, Stubbable`
 - Extensions use fully qualified names: `{Parent}.{NestedType}`
-- Two-tier Stubbable: zero-arg always delegates to parameterized
+- Parent (`@ViewModel`): hand-write only the fully-defaulted `stub(...)`; the macro synthesizes zero-arg `stub()`
+- Nested types (plain `Stubbable`, no `@ViewModel`): hand-write both tiers — zero-arg delegates to parameterized
 - Section markers: `// MARK: - Nested Types`
 
 ---
@@ -913,10 +910,8 @@ public struct CardViewModel: Codable, Sendable {
 }
 
 public extension CardViewModel {
-    static func stub() -> Self {
-        .stub(id: .init())
-    }
-
+    // `@ViewModel` synthesizes the zero-arg `stub()` witness from this
+    // fully-defaulted parameterized stub — do not hand-write `stub()`.
     static func stub(
         id: ModelIdType = .init(),
         title: String = "Sample Card",

--- a/.claude/skills/fosmvvm-viewmodel-generator/reference.md
+++ b/.claude/skills/fosmvvm-viewmodel-generator/reference.md
@@ -58,7 +58,7 @@ public struct {Name}ViewModel: RequestableViewModel {
 
     // MARK: - Identity
 
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
 
     // MARK: - Initialization
 
@@ -172,7 +172,7 @@ public struct {Name}ViewModel: Codable, Sendable {
 
     // MARK: - Identity
 
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
 
     // MARK: - Initialization
 
@@ -474,7 +474,7 @@ public struct {Name}ViewModel {
 
     // MARK: - Identity
 
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
 
     // MARK: - Initialization
 
@@ -563,7 +563,7 @@ public struct SettingsViewModel {
 
     // MARK: - Identity
 
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
 
     // MARK: - Initialization
 
@@ -763,7 +763,7 @@ public struct {Name}ViewModel {
     }
     #endif
 
-    public var vmId = ViewModelId()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
 
     // MARK: Initialization
 
@@ -861,7 +861,7 @@ public struct DashboardViewModel: RequestableViewModel {
     public let cards: [CardViewModel]
     public let totalCount: LocalizableInt
 
-    public var vmId: ViewModelId = .init()
+    public var vmId: ViewModelId = .init(type: Self.self)  // singleton
 
     public init(cards: [CardViewModel], totalCount: Int) {
         self.cards = cards

--- a/.claude/skills/fosmvvm-viewmodel-test-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-viewmodel-test-generator/SKILL.md
@@ -21,6 +21,20 @@ ViewModel testing in FOSMVVM verifies three critical aspects:
 
 The `LocalizableTestCase` protocol provides infrastructure that tests all three in a single call.
 
+> **The version baseline is a COMMITTED artifact (in a downstream app).** Versioning
+> stability works by comparing the ViewModel's current serialization against a stored
+> baseline JSON (`{Name}ViewModel_<version>.json`, written beside the test under
+> `Tests/.../.VersionedTestJSON/`). For an app that **ships a versioned wire contract to
+> real clients, commit that baseline to git** — it is the canary that catches an
+> accidental wire-shape change across builds. If it isn't committed, it regenerates fresh
+> every clean build and silently protects nothing. (**Different policy for FOSUtilities
+> itself:** its own baselines are *regenerable fixtures* with no shipped contract — the
+> version tags are arbitrary — so FOS deliberately git-ignores them except one intentional
+> serialization canary. Downstream apps are the opposite: commit real baselines.) The
+> primary `expectFullViewModelTests(_:)` now forwards `#filePath`/`#line`, so the baseline
+> lands beside **your** test (under `Tests/.../.VersionedTestJSON/`) automatically —
+> commit that file.
+
 ---
 
 ## When to Use This Skill
@@ -378,3 +392,4 @@ let vm = try .stub().toJSON(encoder: encoder(locale: en)).fromJSON()
 | 1.0 | 2025-01-02 | Initial skill |
 | 1.1 | 2026-01-19 | Updated LocalizableTestCase example to use {ViewModelsTarget}.resourceAccess pattern. |
 | 1.2 | 2026-01-24 | Update to context-aware approach (remove file-parsing/Q&A). Skill references conversation context instead of asking questions or accepting file paths. |
+| 1.3 | 2026-07-02 | Note the version baseline is a **committed artifact** for downstream apps (FOS's own baselines are regenerable/git-ignored fixtures — different policy); `expectFullViewModelTests(_:)` now forwards `#filePath`/`#line` so the baseline lands beside the caller's test. (backlog B7) |

--- a/.claude/skills/shared/NAMES.md
+++ b/.claude/skills/shared/NAMES.md
@@ -1,0 +1,116 @@
+# FOSMVVM Naming Dictionary
+
+The canonical reference for naming FOSMVVM types. The generator skills cite this file;
+when a type name feels ambiguous, **this file decides**. Naming is not cosmetic in
+FOSMVVM — the module *is* the namespace and paths are derived from type names, so a
+name is part of the contract.
+
+> **Why naming is load-bearing (SOLID).** A FOSMVVM name should encode the type's
+> *single responsibility* and its *place in the namespace*, not fight the type system:
+> - **Single Responsibility (SRP):** the *primary* axis a type belongs to leads its
+>   name, so a family of related types stays cohesive and discoverable.
+> - **Interface Segregation / "the module is the namespace" (ISP):** you name a type
+>   for what it *means* inside its module, never to dodge a collision with a type in
+>   another module.
+> - **Development velocity is lifetime velocity:** consistent, sortable names are how a
+>   maintainer *finds* the right type six months later. Inconsistent naming is a slow,
+>   compounding tax.
+
+---
+
+## 1. Request type names
+
+### 1a. Write / action requests → `<Noun><Verb>Request` (noun **first**)
+
+The concrete request type leads with the **entity/noun**, then the **action verb**,
+then `Request`. This holds for the standard REST verbs **and** for semantic actions.
+
+| Operation | ✅ Correct (noun-first) | ❌ Wrong (verb-first) |
+|-----------|------------------------|----------------------|
+| Create a User (POST) | `UserCreateRequest` | `CreateUserRequest` |
+| Update a User (PATCH) | `UserUpdateRequest` | `UpdateUserRequest` |
+| Replace a User (PUT) | `UserReplaceRequest` | `ReplaceUserRequest` |
+| Delete a User (DELETE) | `UserDeleteRequest` | `DeleteUserRequest` |
+| Semantic action ("move an idea") | `IdeaMoveRequest` | `MoveIdeaRequest` |
+| Semantic action ("mint a token") | `AgentTokenMintRequest` | `MintAgentTokenRequest` |
+
+**Why noun-first (SRP — cohesion on the primary axis).** The entity is the primary
+axis a request belongs to. Noun-first keeps a whole entity's request family together —
+`UserCreateRequest`, `UserDeleteRequest`, `UserShowRequest`, `UserUpdateRequest` sort
+and read as one group. Verb-first *scatters* the same family across the alphabet
+(`Create…` under C, `Delete…` under D) and buries the thing that actually matters
+(which entity). It also matches the read-request forms below, so **every** request for
+an entity shares one prefix.
+
+**Anti-pattern callout:** `CreateUserRequest` / `MoveIdeaRequest` / `MintAgentTokenRequest`
+are verb-first and **wrong**. If you have existing verb-first names, they are a rename
+item — do not add more.
+
+### 1b. ViewModel read requests → `<Noun>Request` (Show is implied — **no verb**)
+
+A request that fetches the data to render a screen/page ViewModel takes the ViewModel's
+noun with **no verb** — the read is the one canonical fetch, so a "Show" verb would be
+noise.
+
+| Screen ViewModel | ✅ Read request |
+|------------------|----------------|
+| `LandingPageViewModel` | `LandingPageRequest` |
+| `DocksViewModel` | `DocksRequest` |
+| `DashboardViewModel` | `DashboardRequest` |
+
+This is still noun-first — the noun is the screen. It composes with 1a: an entity that
+has both a screen read and writes reads as `Docks` + `Docks…Request`.
+
+### 1c. Raw-data Show requests → `<Entity>ShowRequest`
+
+A request that reads **raw entity data** (not a screen ViewModel) keeps an explicit
+`Show`, noun-first: `UserShowRequest`. The explicit verb distinguishes it from other
+reads that may operate on the same entity.
+
+---
+
+## 2. Duplicate type names across modules are fine — the module *is* the namespace
+
+A DataModel/wire type and a ViewModel display type **may share a name**. Do **not**
+contort a display type's name to avoid colliding with its domain counterpart.
+
+```swift
+HarborChannel.Tier      // the wire/DataModel type (domain module)
+HarborViewModels.Tier   // the display projection (ViewModel module) — distinct type, fine
+```
+
+Each module *is* a Swift namespace, and the Data-vs-View context is part of the
+contract, so the two `Tier`s coexist as distinct types. The `ViewModelFactory` holds the
+module-qualified mapping between them.
+
+**Why (ISP + the projection boundary).** The ViewModel `Tier` is a *projection of* the
+domain `Tier`, not the same type — often a subtly different shape. A same-named-but-
+distinct type is **correct**, not a smell. (This is the naming corollary of the
+Dependency-Inversion boundary: the ViewModel module must not import the domain module —
+see the viewmodel-generator's "ViewModel module must not depend on domain types"
+section. The Factory is the one place that sees both.)
+
+**Name a display type for what it *means*, not to dodge a collision.** If a
+more-descriptive display name is clearer (`GuestPlatform` vs a bare `Platform`), choose
+it for *meaning* — not out of fear of the collision, which is harmless.
+
+---
+
+## Quick reference
+
+| You are naming… | Form | Example |
+|-----------------|------|---------|
+| Create/Update/Replace/Delete request | `<Noun><Verb>Request` | `UserCreateRequest` |
+| Semantic-action request | `<Noun><Action>Request` | `IdeaMoveRequest` |
+| Screen/page ViewModel read request | `<Noun>Request` | `DocksRequest` |
+| Raw-entity read request | `<Entity>ShowRequest` | `UserShowRequest` |
+| Display type colliding with a domain type | name for meaning; collision is fine | `HarborViewModels.Tier` |
+
+## Red flags — STOP
+
+- A request name that **starts with a verb** (`Create…`, `Update…`, `Move…`, `Mint…`) —
+  flip it noun-first.
+- Adding a suffix/prefix to a ViewModel display type **only** to avoid a same-named
+  domain type — the collision is harmless; name for meaning instead.
+- A screen read request carrying a `Show`/`Get`/`Fetch` verb — drop it; the noun alone
+  is the read.

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,9 @@ DerivedData/
 .derivedData
 *.tmp
 session-state-*.json
-Sources/.VersionedTestJSON
+
+# Versioned-ViewModel test baselines are regenerable test fixtures (no shipped
+# wire-format contract), so they are not committed. Intentional serialization
+# canaries are tracked explicitly via the negation below.
+Tests/**/.VersionedTestJSON/*
+!Tests/**/.VersionedTestJSON/TestVersionedViewModel_*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to **FOSUtilities** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **WebAssembly (WASM) platform support**, including a WASI `URLSession`
+  implementation (with JavaScript wrapper functions that preserve `this`
+  context) so `FOSFoundation` networking works in the browser.
+- **Custom `URLSession` injection** — an application can now supply its own
+  `URLSession` through `MVVMEnvironment`.
+- **`@LocalizedDouble`** — a localized, locale-formatted `Double` property
+  wrapper (`LocalizableDouble`), alongside the existing `@LocalizedInt`.
+- **Localizable array access** — localized array properties (`@LocalizedStrings`)
+  for binding collections of localized values.
+- **`OperationBus`** — a mechanism for dispatching ViewModel operations.
+- **`Localizable` support for SwiftUI `Label` and `LabeledContent`.**
+- **`ViewModelDisplayTestCase`** (FOSTestingUI) — a display-only ViewModel UI
+  test base class that does not require a `ViewModelOperations` type.
+- **FOSMVVM React runtime resources** are served from `FOSMVVMVapor` at
+  `/fosmvvm/react/` under a global namespace.
+- **`ReplaceRequest` protocol** — the PUT verb of the write-request family
+  (`Create` / `Update` / `Delete` / `Destroy` / **`Replace`**). It mirrors
+  `UpdateRequest` (`RequestBody: ValidatableModel`, `action == .replace`) and
+  adds the `ReplaceResponseBody` marker. The generic `ServerRequestController`
+  already routes `.replace` to `PUT`, so no server-side change is required to
+  serve one.
+- **`@ViewModel` synthesizes the `Stubbable` witness.** When a type provides a
+  fully-defaulted parameterized `stub(...)` but no zero-argument `stub()`, the
+  macro now generates `static func stub() -> Self`, forwarding each parameter's
+  default explicitly (so the call binds to the parameterized overload rather than
+  recursing into the witness). Types no longer need to hand-write the boilerplate
+  witness alongside a parameterized stub.
+
+### Changed
+
+- **Yams dependency now points at the official `jpsim/Yams`** (the WASM support
+  is kept dormant).
+
+### Fixed
+
+- **`FormFieldView`** now preserves typed whitespace and uses the current
+  `onNewValue` closure, and resolves a debounce race and a `FocusState`
+  field-clear bug observed on iOS 18.
+- **FOSMVVM React resources** are served from the correct bundle root.
+- A missing Linux `import` was added.
+- **Versioned ViewModel baselines are persisted beside the calling test**, not
+  inside FOSTesting's own source. `expectFullViewModelTests` now forwards
+  `#filePath` / `#line` to `expectVersionedViewModel`, so the baseline directory
+  is resolved at the developer's test file. Previously the convenience wrapper
+  resolved `#filePath` to FOSTesting's source and wrote baselines to an
+  ephemeral, ignored location, defeating cross-version drift detection.
+- **Version-baseline directories anchor on the SwiftPM test-target root**
+  (`Tests/<Target>/.VersionedTestJSON`), independent of how deeply the calling
+  test file is nested. This keeps equally-named types in sibling test targets
+  from colliding on a shared baseline file. Non–SwiftPM layouts fall back to the
+  previous behavior.
+
+## Prior releases
+
+Releases up to and including **0.3.7** are recorded as
+[Git tags](https://github.com/foscomputerservices/FOSUtilities/tags) and GitHub
+Releases. This changelog begins tracking notable changes from the next release
+onward.
+
+[Unreleased]: https://github.com/foscomputerservices/FOSUtilities/compare/0.3.7...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test file is nested. This keeps equally-named types in sibling test targets
   from colliding on a shared baseline file. Non–SwiftPM layouts fall back to the
   previous behavior.
+  - **⚠ Migration (downstream apps that commit baselines):** the baseline path
+    changed. If you committed version baselines at the old location, move them to
+    `Tests/<Target>/.VersionedTestJSON/`. A baseline left at the old path is not
+    found, silently **regenerated**, and the test **passes** — so cross-version
+    drift detection is quietly lost until the files are moved. (FOSUtilities' own
+    baselines are now git-ignored, so only downstream consumers are affected.)
 
 ## Prior releases
 

--- a/Sources/FOSMVVM/Macros/Macros.swift
+++ b/Sources/FOSMVVM/Macros/Macros.swift
@@ -29,7 +29,7 @@ public macro FieldValidationModel() = #externalMacro(
 )
 
 @attached(extension, conformances: RetrievablePropertyNames, ViewModel, ClientHostedViewModelFactory, RequestableViewModel)
-@attached(member, names: named(propertyNames), named(Request), named(AppState), named(model), named(modelSync), named(ClientHostedRequest))
+@attached(member, names: named(propertyNames), named(Request), named(AppState), named(model), named(modelSync), named(ClientHostedRequest), named(stub))
 public macro ViewModel(options: Set<ViewModelOptions> = []) = #externalMacro(
     module: "FOSMacros",
     type: "ViewModelMacro"

--- a/Sources/FOSMVVM/Protocols/ReplaceRequest.swift
+++ b/Sources/FOSMVVM/Protocols/ReplaceRequest.swift
@@ -1,0 +1,41 @@
+// ReplaceRequest.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+
+/// A ``ServerRequest`` that requests that the server **replace** a resource
+///
+/// `ReplaceRequest` is the PUT verb of the write-protocol family: unlike
+/// ``UpdateRequest`` (PATCH, a partial modification of an existing resource),
+/// a replace supplies the resource's full desired state. It mirrors
+/// ``UpdateRequest``'s contract — its ``ServerRequest/RequestBody`` is a
+/// ``ValidatableModel`` so the same ``Fields`` validation applies at every layer.
+public protocol ReplaceRequest: ServerRequest, Stubbable
+    where RequestBody: ValidatableModel, ResponseBody: ReplaceResponseBody {}
+
+public extension ReplaceRequest {
+    static var baseTypeName: String {
+        "ReplaceRequest"
+    }
+
+    var action: ServerRequestAction {
+        .replace
+    }
+}
+
+public protocol ReplaceResponseBody: ServerRequestBody {}
+
+extension EmptyBody: ReplaceResponseBody {}

--- a/Sources/FOSMacros/ViewModelMacro.swift
+++ b/Sources/FOSMacros/ViewModelMacro.swift
@@ -257,6 +257,23 @@ public struct ViewModelMacro: ExtensionMacro, MemberMacro {
             newDecls.append(DeclSyntax(modelDecl))
         }
 
+        // Synthesize the `Stubbable` witness `stub()` when the VM provides a
+        // fully-defaulted parameterized `stub(...)` but no zero-arg `stub()`.
+        // Swift does not let a defaulted parameter satisfy the no-arg requirement,
+        // so we forward each parameter with its default made *explicit* — the call
+        // then binds unambiguously to the parameterized overload rather than
+        // recursing back into this witness.
+        if let stubSource = structDecl.stubWitnessSource {
+            let stubDecl = try FunctionDeclSyntax(
+                """
+                public static func stub() -> Self {
+                    Self.stub(\(raw: stubSource.forwardingDefaultArguments))
+                }
+                """
+            )
+            newDecls.append(DeclSyntax(stubDecl))
+        }
+
         // Generate the propertyNames function
         var pairs = properties.map { "_\($0.id): \"\($0.name)\"" }.joined(separator: ", ")
         if pairs.isEmpty {
@@ -301,6 +318,29 @@ private extension StructDeclSyntax {
         } ?? false
     }
 
+    /// The parameterized `static func stub(...)` the synthesized `Stubbable`
+    /// witness should forward to, or `nil` when the macro should not synthesize one.
+    ///
+    /// Returns `nil` when a zero-parameter `static func stub()` already satisfies
+    /// the witness, or when no parameterized `stub(...)` has *all* parameters
+    /// defaulted (the macro cannot invent argument values, so it stays out of the
+    /// way and lets the normal `Stubbable` conformance error surface).
+    var stubWitnessSource: FunctionDeclSyntax? {
+        let stubFuncs = memberBlock.members
+            .compactMap { $0.decl.as(FunctionDeclSyntax.self) }
+            .filter { $0.name.text == "stub" && $0.isStatic }
+
+        // A zero-arg stub() already witnesses Stubbable — never overload it.
+        guard !stubFuncs.contains(where: \.signature.parameterClause.parameters.isEmpty)
+        else { return nil }
+
+        // Only a stub(...) with every parameter defaulted can be forwarded no-arg.
+        return stubFuncs.first { fn in
+            let params = fn.signature.parameterClause.parameters
+            return !params.isEmpty && params.allSatisfy { $0.defaultValue != nil }
+        }
+    }
+
     var initParams: [(name: String, type: String)] {
         let initializers = memberBlock.members.compactMap {
             $0.decl.as(InitializerDeclSyntax.self)
@@ -315,6 +355,25 @@ private extension StructDeclSyntax {
             }
             return (name: param.firstName.text, type: typeAnnotation)
         }
+    }
+}
+
+private extension FunctionDeclSyntax {
+    var isStatic: Bool {
+        modifiers.contains { $0.name.tokenKind == .keyword(.static) }
+    }
+
+    /// A call-argument list that passes every parameter its own default value
+    /// explicitly, e.g. `count: 8, name: "x"`. A parameter with an omitted
+    /// external label (`_`) is forwarded positionally.
+    var forwardingDefaultArguments: String {
+        signature.parameterClause.parameters.compactMap { param -> String? in
+            guard let defaultValue = param.defaultValue?.value.trimmed.description else {
+                return nil
+            }
+            let label = param.firstName.text
+            return label == "_" ? defaultValue : "\(label): \(defaultValue)"
+        }.joined(separator: ", ")
     }
 }
 #endif

--- a/Sources/FOSTesting/Expectations.swift
+++ b/Sources/FOSTesting/Expectations.swift
@@ -114,7 +114,21 @@ public func expectVersionedViewModel<VM: ViewModel>(_ viewModelType: VM.Type, ve
 
 private extension FileManager {
     func testFileDirectory(basePath: String) -> URL {
-        URL(fileURLWithPath: basePath)
+        let components = URL(fileURLWithPath: basePath).pathComponents
+
+        // Anchor on the SwiftPM test-target root: `Tests/<Target>/.VersionedTestJSON`.
+        // This is independent of how deeply the calling test file is nested, and
+        // keeps each target's baselines in their own directory (so equally-named
+        // types in sibling targets — e.g. two `TestViewModel`s — never collide).
+        if let testsIndex = components.lastIndex(of: "Tests"), testsIndex + 1 < components.count {
+            let targetRoot = components[...(testsIndex + 1)].reduce(URL(fileURLWithPath: "/")) { url, component in
+                component == "/" ? url : url.appendingPathComponent(component)
+            }
+            return targetRoot.appendingPathComponent(".VersionedTestJSON")
+        }
+
+        // Fallback for non-SwiftPM layouts with no `Tests` directory in the path.
+        return URL(fileURLWithPath: basePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent(".VersionedTestJSON")

--- a/Sources/FOSTesting/FOSTesting.docc/ViewModelTesting.md
+++ b/Sources/FOSTesting/FOSTesting.docc/ViewModelTesting.md
@@ -31,6 +31,14 @@ that is needed to test each *ViewModel*.  This method will test the following:
 - That all supported back-versions are decodable by the latest code
 - That all @LocalizedString properties have translations
 
+> Important: The version baseline JSON (`<Name>ViewModel_<version>.json`, written under
+> `Tests/.../.VersionedTestJSON/` beside your test) is a **committed artifact** for any
+> app that ships a versioned wire contract — commit it so it can catch an accidental
+> wire-shape change across builds. `expectFullViewModelTests` forwards `#filePath`/`#line`
+> so the baseline lands next to the calling test. (FOSUtilities' *own* baselines are
+> regenerable fixtures with no shipped contract and are deliberately git-ignored — the
+> opposite policy from a downstream app.)
+
 ### Example
 
 ```swift

--- a/Sources/FOSTesting/LocalizableTestCase.swift
+++ b/Sources/FOSTesting/LocalizableTestCase.swift
@@ -133,13 +133,15 @@ public extension LocalizableTestCase {
     /// - Parameters:
     ///   - viewModelType: A *System.Type* of a type that conforms to **ViewModel**
     ///   - locales: An optional set of **Locale**s to test (default: LocalizableTestCase.locales)
-    func expectFullViewModelTests(_ viewModelType: (some ViewModel & ViewModel).Type, locales: Set<Locale>? = nil) throws {
+    func expectFullViewModelTests(_ viewModelType: (some ViewModel & ViewModel).Type, locales: Set<Locale>? = nil, file: String = #filePath, line: Int = #line) throws {
         let vmEncoder = encoder(locale: locales?.first ?? self.locales.first ?? Self.en)
 
         try expectCodable(viewModelType, encoder: vmEncoder)
         try expectVersionedViewModel(
             viewModelType,
-            encoder: vmEncoder
+            encoder: vmEncoder,
+            file: file,
+            line: line
         )
         try expectTranslations(viewModelType, locales: locales)
     }

--- a/Tests/FOSMVVMTests/ReplaceRequestTests.swift
+++ b/Tests/FOSMVVMTests/ReplaceRequestTests.swift
@@ -1,0 +1,54 @@
+// ReplaceRequestTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+import Testing
+
+/// A minimal concrete `ReplaceRequest` (PUT). Its existence proves the protocol
+/// carries the mirror of `UpdateRequest`'s constraints — `RequestBody:
+/// ValidatableModel`, `ResponseBody: ReplaceResponseBody` — and its `action`
+/// resolves to `.replace`, which the action enum already maps to PUT.
+final class TestReplaceRequest: ReplaceRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = EmptyBody
+    typealias ResponseError = EmptyError
+
+    required init(
+        query: EmptyQuery? = nil,
+        fragment: EmptyFragment? = nil,
+        requestBody: EmptyBody? = nil,
+        responseBody: EmptyBody? = nil
+    ) {}
+
+    static func stub() -> Self {
+        .init()
+    }
+}
+
+@Suite("ReplaceRequest")
+struct ReplaceRequestTests {
+    @Test func actionIsReplace() {
+        #expect(TestReplaceRequest().action == .replace)
+    }
+
+    @Test func baseTypeNameIsReplaceRequest() {
+        #expect(TestReplaceRequest.baseTypeName == "ReplaceRequest")
+    }
+}

--- a/Tests/FOSMVVMTests/SynthesizedStubWitnessTests.swift
+++ b/Tests/FOSMVVMTests/SynthesizedStubWitnessTests.swift
@@ -1,0 +1,64 @@
+// SynthesizedStubWitnessTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+import Testing
+
+/// A child ViewModel that provides ONLY a fully-defaulted parameterized `stub(...)`
+/// and NO zero-arg `stub()`. It compiles as a `ViewModel` (which requires
+/// `Stubbable`) only because the `@ViewModel` macro synthesizes the witness.
+@ViewModel
+struct StubWitnessViewModel {
+    let count: Int
+    let label: String
+
+    var vmId = ViewModelId()
+
+    static func stub(count: Int = 8, label: String = "berth") -> Self {
+        .init(count: count, label: label)
+    }
+}
+
+@Suite("Synthesized Stub Witness")
+struct SynthesizedStubWitnessTests {
+    /// Generic dispatch through `Stubbable` — this only type-checks if the macro
+    /// produced a genuine `static func stub() -> Self` witness, and only returns
+    /// (rather than infinitely recursing) because the witness forwards to the
+    /// parameterized overload with explicit arguments.
+    private func makeStub<T: Stubbable>(_: T.Type) -> T {
+        T.stub()
+    }
+
+    @Test func synthesizedWitnessReturnsDefaultedInstance() {
+        let vm = StubWitnessViewModel.stub()
+        #expect(vm.count == 8)
+        #expect(vm.label == "berth")
+    }
+
+    @Test func parameterizedStubStillOverridesDefaults() {
+        let vm = StubWitnessViewModel.stub(count: 3)
+        #expect(vm.count == 3)
+        #expect(vm.label == "berth")
+    }
+
+    @Test func witnessSatisfiesStubbableProtocol() {
+        let vm = makeStub(StubWitnessViewModel.self)
+        #expect(vm.count == 8)
+        #expect(vm.label == "berth")
+    }
+}

--- a/Tests/FOSMVVMTests/VersionedBaselinePathTests.swift
+++ b/Tests/FOSMVVMTests/VersionedBaselinePathTests.swift
@@ -1,0 +1,117 @@
+// VersionedBaselinePathTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import FOSTesting
+import Foundation
+import Testing
+
+/// Throwaway ViewModels used only to drive baseline-file placement.
+@ViewModel
+struct PathAnchorTestVM {
+    let value: Int
+    var vmId = ViewModelId()
+
+    static func stub() -> Self {
+        .init(value: 1)
+    }
+}
+
+@ViewModel
+struct ForwardingTestVM {
+    let value: Int
+    var vmId = ViewModelId()
+
+    static func stub() -> Self {
+        .init(value: 1)
+    }
+}
+
+@Suite("Versioned Baseline Path Anchoring")
+struct VersionedBaselinePathTests {
+    /// The version baseline directory must anchor on the SwiftPM test-target root
+    /// (`Tests/<Target>/.VersionedTestJSON`), independent of how deeply the calling
+    /// test file is nested — NOT two directories up from the file.
+    @Test func anchorsOnTestTargetRootRegardlessOfDepth() throws {
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory.appendingPathComponent("VTJ-\(UUID().uuidString)")
+
+        // A deeply-nested test file path: <tempRoot>/Tests/AnchorTarget/Deep/Nested/Foo.swift
+        let fakeFile = tempRoot
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("AnchorTarget")
+            .appendingPathComponent("Deep")
+            .appendingPathComponent("Nested")
+            .appendingPathComponent("FooTests.swift")
+
+        let expectedDir = tempRoot
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("AnchorTarget")
+            .appendingPathComponent(".VersionedTestJSON")
+
+        // The old (buggy) two-up location, which must NOT be used.
+        let wrongDir = tempRoot
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("AnchorTarget")
+            .appendingPathComponent("Deep")
+            .appendingPathComponent(".VersionedTestJSON")
+
+        defer { try? fm.removeItem(at: tempRoot) }
+
+        try expectVersionedViewModel(PathAnchorTestVM.self, file: fakeFile.path)
+
+        #expect(fm.fileExists(atPath: expectedDir.path))
+        #expect(!fm.fileExists(atPath: wrongDir.path))
+    }
+}
+
+@Suite("Versioned Baseline Forwarding")
+struct VersionedBaselineForwardingTests: LocalizableTestCase {
+    let locStore: LocalizationStore
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
+            bundle: .module,
+            resourceDirectoryName: "TestYAML"
+        )
+    }
+
+    /// `expectFullViewModelTests` must persist its version baseline beside the
+    /// *caller's* test file, not FOSTesting's own source. It proves this by
+    /// forwarding an explicit `file:` and confirming the baseline lands under the
+    /// target root derived from that path.
+    @Test func fullViewModelTestsForwardsCallerFile() throws {
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory.appendingPathComponent("VTJ-\(UUID().uuidString)")
+
+        let fakeFile = tempRoot
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("FwdTarget")
+            .appendingPathComponent("Sub")
+            .appendingPathComponent("BarTests.swift")
+
+        let expectedDir = tempRoot
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("FwdTarget")
+            .appendingPathComponent(".VersionedTestJSON")
+
+        defer { try? fm.removeItem(at: tempRoot) }
+
+        try expectFullViewModelTests(ForwardingTestVM.self, file: fakeFile.path)
+
+        #expect(fm.fileExists(atPath: expectedDir.path))
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Extensions/Application+FOSTests.swift
+++ b/Tests/FOSMVVMVaporTests/Extensions/Application+FOSTests.swift
@@ -74,9 +74,17 @@ struct ApplicationFOSAdditionTests: LocalizableTestCase {
 
         try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
 
-        Task { try await app.execute() }
-
-        sleep(1)
+        // Boot synchronously so the async lifecycle handler
+        // (YamlLocalizationInitializer.willBootAsync → configureFOSMVVMReactResources)
+        // registers the FileMiddleware *before* any request is issued. `app.test(...)`
+        // only runs the synchronous `boot()`, which never fires `willBootAsync`, so the
+        // middleware would otherwise never be registered on the in-memory tester.
+        //
+        // The previous `Task { try await app.execute() }` + `sleep(1)` raced a background
+        // boot against a fixed 1s delay; under heavier parallel-suite load on Linux CI the
+        // boot lost the race and every file 404'd. `asyncBoot()` is idempotent (guarded by
+        // `isBooted`), so the sync `boot()` inside `app.test(...)` simply no-ops.
+        try await app.asyncBoot()
 
         // Test that React resources are accessible at /fosmvvm/react/
         let testFiles = ["fosmvvmWasmRuntime.js", "viewModelComponent.js", "fosmvvm.css", "README.md"]

--- a/Tests/FOSMacrosTests/ViewModelStubMacroTests.swift
+++ b/Tests/FOSMacrosTests/ViewModelStubMacroTests.swift
@@ -1,0 +1,229 @@
+// ViewModelStubMacroTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(macOS)
+import FOSFoundation
+import FOSMacros
+import Foundation
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+final class ViewModelStubMacroTests: XCTestCase {
+    private let testMacros: [String: any Macro.Type] = [
+        "ViewModel": ViewModelMacro.self
+    ]
+
+    /// When a VM provides a fully-defaulted parameterized `stub(...)` but no
+    /// zero-arg `stub()`, the macro synthesizes the `Stubbable` witness, forwarding
+    /// each parameter with its default made explicit (so the call binds to the
+    /// parameterized overload and never recurses into the witness).
+    func testSynthesizesWitnessFromParameterizedStub() {
+        assertMacroExpansion(
+            #"""
+            @ViewModel struct TestViewModel {
+                let count: Int
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub(count: Int = 8) -> TestViewModel {
+                    .init(count: count)
+                }
+                init(count: Int) {
+                    self.count = count
+                }
+            }
+            """#,
+            expandedSource: #"""
+            struct TestViewModel {
+                let count: Int
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub(count: Int = 8) -> TestViewModel {
+                    .init(count: count)
+                }
+                init(count: Int) {
+                    self.count = count
+                }
+
+                public static func stub() -> Self {
+                    Self.stub(count: 8)
+                }
+
+                public func propertyNames() -> [LocalizableId: String] {
+                    [:]
+                }
+            }
+
+            extension TestViewModel: ViewModel {
+            }
+
+            extension TestViewModel: RetrievablePropertyNames {
+            }
+            """#,
+            macros: testMacros,
+            indentationWidth: .spaces(4)
+        )
+    }
+
+    /// A hand-written zero-arg `stub()` already witnesses `Stubbable`; the macro
+    /// must NOT emit a second `stub()` (which would be a redeclaration), even when
+    /// a parameterized `stub(...)` is also present.
+    func testDoesNotClobberExistingZeroArgStub() {
+        assertMacroExpansion(
+            #"""
+            @ViewModel struct TestViewModel {
+                let count: Int
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub() -> TestViewModel {
+                    .stub(count: 8)
+                }
+                static func stub(count: Int = 8) -> TestViewModel {
+                    .init(count: count)
+                }
+                init(count: Int) {
+                    self.count = count
+                }
+            }
+            """#,
+            expandedSource: #"""
+            struct TestViewModel {
+                let count: Int
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub() -> TestViewModel {
+                    .stub(count: 8)
+                }
+                static func stub(count: Int = 8) -> TestViewModel {
+                    .init(count: count)
+                }
+                init(count: Int) {
+                    self.count = count
+                }
+
+                public func propertyNames() -> [LocalizableId: String] {
+                    [:]
+                }
+            }
+
+            extension TestViewModel: ViewModel {
+            }
+
+            extension TestViewModel: RetrievablePropertyNames {
+            }
+            """#,
+            macros: testMacros,
+            indentationWidth: .spaces(4)
+        )
+    }
+
+    /// When a parameterized `stub(...)` has any non-defaulted parameter, the macro
+    /// cannot invent a value, so it synthesizes nothing and lets the normal
+    /// `Stubbable` conformance error surface.
+    func testDoesNotSynthesizeWhenNotAllParametersDefaulted() {
+        assertMacroExpansion(
+            #"""
+            @ViewModel struct TestViewModel {
+                let count: Int
+                let name: String
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub(count: Int = 8, name: String) -> TestViewModel {
+                    .init(count: count, name: name)
+                }
+                init(count: Int, name: String) {
+                    self.count = count
+                    self.name = name
+                }
+            }
+            """#,
+            expandedSource: #"""
+            struct TestViewModel {
+                let count: Int
+                let name: String
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub(count: Int = 8, name: String) -> TestViewModel {
+                    .init(count: count, name: name)
+                }
+                init(count: Int, name: String) {
+                    self.count = count
+                    self.name = name
+                }
+
+                public func propertyNames() -> [LocalizableId: String] {
+                    [:]
+                }
+            }
+
+            extension TestViewModel: ViewModel {
+            }
+
+            extension TestViewModel: RetrievablePropertyNames {
+            }
+            """#,
+            macros: testMacros,
+            indentationWidth: .spaces(4)
+        )
+    }
+
+    /// Forwarding transcribes each default expression verbatim and respects labels:
+    /// a `_` external label is forwarded positionally, an external label is kept,
+    /// and non-literal defaults (an array literal) round-trip unchanged.
+    func testForwardsPositionalAndLabeledDefaults() {
+        assertMacroExpansion(
+            #"""
+            @ViewModel struct RowViewModel {
+                let berths: [Int]
+                let label: String
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub(_ berths: [Int] = [1, 2], named label: String = "row") -> RowViewModel {
+                    .init(berths: berths, label: label)
+                }
+                init(berths: [Int], label: String) {
+                    self.berths = berths
+                    self.label = label
+                }
+            }
+            """#,
+            expandedSource: #"""
+            struct RowViewModel {
+                let berths: [Int]
+                let label: String
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub(_ berths: [Int] = [1, 2], named label: String = "row") -> RowViewModel {
+                    .init(berths: berths, label: label)
+                }
+                init(berths: [Int], label: String) {
+                    self.berths = berths
+                    self.label = label
+                }
+
+                public static func stub() -> Self {
+                    Self.stub([1, 2], named: "row")
+                }
+
+                public func propertyNames() -> [LocalizableId: String] {
+                    [:]
+                }
+            }
+
+            extension RowViewModel: ViewModel {
+            }
+
+            extension RowViewModel: RetrievablePropertyNames {
+            }
+            """#,
+            macros: testMacros,
+            indentationWidth: .spaces(4)
+        )
+    }
+}
+#endif

--- a/docs/work/ci-react-linux-404-handoff.md
+++ b/docs/work/ci-react-linux-404-handoff.md
@@ -1,0 +1,60 @@
+# RESOLVED: PR #103 Linux CI failure — `reactResourcesServed()` 404s
+
+**Status:** root cause found and fixed in
+`Tests/FOSMVVMVaporTests/Extensions/Application+FOSTests.swift` (uncommitted at time of
+writing). macOS local: green. Awaiting Linux CI confirmation on the branch.
+
+## Actual root cause — a test-boot race, NOT a serving/bundling bug
+`reactResourcesServed()` booted the Vapor app in a **background task** and waited a fixed
+`sleep(1)` before issuing requests:
+```swift
+Task { try await app.execute() }   // execute() → startup() → asyncBoot() → willBootAsync
+sleep(1)                            // hope boot finished
+```
+The FileMiddleware for `/fosmvvm/react/*` is registered by
+`YamlLocalizationInitializer.willBootAsync` (→ `configureFOSMVVMReactResources()`). That is an
+**async** lifecycle handler, so it only runs via `asyncBoot()`. `app.test(...)` internally runs
+only the **synchronous** `boot()` (see `VaporTesting/TestingApplicationTester.testing()` →
+`try self.boot()`), which fires `willBoot`/`didBoot` but **never `willBootAsync`** — hence the
+background `execute()` + `sleep(1)` was the *only* thing registering the middleware.
+
+Under this PR the FOSMVVMVaporTests process grew from **323 tests / 40 suites** to
+**330 tests / 44 suites** (+4 suites from `ReplaceRequestTests`,
+`SynthesizedStubWitnessTests`, `VersionedBaselinePathTests`, `ViewModelStubMacroTests`). The
+extra parallel-suite contention on the Linux runner pushed background boot past the 1s window,
+so requests hit an app whose FileMiddleware wasn't registered yet → **all 4 files 404**.
+
+The serving code, `Package.swift`, and the resource files are **byte-identical** to the green
+commit `138e2cb` (PR #98 run 28583310138, ubuntu 6.2.1 PASS). The PR changed the *timing* this
+latent race depended on, not the serving logic.
+
+## The fix
+Replace the background-boot race with a foreground, awaited boot:
+```swift
+try await app.asyncBoot()   // runs willBootAsync → registers FileMiddleware, synchronously
+```
+`asyncBoot()` is idempotent (`isBooted`-guarded), so the sync `boot()` inside `app.test(...)`
+no-ops. No server bind (test tester defaults to `.inMemory`), no `sleep`, no race. Local run
+drops from ~2s to 0.016s and logs confirm `willBootAsync` ("Serving FOSMVVM client resources
+from: …") fires *before* the first GET.
+
+## Why the earlier hypotheses were all wrong
+- **`.gitignore` (commit 82fb579):** the 4 react files are **tracked** and **not ignored** by
+  the new `Tests/**/.VersionedTestJSON/*` pattern → present on any fresh checkout. Ruled out.
+- **Linux bundle-probe in `configureFOSMVVMReactResources`:** proven-good on Linux at
+  `138e2cb`/`d2ff98e` (both ubuntu PASS). The probe was never the problem; the middleware just
+  hadn't been registered yet when requests were sent.
+- **"pre-existing / not this PR":** it *was* introduced by this PR's timing shift, but as a
+  race exposure, not a logic regression.
+
+## Empirical evidence (for the record)
+- Run 28583310138 (PR #98, `138e2cb`, 10:39): `reactResourcesServed()` ✔ PASS, all 200.
+- Run 28618417621 (this PR, `768a554`, 20:24): ✘ FAIL, all 404, "6 issues incl. 2 known"
+  (the 4 non-known = the 4 react 404s; 2 known = unrelated `loadCSVData`).
+- CI runs on `pull_request`/`workflow_dispatch` only — `main` is never directly tested, so
+  "main was green on Linux" only ever meant "some PR's merge commit was green."
+
+## Also pending on this branch (unrelated to CI, already decided)
+- Stub-placement skill fix (SKILL.md Stubbable Pattern + reference.md Templates 2/4/Dashboard
+  CardViewModel) + CHANGELOG baseline-path migration note — DONE in working tree, uncommitted.
+  These were to land as a new commit once CI direction was settled. That's now settled.

--- a/docs/work/fosmvvm-app-project-template.md
+++ b/docs/work/fosmvvm-app-project-template.md
@@ -1,0 +1,373 @@
+# FOSMVVM SwiftUI app — reusable `project.yml` template + recipe
+
+> Copied into FOSUtilities from the Harbor Port-Authority worktree on 2026-07-02 (backlog
+> item C3). This is the version-controlled home; the `fosmvvm-swiftui-app-setup` skill
+> references it. Harbor type names (`HarborViewModels`, `PortAuthority`) are illustrative.
+
+A verified, parameterized XcodeGen `project.yml` for a FOSMVVM SwiftUI **app** that lives beside a
+SwiftPM package in one tree, plus the recipe explaining *why* each load-bearing piece exists.
+Configuring these projects by hand takes hours because of Xcode's quirks (the `SPMLibraries` umbrella
+for type identity, source-inclusion of the shared module, app-hosted test targets, the test plan).
+This template makes it a one-shot.
+
+Reverse-engineered from David's hand-built `PortAuthority.xcodeproj` and **verified to build**
+(`xcodebuild … build-for-testing` → `** TEST BUILD SUCCEEDED **`: the app + an app-hosted unit-test
+bundle + a UI-test bundle all compile and link). It supersedes/refines the `fosmvvm-swiftui-app-setup`
+skill's Template 7 — see the deltas at the bottom.
+
+---
+
+## The shape (FOSMVVM "Option A" — source-inclusion)
+
+```
+{AppName}.xcodeproj                     ← derived from project.yml; git-ignored
+Sources/
+  SPMLibraries/SPMLibraries.swift       ← umbrella framework (the ONLY doorway for SPM products)
+  {ViewModelsModule}/                    ← shared CONTRACT module: ViewModels/ Requests/ Versioning/
+  {ViewsModule}/                         ← the SwiftUI Views layer
+  {AppTarget}/                           ← the App layer: {AppName}App.swift + Info.plist + .entitlements
+Tests/
+  {Base}UnitTests/                       ← app-hosted unit tests (share the app's FOS type identity)
+  {Base}UITests/                         ← UI tests
+{AppName}.xctestplan                     ← aggregates the two test targets (see the caveat)
+```
+
+Three collaborators:
+
+1. **`SPMLibraries`** — a thin framework that links FOSFoundation/FOSMVVM (and any other external SPM
+   product). It is the *single* place external products enter the build. Every target that needs FOS
+   types links this ONE framework, so there is exactly one copy of each FOS type.
+2. **The app (`{AppTarget}`)** — compiles the shared contract module's source (`{ViewModelsModule}`)
+   and the Views (`{ViewsModule}`) **directly** alongside its own App layer (Option A: source is
+   *included*, not linked as a separate framework). It links **only** `SPMLibraries`.
+3. **The test bundles** — host on the app (`TEST_HOST`/`BUNDLE_LOADER`), so they see the app's exact
+   FOS type identity. That app-hosted linkage is the real proof the umbrella works.
+
+---
+
+## Why each piece is load-bearing (the recipe)
+
+### 1. The `SPMLibraries` umbrella — type identity (`TypeA != TypeA`)
+**Rule:** an Xcode app that consumes SPM package products across more than one target (app + unit
+tests + UI tests) MUST vend them through a single umbrella *dynamic* framework that every other
+target depends on — **never** link the SPM products directly into each target.
+
+**Why:** linking an SPM library into multiple targets compiles a *separate copy* of its types into
+each, and Swift's mangled type name carries the linking context — so the "same" type has a different
+runtime identity per target. An instance crossing a target boundary then fails `is` / `as?` / `==` /
+`===`. It **compiles clean and breaks at runtime far from the cause.** One umbrella framework = one
+canonical copy = one shared identity. This is a generic Xcode+SPM packaging bug, *not* a FOS quirk —
+but it bites FOSMVVM especially hard because FOSMVVM internals compare types (type-derived request
+paths, ViewModel/Request resolution, versioning). Do NOT "simplify" by linking FOS per-target.
+
+`SPMLibraries.swift` can be almost empty (`import Foundation`); its job is to *link* the products so
+they exist once. (Optionally `@_exported import FOSFoundation` / `@_exported import FOSMVVM` to let
+consumers write `import SPMLibraries` — but with source-inclusion the included files just
+`import FOSFoundation` directly and resolve transitively through the linked umbrella.)
+
+### 2. Source-inclusion of the shared module (Option A)
+The app target's `sources:` list the **folders** of the shared contract module and the Views layer,
+so they compile *into* the app module. Views then reference ViewModels with no cross-module `import`.
+XcodeGen emits classic file references (globs the folders), not Xcode-16 `fileSystemSynchronizedGroups`
+— the build resolves identically because both compile the same set of files. `import FOSFoundation` /
+`import FOSMVVM` inside the included source resolves through the linked `SPMLibraries` (Xcode
+propagates a linked framework's SPM product modules to the linking target).
+
+### 3. App-hosted test targets + the target-name/PRODUCT_NAME trap
+Make the unit-test target **depend on the app target** → XcodeGen sets it up as app-hosted
+(`TEST_HOST`/`BUNDLE_LOADER`), so it links against the app and shares its FOS types.
+
+**Trap:** if the app **target name differs from its `PRODUCT_NAME`** (here target `PortAuthorityUI`,
+product `PortAuthority`, bundle `PortAuthority.app`), XcodeGen derives `TEST_HOST` from the *target*
+name (`…/PortAuthorityUI.app/…/PortAuthorityUI`) which does not exist → the unit test fails to link
+with `ld: library '…/PortAuthorityUI' not found`. Pin it explicitly:
+```yaml
+TEST_HOST: "$(BUILT_PRODUCTS_DIR)/{ProductName}.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/{ProductName}"
+BUNDLE_LOADER: "$(TEST_HOST)"
+```
+(If you keep target name == PRODUCT_NAME, XcodeGen derives this correctly and you can omit it.)
+
+### 4. Test-target naming — never bare `{AppName}Tests`/`{AppName}UITests`
+For an app whose name ends in `UI`, `{AppName}Tests` = `PortAuthorityUITests` *reads* as a UI-test
+name, and `{AppName}UITests` = `PortAuthorityUIUITests` doubles the "UI". Strip a trailing `UI` to get
+`{Base}`, then name them **`{Base}UnitTests`** (unit) and **`{Base}UITests`** (UI). Unit tests should
+say "Unit".
+
+### 5. No `disable-library-validation`
+Do **not** add `com.apple.security.cs.disable-library-validation` to the app entitlements. That escape
+hatch is only needed when a macOS hardened-runtime app loads an **ad-hoc-signed SwiftPM
+`PackageFrameworks` dylib** (Team ID mismatch). Here the app links `SPMLibraries.framework`, which is
+built and signed with the app's own Team ID, so hardened-runtime library validation passes. The app's
+entitlements stay minimal (e.g. `app-sandbox` + `network.client`).
+
+### 6. Deployment target ≥ every **linked** package's platform floor (source-inclusion changes this)
+The app's `deploymentTarget` must be **>= the platforms of every package it LINKS** — here that is
+**FOSUtilities** (via `SPMLibraries`), not Harbor's own `Package.swift`. This is a real distinction
+under Option A: the app **source-includes** `HarborViewModels` rather than linking its product, so
+`Package.swift`'s `platforms: [.macOS(.v26)]` **does not constrain the app** — it only constrains code
+that *links* the Harbor product (server targets, other packages). The included source imposes only its
+own API-availability needs. So the app's floor = the linked FOS products' floor + whatever the included
+files require. Keep `SWIFT_VERSION`, `SWIFT_STRICT_CONCURRENCY`, `DEVELOPMENT_TEAM`, and the
+distribution flag in `settings.base` so every target inherits them uniformly.
+
+### 7. `BUILD_LIBRARY_FOR_DISTRIBUTION` — mind the spelling
+The real Xcode setting is the **singular** `BUILD_LIBRARY_FOR_DISTRIBUTION`. The plural
+`BUILD_LIBRARIES_FOR_DISTRIBUTION` used by some templates is a **no-op typo**. For an in-tree app set
+`BUILD_LIBRARY_FOR_DISTRIBUTION: NO` — YES enables module stability you don't need and breaks
+`@_spi`/`package` access.
+
+### 8. The `.xctestplan` caveat (the one thing XcodeGen can't faithfully reproduce) ⚠
+A hand-authored `.xctestplan` pins each test target by a **UUID + container** (e.g.
+`identifier: 7A00A3E2…`, `container:{AppName}.xcodeproj`). XcodeGen mints its **own** target UUIDs on
+generate, which will NOT match — so after a regenerate the plan's target references dangle and the
+`test` action shows missing targets. XcodeGen references the plan file as-is; it does not rewrite it.
+
+The build itself is unaffected (list the test targets in the scheme's `build.targets`), so app + both
+test bundles compile/link regardless — only the Xcode `test` action needs the plan valid. Pick one:
+
+- **(A) Regenerable default — no committed plan.** Drop the `.xctestplan`; let the scheme's `test`
+  action list the test targets directly (`test.targets:`). Fully regenerable, nothing to reconcile.
+  Recommended unless you specifically want a shared plan.
+- **(B) Keep the committed plan — reconcile UUIDs once.** After the first real `xcodegen generate`,
+  open the plan in Xcode and re-add the two test targets so Xcode writes the *generated* UUIDs.
+  XcodeGen UUIDs are deterministic per project+target, so this one-time fix survives future
+  regenerations. Also fix any stale `container:` name left in the plan's `defaultOptions`.
+
+---
+
+## The template
+
+Placeholders:
+
+| Placeholder | Meaning | PortAuthority value |
+|---|---|---|
+| `{AppName}` | Project name = `.xcodeproj` name | `PortAuthority` |
+| `{AppTarget}` | App target name (may differ from `{AppName}`) | `PortAuthorityUI` |
+| `{ProductName}` | App `PRODUCT_NAME` / `.app` bundle name | `PortAuthority` |
+| `{ViewModelsModule}` | Shared contract module folder under `Sources/` | `HarborViewModels` |
+| `{ViewsModule}` | Views layer folder under `Sources/` | `PortAuthorityUIViews` |
+| `{Base}` | App name with a trailing `UI` stripped (for test names) | `PortAuthority` |
+| `{BundleID}` | App reverse-DNS bundle id | `com.cirtecmed.harbor.portauthority` |
+| `{BundleIDRoot}` | Reverse-DNS root for framework/test ids | `com.cirtecmed.harbor.port-authority` |
+| `{TeamID}` | Apple developer Team ID | `4U3ZN9L8FT` |
+| `{macOSDeployment}` | macOS deployment target (≥ package floor) | `26.0` |
+| `{FOSUtilitiesRef}` | FOSUtilities version pin (match `Package.swift`) | `branch: main` |
+
+```yaml
+name: {AppName}
+
+options:
+  deploymentTarget:
+    macOS: "{macOSDeployment}"          # >= every depended package's platform floor
+  createIntermediateGroups: true
+  groupSortPosition: top
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    SWIFT_STRICT_CONCURRENCY: complete
+    BUILD_LIBRARY_FOR_DISTRIBUTION: NO   # singular! the plural is a no-op typo
+    DEVELOPMENT_TEAM: {TeamID}
+
+packages:
+  FOSUtilities:                          # match the SwiftPM Package.swift ref exactly (single copy)
+    url: https://github.com/foscomputerservices/FOSUtilities.git
+    {FOSUtilitiesRef}
+
+targets:
+  # ── SPMLibraries: the ONE doorway for external SPM products (type identity) ──
+  SPMLibraries:
+    type: framework
+    platform: macOS
+    sources:
+      - path: Sources/SPMLibraries
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: {BundleIDRoot}.SPMLibraries
+        GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - package: FOSUtilities
+        product: FOSFoundation
+      - package: FOSUtilities
+        product: FOSMVVM
+      # Add every other external SPM product HERE, once.
+
+  # ── The app: source-includes the shared module + Views (Option A); links only SPMLibraries ──
+  {AppTarget}:
+    type: application
+    platform: macOS
+    sources:
+      - path: Sources/{AppTarget}
+        excludes:
+          - "Info.plist"
+          - "{AppTarget}.entitlements"
+      - path: Sources/{AppTarget}/Info.plist
+        buildPhase: none
+      - path: Sources/{AppTarget}/{AppTarget}.entitlements
+        buildPhase: none
+      - path: Sources/{ViewsModule}
+      - path: Sources/{ViewModelsModule}
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: {BundleID}
+        PRODUCT_NAME: {ProductName}
+        INFOPLIST_FILE: Sources/{AppTarget}/Info.plist
+        CODE_SIGN_ENTITLEMENTS: Sources/{AppTarget}/{AppTarget}.entitlements  # NO disable-library-validation
+        ENABLE_HARDENED_RUNTIME: YES
+        MARKETING_VERSION: "0.1"
+        CURRENT_PROJECT_VERSION: 1
+    dependencies:
+      - target: SPMLibraries
+        embed: true
+        codeSign: true
+
+  # ── App-hosted unit tests: share the app's FOS type identity ──
+  {Base}UnitTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: Tests/{Base}UnitTests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: {BundleIDRoot}-unit-tests
+        GENERATE_INFOPLIST_FILE: YES
+        # Only needed when {AppTarget} != {ProductName}; pin TEST_HOST to the real product.
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/{ProductName}.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/{ProductName}"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+    dependencies:
+      - target: {AppTarget}
+      - target: SPMLibraries
+        embed: false                     # link only; the app already embeds it
+
+  {Base}UITests:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: Tests/{Base}UITests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: {BundleIDRoot}-ui-tests
+        GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: {AppTarget}
+
+schemes:
+  {AppName}:
+    build:
+      targets:
+        {AppTarget}: all
+        {Base}UnitTests: [test]
+        {Base}UITests: [test]
+    run:
+      config: Debug
+    test:
+      config: Debug
+      # Option A (regenerable default): drop the plan, list targets here instead —
+      #   targets: [ {Base}UnitTests, {Base}UITests ]
+      # Option B (committed plan): reference it, and reconcile its target UUIDs once (see caveat #8).
+      testPlans:
+        - path: {AppName}.xctestplan
+          defaultPlan: true
+    archive:
+      config: Release
+```
+
+---
+
+## Verify (throwaway name — never overwrite an open project)
+If the real `.xcodeproj` is open in Xcode, generate under a throwaway name, build, then delete it:
+```bash
+sed 's/^name: {AppName}$/name: {AppName}Verify/' project.yml > project.verify.yml
+xcodegen generate --spec project.verify.yml
+xcodebuild -project {AppName}Verify.xcodeproj -scheme {AppName} \
+  -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO
+rm -rf {AppName}Verify.xcodeproj project.verify.yml
+```
+`build-for-testing` compiling+linking BOTH test bundles against the app is the type-identity proof
+(an app-hosted test can only link if it shares the app's single FOS instantiation). Note: under a
+throwaway name the committed `.xctestplan`'s `container:{AppName}.xcodeproj` won't match, so verify
+via the `build`/`build-for-testing` action (which uses `build.targets`), not the `test` action.
+
+---
+
+## Lifecycle: generators **scaffold**, they don't **maintain** (David, 2026-07-02)
+
+The generator is a **one-shot scaffolder**, not a lifetime project manager. It earns its keep exactly
+once — creating the project — because it nails the hard, easy-to-forget setup (the `SPMLibraries`
+umbrella, source-inclusion, app-hosted tests, the `TEST_HOST` pin, Swift 6 + strict concurrency) that
+is tedious and error-prone by hand, and that Claude in particular should not hand-author into a raw
+`.pbxproj`. Once the project is **stable**, the tweaks a project accrues over its life (a build
+setting, a destination, a folder) are few and are better made **in Xcode by hand** — regenerating
+clobbers them. So:
+
+1. **Scaffold once** with this template (or have Claude run it).
+2. **Do the two things XcodeGen structurally can't**, once, in Xcode after the final generate:
+   - **Synchronized folders (`PBXFileSystemSynchronizedRootGroup`).** XcodeGen (through 2.45.4) emits
+     classic **enumerated** groups — it globs the folder at generate-time and lists each file. It does
+     **not** emit Xcode-16 synchronized folders (the ones that auto-mirror the filesystem: add a file
+     on disk → it's in the target, no regen). The build is identical either way, but the
+     *auto-mirroring* is lost. Re-add `{ViewModelsModule}` / `{ViewsModule}` / `{AppTarget}` as
+     **synchronized folders** in Xcode. (Deemed critical here — treat its absence as the reason not to
+     keep regenerating.)
+   - **iOS/iPadOS destinations** (see below).
+3. **Commit the `.xcodeproj`** (stop git-ignoring it) — it is now the hand-maintained source of truth.
+   Keep `project.yml` as a documented **seed** (how the project was born), *not* a live regen target.
+   Regenerate only for a from-scratch rebuild, re-applying the two hand steps.
+
+### The concurrency win — the template beats Xcode's own new-app default
+Verify the generated project carries `SWIFT_VERSION 6.0` + `SWIFT_STRICT_CONCURRENCY complete` and
+**zero** `SWIFT_APPROACHABLE_CONCURRENCY` / `SWIFT_DEFAULT_ACTOR_ISOLATION` keys. A fresh Xcode 26 app
+enables **Approachable Concurrency** by default (`@MainActor`-by-default, relaxed isolation) — which
+you may explicitly *not* want. Because XcodeGen sets only what `project.yml` declares, you get clean
+strict-complete concurrency **without** the IDE's relaxed defaults. That is a reason to scaffold from
+this template even though you hand-maintain afterward. (If you ever *do* want approachable concurrency,
+you must add those keys yourself — they won't appear on their own.)
+
+### iOS/iPadOS is a **destinations-only** change under source-inclusion
+Because the app **source-includes** the shared module rather than linking its product (recipe #2 / #6),
+supporting iOS/iPadOS needs **no package change** — only destinations, provided the included source is
+iOS-clean (no host-only APIs). On the app, `SPMLibraries`, and **both** test targets, replace:
+```yaml
+    platform: macOS
+```
+with (single multi-platform target — **not** `platform: [macOS, iOS]`, which splits into per-platform
+targets and breaks a single-name scheme entry):
+```yaml
+    supportedDestinations: [macOS, iOS]
+```
+and add `iOS: "26.0"` alongside `macOS` under `options.deploymentTarget`. The macOS-specific
+`.entitlements` is harmless on iOS (sandbox is implicit there). For Harbor this Just Works: the
+included `HarborViewModels` is FOSMVVM-only and iOS-clean, and the not-iOS-clean modules
+(`HarborChannel`/`HarborAdmin`) are **not** included, so nothing gates it. This template ships
+macOS-only for the walking skeleton; the change above is all that iOS/iPadOS needs.
+
+---
+
+## Deltas vs. the `fosmvvm-swiftui-app-setup` skill's Template 7
+This template is the **Option A / source-inclusion** variant, verified against a real project. Vs.
+the skill's current Template 7:
+
+- **Option A vs Option B.** Template 7 gives the shared module (`ViewModels`) its own framework target
+  that the app links+embeds. This template **source-includes** the shared module's folder into the app
+  (Views reference ViewModels with no import) and keeps only `SPMLibraries` as a framework. Both are
+  valid; Option A is what PortAuthority uses.
+- **`BUILD_LIBRARY_FOR_DISTRIBUTION` spelling.** Template 7 emits the plural (no-op) form; use the
+  singular.
+- **Test-target names.** Template 7's `{AppName}Tests`/`{AppName}UITests` are ambiguous/doubled for a
+  `…UI` app name; use `{Base}UnitTests`/`{Base}UITests`.
+- **Target-name ≠ PRODUCT_NAME `TEST_HOST` trap.** Not covered by Template 7; pin `TEST_HOST` when
+  they differ.
+- **`.xctestplan`.** Template 7 doesn't mention one; if you commit one, reconcile its UUIDs once
+  (caveat #8) or use the regenerable no-plan scheme.
+- **`platform:` vs `supportedDestinations:`.** For a multi-platform (iOS+macOS) single target, use
+  `supportedDestinations: [iOS, macOS]`, not `platform: [iOS, macOS]` (which splits into per-platform
+  targets and breaks a single-name scheme entry). This template ships macOS-only for the skeleton;
+  because the app source-includes (not links) the shared module, going multi-platform is a
+  destinations-only edit — see "iOS/iPadOS is a destinations-only change" above.
+- **Lifecycle + synchronized folders + concurrency.** Template 7 frames the generator as the project's
+  ongoing definition; this template treats it as a **one-shot scaffolder** — after the final generate,
+  hand-add synchronized folders (`PBXFileSystemSynchronizedRootGroup`, which XcodeGen ≤ 2.45.4 can't
+  emit) and commit the `.xcodeproj`. It also calls out verifying **no** Approachable-Concurrency keys
+  (Xcode 26's new-app default) so you keep strict-complete concurrency. See "Lifecycle" above.
+
+See `docs/work/skill-improvements-triage.md` for the triage that routed this into the skills.

--- a/docs/work/skill-improvements-triage.md
+++ b/docs/work/skill-improvements-triage.md
@@ -1,0 +1,278 @@
+# Skill-improvements triage & execution prep (backlog item #3)
+
+**Status:** prep only — no skill edits made from this doc yet. Written to set up a
+**fresh, carefully-scoped session** to fold the Port-Authority-surfaced skill
+improvements into the `fosmvvm-*` generator skills.
+
+## Why this needs care
+
+Skills **replicate their patterns into every downstream customer app.** A wrong
+pattern in a skill is not one bug — it is the same bug scaffolded into every
+FOSMVVM project that runs the generator. So the bar is: *get it right*, not *get
+it done*. This is the same discipline that (today) kept us from over-folding the
+`stub()` witness — the macro only synthesizes for `@ViewModel` types, so blindly
+deleting every hand-written `stub()` would have broken nested/singleton cases.
+
+## Non-negotiable process (per skill edit)
+
+1. **Source-of-truth ordering:** SOLID first → `.claude/docs/FOSMVVMArchitecture.md`
+   → code. If a backlog entry conflicts with SOLID, that outranks the entry.
+2. **`writing-skills` TDD, every edit (rigid):**
+   - **RED** — run a pressure/generation scenario with a subagent against the
+     **current** skill; watch it reproduce the wrong pattern (baseline).
+   - **GREEN** — edit, then a **fresh subagent reading ONLY the edited skill**
+     must produce the right pattern *and not over-apply it* (the stub test today
+     is the template: it correctly folded `@ViewModel` parents while keeping the
+     singleton and nested-type stubs).
+   - Compile/verify code templates against the real macros where feasible.
+3. **Triage-before-edit:** several entries are **already partially addressed**
+   (e.g. app-setup already has Template 7 + `SPMLibraries`). Re-read the current
+   skill before changing it — do not assume the backlog's "Actual" still holds.
+4. **Versioning:** bump the plugin version (`.claude-plugin/plugin.json`) and the
+   per-skill Version History table when a skill's emitted output changes. Decide
+   cadence with David (one bump at end of batch vs per-skill — see Decisions).
+5. **Never push.** Changes flow back to David for the FOSUtilities release. Commit
+   locally on the working branch only.
+
+## Source of truth & context to load in the fresh session
+
+- **The ratified backlog (Harbor worktree — a SEPARATE repo):**
+  `/Users/david/.config/superpowers/worktrees/accelsharp-harbor/port-authority-ui/docs/work/fosutilities-improvements.md`
+  (line refs below are `L<n>` into this file.)
+- **Verified project template (Harbor worktree):**
+  `…/port-authority-ui/docs/work/fosmvvm-app-project-template.md` — the
+  build-verified `project.yml` recipe that L179/L183 want folded into app-setup.
+- **Architecture doc (this repo):** `.claude/docs/FOSMVVMArchitecture.md` — the
+  "Project Structure" (~L990), "What Belongs Where" (~L1076), and "File
+  Organization Conventions" (~L1096) sections that L135 wants surfaced in app-setup.
+- **Skills (this repo):** `.claude/skills/fosmvvm-{viewmodel-generator,
+  viewmodel-test-generator, swiftui-app-setup, ui-tests-generator,
+  serverrequest-generator}/` and the `shared/` skill dir.
+- **Memory:** `[[fosutilities-improvements-status]]`, `[[fosutilities-040-release]]`.
+
+---
+
+## Triage
+
+Legend: ✅ done · ⛔ withdrawn (do NOT act) · 📚 library-not-skill · 🏠 Harbor-side ·
+🏛 architecture/item-#4 (brainstorm-gated) · ✳️ **OPEN & FOS-skill-facing (= item #3)**.
+
+### ✅ Done — no action
+- **Stub scaffolding fold-in** (L53–54) — done this session, commit `a7a4444`.
+  `-viewmodel-test-generator` needed no change (its fixtures are plain
+  `ViewModel`-protocol structs with no parameterized stub).
+- **`ReplaceRequest`** (L67) — shipped.
+- **`uiTestingIdentifier` library modifier** (L68) — ships in FOSMVVM `main`;
+  only client-copy deletion remains (tracked in 0.4.0 release, not here).
+- **`FOSTesting` baseline-directory fix** (L90) — shipped (commit `82fb579`).
+  *Residual skill-doc note → see ✳️ B7.*
+
+### ⛔ Withdrawn — do NOT act (acting would bless an anti-pattern)
+- **Route-group prefix helper** (L97) — ViewModels are middleware-gated, never
+  string-route-grouped. No `FOSTestingVapor` change.
+- **`.bind()` addressing / `requestURL`** (L113) — base URLs are clean hosts;
+  `requestURL` discarding a base-URL path is correct by design.
+
+### 📚 Library, not a skill (tracked elsewhere)
+- **Vapor `encodeResponse` serve-path gap** (L108–111) = backlog **item #1**,
+  tracked in `docs/work/vapor-viewmodelfactory-encodeResponse-gap.md`. Its own
+  focused session; not part of #3.
+
+### 🏠 Harbor-side (not a FOS change)
+- `HarborAdmin` verb-first NAMES divergence (L44) — David's rename call.
+- `HarborChannel` not iOS-clean / host code not `#if os(macOS)`-gated (L126).
+- Build-proof `iPhone 16` simulator stale vs iOS-26 floor (L132).
+- `stubLocalization:` knob on `withLiveHarbormaster`/`withAdminApp` (L111 pt 3).
+- Splitting the current `DocksViewModel.swift` into one-file-per-VM (L43, the
+  *code-cleanup* half; the *skill* half is ✳️ B2).
+
+### 🏛 Architecture — backlog item #4, brainstorm-gated (NOT #3)
+- Subscribable/live `.bind()` → `@ViewModel(options:[.live])` (L72).
+- Server-hosted `ViewModelOperations` pattern (L73).
+- Independent per-contract `SystemVersion` lines (L74).
+
+---
+
+## ✳️ OPEN & FOS-skill-facing — this IS item #3
+
+Grouped by target. Each entry: backlog line ref + the change + current-skill note.
+
+### A. NEW ARTIFACT — FOSMVVM naming dictionary — ✅ DONE (GREEN-verified 2026-07-02)
+Authored `.claude/skills/shared/NAMES.md` (Decision 1). RED baseline: subagent on the
+*current* serverrequest-generator produced verb-first `CreateUserRequest`… (A2 read
+requests were already correct — a "keep" case). GREEN: fresh subagent on the edited
+skills produced noun-first CRUD **and** kept read requests verb-less (rejected
+`DocksShowRequest`) **and** handled the duplicate-name case. Skills bumped:
+serverrequest-generator → 2.10, viewmodel-generator → 2.10.
+- **A1** (L40) ✅ Final/verb request types → `<Noun><Verb>Request` (noun-first, REST
+  verb *and* semantic actions). NAMES.md §1a + serverrequest-generator "Naming the
+  Concrete Request Type" section; flipped all verb-first examples in that skill.
+- **A2** (L41) ✅ ViewModel read requests → `<Noun>Request` (verb-less). NAMES.md §1b;
+  viewmodel-generator Naming Conventions row clarified (`DocksRequest`, not
+  `DocksShowRequest`). (Was already correct — GREEN confirms not broken.)
+- **A3** (L61) ✅ Duplicate type names across modules are fine (module *is* the
+  namespace). NAMES.md §2 + viewmodel-generator note (with the DIP corollary).
+
+### B. `fosmvvm-viewmodel-generator` (+ `-viewmodel-test-generator`)
+- **B1** (L42) ✅ DONE (GREEN 2026-07-02, viewmodel-generator 2.12) — explicit
+  anti-mega-VM callout (SRP) on the top-level template. Was already implicitly correct
+  via "Two Categories"; callout makes it bulletproof.
+- **B2** (L43) ✅ DONE (GREEN 2026-07-02) — canonical "File Organization Conventions" in
+  **app-setup 1.5** (Decision 2 owner) + one-file-per-VM scaffolding pointer added to
+  viewmodel-generator 2.12 citing it. GREEN: one-file-per-type + container dir + mirroring.
+- **B3** (L52) ✅ DONE (GREEN 2026-07-02, viewmodel-generator 2.12) — "Dates and Numbers"
+  now states the principle: init param is the plain Swift type, init body wraps + owns
+  formatting policy (`.init(value:, showGroupingSeparator:)`); callers/stubs pass plain
+  values. Card/UserCard row templates demonstrate it. Was partly present for Int/Date;
+  now explicit + SRP framing.
+- **B4** (L55 **=** L153) ✅ DONE (GREEN 2026-07-02, viewmodel-generator 2.12) —
+  **rewrote Identity section** (stable data identity; singleton vs list-row; String/Int/
+  UUID/merged ids; List-churn warning) and reconciled **all** `.init()` throwaways in
+  SKILL.md + reference.md. **Compile-verified against the real `@ViewModel` macro:**
+  singleton uses `var vmId = .init(type: Self.self)` (a `let`+default is excluded from
+  `Codable` decode — compiler warns), list-row uses `let vmId` + `.init(id:)` in init.
+  GREEN: correct vmId for top-level/String-row/summary + rejected `.init(type:)` on rows.
+- **B5** (L56) ✅ DONE (GREEN 2026-07-02, viewmodel-generator 2.12) — Decision 6 =
+  **hard rule**. Added dedicated **"ViewModel Module Must NOT Depend on Domain Types
+  (Dependency Inversion)"** section: category-error framing, owned display enums, Factory
+  performs projection, + the optional Factory-adapter domain-typed-init extension (server
+  module only). GREEN over-application guard: Factory correctly imports BOTH modules (the
+  one exception); adapter-init lives server-side.
+- **B6** (L57) ✅ DONE (GREEN 2026-07-02, viewmodel-generator 2.11) — Enum Localization
+  Pattern now raw-less (`enum X: Codable, Sendable, CaseIterable`; key via
+  `String(describing:)` not `rawValue` — verified `propertyName` is a plain `String` in
+  `LocalizableString.swift`, so YAML keys unchanged) + anti-pattern callout.
+- **B7** (L95-tail) ✅ DONE (GREEN 2026-07-02) — committed-baseline note added to BOTH
+  `-viewmodel-test-generator` (1.3) and `Sources/FOSTesting/FOSTesting.docc/ViewModelTesting.md`:
+  baseline is a committed artifact for downstream apps; FOS's own baselines are
+  regenerable/git-ignored fixtures. Corrected a stale workaround — `expectFullViewModelTests`
+  now forwards `#filePath`/`#line` (verified in `LocalizableTestCase.swift`).
+- **B8** (L159) ✅ DONE (GREEN 2026-07-02, viewmodel-generator 2.11) — added
+  `SystemVersion`/locale-independent row to the field-type table + anti-pattern callout
+  (version → `SystemVersion` via `.versionString`, hostname → `String`, never
+  `LocalizableString`). GREEN produced `version: SystemVersion`, `host: String`.
+- **B9** (L63) ✅ DONE (GREEN 2026-07-02, viewmodel-generator 2.11) — child template +
+  nested-child example drop `: Codable, Sendable` (kept `Identifiable` as a genuine
+  extra) + explicit DRY callout. GREEN over-application guard passed: top-level kept
+  `: RequestableViewModel`, `Identifiable` kept when a `ForEach` needs it.
+
+### C. `fosmvvm-swiftui-app-setup` (largest cluster — reconcile, don't just add)
+Current state: reference.md already has **Template 7** (XcodeGen) *with* an
+`SPMLibraries` umbrella, modeled on ConversationPractice. Several entries below
+are therefore *upgrade/rationale*, not greenfield.
+- **C1** (L135) ✅ DONE (GREEN 2026-07-02, app-setup 1.6) — added "Server-Hosted
+  ViewModel Contract Wiring (Both Sides)" with all four rules + anti-drift callout,
+  **grounded in the real FOSShowcase** (`WebServer/routes.swift` uses
+  `app.routes.register(viewModel:)`, `SwiftUIApp/FOSShowcaseApp.swift` uses clean-host
+  base URLs, `Sources/Resources/` sibling `.copy("../Resources")` from server/test — all
+  verified). Resources-server-only clarified vs the client-hosted tree (annotated). Added
+  native-app-in-root-`.xcodeproj` + Tests-mirror-Sources + link to arch doc. GREEN
+  over-application guard: `.grouped(SomeMiddleware())` correct (only string form banned).
+- **C2** (L147) ✅ DONE (GREEN 2026-07-02, app-setup 1.6) — added the type-identity
+  rationale (`TypeA != TypeA` across targets; generic Xcode/SPM bug) + FOSMVVM-specific
+  reason (type comparison) + "do not link per-target" callout; retitled the umbrella
+  **REQUIRED** (was "Optional") in the section header, build-system table, and tree
+  comment. GREEN over-application guard: UI-test target is the exception (links directly,
+  separate process → routes to ui-tests generator).
+- **C3** (L118 + L179 + L171) ✅ DONE (GREEN 2026-07-02, app-setup 1.7) — copied the
+  build-verified template into **`docs/work/fosmvvm-app-project-template.md`** (Decision 3)
+  and folded a "Verified project template" callout + Lifecycle into app-setup: Option-A
+  source inclusion, **singular `BUILD_LIBRARY_FOR_DISTRIBUTION`** (fixed the plural no-op
+  typo throughout SKILL.md + reference.md), `{Base}UnitTests`/`{Base}UITests` naming,
+  `TEST_HOST` pin, app-hosted tests, `supportedDestinations`, `.xctestplan` caveat. GREEN
+  confirmed all.
+- **C4** (L196) ✅ DONE (GREEN 2026-07-02, app-setup 1.7) — added `.testHost()` no-arg
+  display-only baseline + closure form as the typed-config opt-in; corrected `underTest`
+  detection to `ProcessInfo…environment["__FOS_ViewModel"]` (verified `presentView` sets
+  `launchEnvironment`, no args, in `ViewModelViewTestCase.swift`); replace_all'd the old
+  `arguments.count` form. GREEN over-application guard: typed-config app → closure form.
+- **C5** (L211) ✅ DONE (GREEN 2026-07-02, app-setup 1.7) — "Lifecycle: XcodeGen scaffolds,
+  it does not maintain": one-shot, hand-add synchronized folders + iOS destinations, commit
+  the `.xcodeproj`, keep strict-complete concurrency (no Approachable-Concurrency keys),
+  destinations-only iOS. GREEN confirmed.
+- **C6** (L165) ✅ DONE (GREEN 2026-07-02, app-setup 1.7 / Decision 4 = app-setup owns) —
+  the skills already prescribed `SystemVersion+App.swift` everywhere (verified: no skill
+  emits `<Module>Version.swift`); added an explicit tree annotation ("name for the TYPE +
+  matching header, NOT `<Module>Version.swift`"). GREEN produced `SystemVersion+App.swift`.
+
+### D. `fosmvvm-ui-tests-generator`
+- **D1** (L185) ✅ DONE (GREEN 2026-07-02, ui-tests-generator 1.3) — Tier-1 note:
+  `.uiTestingIdentifier(_:)` is a FOSMVVM `View` modifier (`import FOSMVVM`,
+  `SwiftUI Support/View+Testing.swift` — path + DEBUG-gating verified against source),
+  DEBUG-only/no-op-in-release so applied **unconditionally** (not `#if DEBUG`); don't
+  define/copy it. Paired with same-string `XCUIApplication` accessor.
+- **D2** (L191) ✅ DONE (GREEN 2026-07-02, ui-tests 1.4) — version-floor note for
+  `ViewModelDisplayTestCase<VM>` (recent FOSTestingUI where `ViewModelViewTestCase`
+  inherits it; verified in `ViewModelViewTestCase.swift`) + older-ref no-op-`ViewModelOperations`
+  fallback. GREEN produced the right base class + fallback.
+- **D3** (L203) ✅ DONE (GREEN 2026-07-02, ui-tests 1.4) — added "UI-Test Target Wiring
+  (Xcode project)": (1) link FOS **directly, NOT via `SPMLibraries`** (separate process,
+  trap doesn't apply, testing framework must not ride in the app); (2) source-include the
+  shared contract module for the VM type + `.stub()`; (3) copy the server localization tree
+  + `resourceDirectoryName:`. GREEN over-application guard: umbrella rule scoped to
+  app-hosted unit tests; UI-test links directly.
+
+**Pre-existing bug found + ✅ FIXED (David asked, 2026-07-02):** ui-tests SKILL.md
+display-only checklist listed `operations stored from viewModel.operations` under "Views
+WITHOUT operations" — a copy-paste contradiction with the "No operations property needed"
+line above it. Replaced with a correct bullet (subclass `ViewModelDisplayTestCase<VM>`).
+
+---
+
+## Cross-cutting — resolve before/while editing
+
+- **Dedupe overlaps into single edits:** B4 (L55≡L153); the **file/directory
+  organization** story appears in B2 (L43), B-dir (L59), C1 (L135), C5 (L211) —
+  tell it **once** in a canonical place and have the others reference it
+  (Decision 2). The **`project.yml`** appears in L118/L171/L179 — one consolidated
+  task (C3). **Version-line file** spans B/C (C6/L165) — one owner (Decision 4).
+- **L59 (directory named for container)** ✅ DONE — folded into app-setup 1.5 "File
+  Organization Conventions" (rule 2 + rule 3: grouping repeats across every layer).
+- **The naming rules (A1–A3)** feed *both* the new dictionary and the
+  serverrequest/viewmodel generators — author the dictionary first, then have the
+  generators cite it (DRY: skills show the pattern, dictionary is the reference).
+
+## Decisions for David (RESOLVED 2026-07-02)
+
+1. **Naming dictionary home** → ✅ **`shared/` reference (`NAMES.md`)**. Authored as
+   a reference doc in the `shared/` skill dir; the serverrequest- and
+   viewmodel-generators cite it (DRY, single-source). (Affects A1–A3.)
+2. **Canonical owner of file/directory organization** → ✅ **app-setup owns it**.
+   `fosmvvm-swiftui-app-setup` tells the full file-org story once (C1/C5);
+   viewmodel-generator references it. So B2/L59/C1/C5 don't triplicate.
+3. **`fosmvvm-app-project-template.md`** → ✅ **Copy into this repo's `docs/work/`**
+   (version-controlled with the skill), fold inline into app-setup, retire the Harbor
+   standalone. (For C3, task-group 4.)
+4. **Version-line file owner** — *taking default*: **app-setup** (C6), consistent
+   with Decision 2's app-setup ownership of layout/naming.
+5. **Sequencing** — *taking the doc's Recommended sequencing* (below) unless
+   redirected.
+6. **B5 (category-error) scope** → ✅ **Hard rule, enforced**. Generator scaffolds
+   a domain-free VM by default + emits a DIP callout; a domain type in a VM is a
+   category error. (Strongest SOLID stance.)
+7. **Plugin-version cadence** → ✅ **One bump at end of batch** (single version bump
+   + consolidated release note once item-#3 lands).
+
+## Recommended sequencing (subject to Decision 5)
+
+1. **Foundations that others cite:** A (naming dictionary) → Decision-2 file-org
+   canonical doc. Nothing else should duplicate these.
+2. **Quick, low-risk, self-contained conventions** (build confidence, small blast
+   radius): B6, B9, B8, D1. Each is a tight RED→GREEN loop like today's stub fold.
+3. **The viewmodel-generator conceptual/coupling set:** B1–B5, B7 — these define
+   how a correct FOSMVVM VM is authored; B5 is the heaviest (get David's confirm).
+4. **The app-setup blockers + template:** C1, C2, then C3 (fold the verified
+   template), then C4/C5/C6. Highest customer value, most reconciliation.
+5. **UI-test wiring:** D2, D3.
+6. Bump plugin version per Decision 7; commit on the working branch; do not push.
+
+## Verification protocol (apply to every edit)
+
+- **Baseline (RED):** subagent using the *current* skill reproduces the wrong
+  pattern. **Confirm (GREEN):** fresh subagent reading *only* the edited skill
+  produces the right pattern **and does not over-apply** (the failure mode today
+  was over-folding — actively test the "keep" cases too).
+- Ground every change against SOLID → `FOSMVVMArchitecture.md` → code, and against
+  the in-repo precedents the backlog cites (FOSShowcase `routes.swift` /
+  `FOSShowcaseApp.swift`, `ObservedFleetState` stubs, etc.).
+- Compile code templates against the real macros where feasible.

--- a/docs/work/vapor-viewmodelfactory-encodeResponse-gap.md
+++ b/docs/work/vapor-viewmodelfactory-encodeResponse-gap.md
@@ -1,0 +1,66 @@
+# `VaporViewModelFactory` serving path is unexercised — missing localizing `encodeResponse`
+
+- **Status:** ⬜ open (not scheduled — do NOT fold into the current change set)
+- **Surfaced:** 2026-07-02, while investigating the "assert the server actually serves *localized* ViewModels" improvement item.
+- **Area:** `FOSMVVMVapor` (server-hosted ViewModel serving), `FOSTestingVapor`.
+
+## Summary
+
+The server-hosted localized-serve path — `VaporViewModelFactory` → `VaporServerRequestHost` → `VaporServerRequestTest` — has quietly bit-rotted. **No type in the repo conforms to `VaporViewModelFactory`**, there is **no default `encodeResponse(for:)`**, the **docc example omits it** (so the documented pattern would not compile), and the **one end-to-end test is commented out**. The likely trigger is that **Vapor made `AsyncResponseEncodable` (async `encodeResponse`) the required conformance** at some point after this code was written, and nothing was updated to provide the async default.
+
+## How it was found
+
+Tried to re-enable the disabled dogfood test `Tests/FOSMVVMVaporTests/Protocols/VaporServerRequestHostTests.swift :: performBasicRequest()` (which asserts a served ViewModel's `@LocalizedString` resolves to a non-empty value). Peeling the failure revealed three layers:
+
+1. **Not the original tooling bug.** The test was disabled long ago for a Swift 6.0-beta error (`Unknown command -NSTreatUnknownArgumentsAsOpen`); we never get far enough to hit it.
+2. **Stale fixture.** `Tests/FOSMVVMVaporTests/TestViewModel.swift` conforms to the old `ViewModelFactory` with `Context = Self`; `VaporViewModelFactory` now requires `Context == VaporModelFactoryContext<Request>`.
+3. **Library gap (the real issue).** Modernizing the fixture to `VaporViewModelFactory` fails with:
+   `type 'TestViewModel' does not conform to protocol 'AsyncResponseEncodable'` — Vapor requires `func encodeResponse(for:) async throws -> Response`, and FOSMVVMVapor provides no default.
+
+## Why this is the crux
+
+`VaporServerRequestHost.boot` returns the ViewModel straight from the route:
+
+```swift
+// Sources/FOSMVVMVapor/Vapor Support/VaporServerRequestHost.swift
+group.get { req in
+    try await Request.ResponseBody.model(req, vmRequest: req.requireServerRequest())
+}
+```
+
+So Vapor relies on the ViewModel's `AsyncResponseEncodable.encodeResponse(for:)` to build the HTTP `Response`. **That is exactly where localization-on-serve must occur** — encode the ViewModel through a localizing encoder built from the request's locale (`Accept-Language`) and the app's `LocalizationStore`. Because there is no shared default, every ViewModel would have to hand-roll identical localizing boilerplate — which defeats the purpose of the protocol — and today none do.
+
+## Root-cause hypothesis
+
+`AsyncResponseEncodable` (the `async` `encodeResponse`) is newer in Vapor than this code. The original `VaporViewModelFactory` likely satisfied the *synchronous* `ResponseEncodable` via a default that no longer applies, or Vapor tightened the requirement to the async form. Needs confirmation against the Vapor changelog / the pinned version.
+
+Requirement (pinned Vapor): `.build/checkouts/vapor/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift:15`
+```swift
+func encodeResponse(for request: Request) async throws -> Response
+```
+
+## Proposed fix (own task — NOT this change set)
+
+1. **Determine where localization-on-serve belongs** — a default `encodeResponse` on `VaporViewModelFactory`, *or* the `VaporServerRequestMiddleware<Request>` the host also installs. (Open question below.)
+2. **Add the localizing default** so a `VaporViewModelFactory` conformer needs to supply only `model(context:)`. It should encode `self` with `JSONEncoder.localizingEncoder(...)` using the request's locale + `Application.localizationStore`.
+3. **Modernize `TestViewModel`** to conform to the current `VaporViewModelFactory` (`Context == VaporModelFactoryContext<Request>`) and re-enable `performBasicRequest()` — which finally establishes whether the `-NSTreatUnknownArgumentsAsOpen` ghost is gone on the current toolchain.
+4. **Fix the docc example** (`Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md`, ~L117) — it omits `encodeResponse` and has a syntax error (`VaporModelFactoryContext<VMRequest>))`).
+
+## Open question
+
+Is localization-on-serve intended to live in `encodeResponse` (the ViewModel encodes itself localized) or in `VaporServerRequestMiddleware<Request>` (post-process the outgoing `Response`)? The host installs both a middleware and relies on `AsyncResponseEncodable`; trace which one is meant to own localization before writing the default, so it lands in the right place.
+
+## Acceptance criteria
+
+- A `VaporViewModelFactory` conformer needs only `model(context:)` — no per-type `encodeResponse`.
+- `performBasicRequest()` is enabled and green: a served ViewModel's `@LocalizedString` resolves to its YAML value (e.g. `aLocalizedString == "Some Text"` for `en`).
+- The docc example compiles as written.
+
+## References
+
+- `Sources/FOSMVVMVapor/Protocols/ViewModelFactory.swift` — `VaporModelFactoryContext`, `VaporViewModelFactory` (L38: `& Vapor.AsyncResponseEncodable`).
+- `Sources/FOSMVVMVapor/Vapor Support/VaporServerRequestHost.swift` — the route handler that returns the ViewModel.
+- `Sources/FOSTestingVapor/VaporServerTestCase.swift` — `VaporServerRequestTest` (real-localization app boot; already exists).
+- `Tests/FOSMVVMVaporTests/Protocols/VaporServerRequestHostTests.swift` — the disabled `performBasicRequest()` test.
+- `Tests/FOSMVVMVaporTests/TestViewModel.swift` — the stale fixture (old `ViewModelFactory`, `Context = Self`).
+- `Tests/FOSMVVMVaporTests/TestYAML/TestViewModel.yml` — has `aLocalizedString: "Some Text"` (en) / `"Algunos textos"` (es).


### PR DESCRIPTION
## Summary

Bundles several FOSMVVM library/testing improvements with a large refresh of the
`fosmvvm-*` generator skills (friction surfaced while building the Port Authority operator
app). Skill edits are grounded in SOLID and verified via `writing-skills` RED→GREEN with
subagents plus compile-checks against the real `@ViewModel` macro / FOSTestingUI /
FOSShowcase.

**Library & testing (Swift)**
- `ReplaceRequest` protocol (PUT verb) + `ReplaceResponseBody` / `EmptyBody` (`2e335ff`)
- `@ViewModel` synthesizes the `Stubbable` `stub()` witness from a fully-defaulted
  parameterized `stub(...)` (`4e55fd3`)
- FormFieldView: debounce race + FocusState field-clear fixes; preserve typed whitespace
  and the current `onNewValue` closure (`1b0d732`, `138e2cb`)
- FOSTesting: version baselines persist beside the caller's test (`#filePath`/`#line`
  forwarding + per-target path) (`82fb579`)

**Skills & docs**
- New `shared/NAMES.md` naming dictionary + build-verified
  `docs/work/fosmvvm-app-project-template.md`
- Updated viewmodel-generator, serverrequest-generator, swiftui-app-setup,
  ui-tests-generator, viewmodel-test-generator (see each skill's Version History table);
  plugin `2.4.0 → 2.5.0`
- `.claude/CLAUDE.md`: "SOLID Is the Foundation" directive; app-setup now recommends
  scaffolded apps adopt the same entry

## Test Plan
- [x] `swift test` — 330 tests / 45 suites pass (2 pre-existing `withKnownIssue` annotations)
- [x] `swift build --build-tests` clean; skill template patterns compile-verified against the real `@ViewModel` macro
- [ ] Reviewer: skim the per-skill Version History tables for the guidance changes
- [ ] Reviewer: confirm the bundled scope (library + skills in one PR) is acceptable, or request a split

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iX6rBbLmTEyrcY4WcRnHK