### PR TITLE
Add missing @LocalizedDate property wrapper

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/docs/FOSMVVMArchitecture.md
+++ b/.claude/docs/FOSMVVMArchitecture.md
@@ -917,7 +917,7 @@ LocalizableString.localized(ref)  →  encode()  →  LocalizableString.constant
     // Simple values
     @LocalizedString var title           // String from YAML
     @LocalizedInt(value: 42) var count   // Formatted integer
-    @LocalizedDate var createdAt         // Formatted date
+    @LocalizedDate(value: model.createdAt) var createdAt // Formatted date
 
     // Contextual composition
     @LocalizedSubs(substitutions: \.subs) var greeting  // "Hello, %{name}!"

--- a/.claude/skills/shared/api-catalog/FOSMVVM.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVM.md
@@ -101,18 +101,20 @@ during encoding (see `localizingEncoder()` under Extensions) — so the server
 localizes ViewModels before they ever reach the client. Stores load from
 `.yml` resources; errors surface as typed enums.
 
-### Bind properties to YAML values — `LocalizedString` / `LocalizedInt` / `LocalizedDouble` / `LocalizedStrings` / `LocalizedCompoundString` / `LocalizedSubs`
+### Bind properties to YAML values — `LocalizedString` / `LocalizedInt` / `LocalizedDouble` / `LocalizedDate` / `LocalizedStrings` / `LocalizedCompoundString` / `LocalizedSubs`
 Reach for this when: declaring localized properties on an `@ViewModel` or
 `@FieldValidationModel` type. The property name is the YAML key by default;
 `parentKey(s)`, `propertyName`, and `index` navigate nested and array values.
-There is no `@LocalizedDate` wrapper — carry a `LocalizableDate` property
-instead.
+`@LocalizedDate` passes `dateStyle`/`timeStyle`/`dateFormat` through to
+`LocalizableDate` (`.medium` date style when nothing is specified); its
+`value:` is required — a date has no zero.
 Don't concatenate or format localized strings in Swift — bind them.
 
 ```swift
 @ViewModel public struct UserViewModel {
     @LocalizedString public var pageTitle // UserViewModel.pageTitle in YAML
     @LocalizedString(parentKey: "email") public var emailTitle
+    @LocalizedDate(value: user.createdAt, dateStyle: .short) public var createdAt
     @LocalizedStrings public var bulletPoints // YAML array
     public var vmId = ViewModelId()
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`@LocalizedDate`** — a localized, locale-formatted `Date` property wrapper
+  (`LocalizableDate`), completing the family alongside `@LocalizedInt` and
+  `@LocalizedDouble`. `dateStyle`/`timeStyle`/`dateFormat` pass through to
+  `LocalizableDate` (`.medium` date style when nothing is specified); `value:`
+  is required.
+
 ## [0.4.0] - 2026-07-03
 
 ### Added

--- a/Sources/FOSMVVM/Localization/LocalizedProperty.swift
+++ b/Sources/FOSMVVM/Localization/LocalizedProperty.swift
@@ -166,6 +166,7 @@ public extension RetrievablePropertyNames {
     typealias LocalizedString = _LocalizedProperty<Self, LocalizableString>
     typealias LocalizedInt = _LocalizedProperty<Self, LocalizableInt>
     typealias LocalizedDouble = _LocalizedProperty<Self, LocalizableDouble>
+    typealias LocalizedDate = _LocalizedProperty<Self, LocalizableDate>
     typealias LocalizedCompoundString = _LocalizedProperty<Self, LocalizableCompoundValue<LocalizableString>>
     typealias LocalizedSubs = _LocalizedProperty<Self, LocalizableSubstitutions>
 }
@@ -340,6 +341,37 @@ public extension RetrievablePropertyNames {
             groupingSize: groupingSize,
             minimumFractionDigits: minimumFractionDigits,
             maximumFractionDigits: maximumFractionDigits
+        )
+        self.bindWrappedValue = nil
+        self.vFirst = vFirst ?? .vInitial
+        self.vLast = vLast
+    }
+
+    /// Initializes the ``LocalizedDate`` property wrapper
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// @ViewModel struct MyViewModel {
+    ///     @LocalizedDate(value: order.placedAt, dateStyle: .short) var placedAt
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - value: The date to localize; formatted for the receiving **Locale** during encoding
+    ///   - dateStyle: The **DateFormatter.Style** for the date portion (when no style or
+    ///      format is provided, ``LocalizableDate`` defaults to `.medium`)
+    ///   - timeStyle: The **DateFormatter.Style** for the time portion (default: none)
+    ///   - dateFormat: A fixed date-format string that overrides the styles (default: none)
+    ///   - vFirst: The first *SystemVersion* that this property is valid in
+    ///   - vLast: The last *SystemVersion* that this property is valid in
+    public init(value: Date, dateStyle: DateFormatter.Style? = nil, timeStyle: DateFormatter.Style? = nil, dateFormat: String? = nil, vFirst: SystemVersion? = nil, vLast: SystemVersion? = nil) where Value == LocalizableDate {
+        self.localizationId = .random(length: 10)
+        self.wrappedValue = .init(
+            value: value,
+            dateStyle: dateStyle,
+            timeStyle: timeStyle,
+            dateFormat: dateFormat
         )
         self.bindWrappedValue = nil
         self.vFirst = vFirst ?? .vInitial

--- a/Sources/FOSMacros/FieldValidationModelMacro.swift
+++ b/Sources/FOSMacros/FieldValidationModelMacro.swift
@@ -51,6 +51,7 @@ public struct FieldValidationModelMacro: ExtensionMacro, MemberMacro {
         "LocalizedString",
         "LocalizedInt",
         "LocalizedDouble",
+        "LocalizedDate",
         "LocalizedCompoundString",
         "LocalizedSubs",
 

--- a/Sources/FOSMacros/ViewModelMacro.swift
+++ b/Sources/FOSMacros/ViewModelMacro.swift
@@ -56,6 +56,7 @@ public struct ViewModelMacro: ExtensionMacro, MemberMacro {
         "LocalizedString",
         "LocalizedInt",
         "LocalizedDouble",
+        "LocalizedDate",
         "LocalizedCompoundString",
         "LocalizedSubs",
 

--- a/Tests/FOSMVVMTests/Localization/LocalizedDateTests.swift
+++ b/Tests/FOSMVVMTests/Localization/LocalizedDateTests.swift
@@ -1,0 +1,124 @@
+// LocalizedDateTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+@testable import FOSMVVM
+import FOSTesting
+import Foundation
+import Testing
+
+struct LocalizedDateTests: LocalizableTestCase {
+    // MARK: - Wrapper Init Tests
+
+    @Test func wrapperInitPassesThrough() {
+        let vm = DateTestViewModel()
+
+        #expect(vm.shortStyled.value == fixedTestDate)
+        #expect(vm.shortStyled.dateStyle == .short)
+        #expect(vm.shortStyled.timeStyle == .short)
+        #expect(vm.shortStyled.dateFormat == nil)
+
+        // A time style alone suppresses the .medium date-style default
+        #expect(vm.timeOnly.timeStyle == .short)
+        #expect(vm.timeOnly.dateStyle == nil)
+        #expect(vm.timeOnly.dateFormat == nil)
+
+        #expect(vm.isoFormatted.value == fixedTestDate)
+        #expect(vm.isoFormatted.dateFormat == "yyyy-MM-dd")
+        // A fixed format suppresses the style default (LocalizableDate's rule)
+        #expect(vm.isoFormatted.dateStyle == nil)
+    }
+
+    @Test func defaultStyle_mediumFromLocalizableDate() {
+        let vm = DateTestViewModel()
+
+        // No style args → LocalizableDate's .medium default applies
+        #expect(vm.defaultStyled.dateStyle == .medium)
+        #expect(vm.defaultStyled.timeStyle == nil)
+        #expect(vm.defaultStyled.dateFormat == nil)
+    }
+
+    // MARK: - Codable Round-Trip Tests
+
+    @Test func codable_localizesPerLocale() throws {
+        let enEncoder = JSONEncoder.localizingEncoder(locale: en, localizationStore: locStore)
+        let enVM: DateTestViewModel = try DateTestViewModel().toJSON(encoder: enEncoder).fromJSON()
+
+        let esEncoder = JSONEncoder.localizingEncoder(locale: es, localizationStore: locStore)
+        let esVM: DateTestViewModel = try DateTestViewModel().toJSON(encoder: esEncoder).fromJSON()
+
+        // Medium style in en contains the abbreviated month "Jul"
+        let enResult = try enVM.defaultStyled.localizedString
+        #expect(enResult.contains("Jul"))
+
+        // Spanish renders the month differently (lowercase "jul")
+        let esResult = try esVM.defaultStyled.localizedString
+        #expect(esResult.contains("jul"))
+        #expect(enResult != esResult)
+    }
+
+    @Test func codable_roundTripPreservesValueAndStatus() throws {
+        let vmEncoder = JSONEncoder.localizingEncoder(locale: en, localizationStore: locStore)
+        let vm: DateTestViewModel = try DateTestViewModel().toJSON(encoder: vmEncoder).fromJSON()
+
+        #expect(vm.defaultStyled.value == fixedTestDate)
+        #expect(vm.defaultStyled.localizationStatus == .localized)
+        #expect(try vm.isoFormatted.localizedString.starts(with: "2024-07-0"))
+    }
+
+    // MARK: - Versioning Tests
+
+    @Test func versioning_flowsThroughToWrapper() {
+        let versioned = DateTestViewModel.LocalizedDate(
+            value: fixedTestDate,
+            vFirst: .v2_0_0,
+            vLast: .v3_0_0
+        )
+        #expect(versioned.vFirst == .v2_0_0)
+        #expect(versioned.vLast == .v3_0_0)
+
+        let unversioned = DateTestViewModel.LocalizedDate(value: fixedTestDate)
+        #expect(unversioned.vFirst == .vInitial)
+        #expect(unversioned.vLast == nil)
+    }
+
+    let locStore: LocalizationStore
+    init() throws {
+        self.locStore = try Self.loadLocalizationStore(
+            bundle: Bundle.module,
+            resourceDirectoryName: "TestYAML"
+        )
+    }
+}
+
+// MARK: - Test ViewModel
+
+/// Fixed date for consistent testing: 2024-07-03 08:46:40 UTC
+private let fixedTestDate = Date(timeIntervalSince1970: 1720000000)
+
+@ViewModel
+private struct DateTestViewModel {
+    @LocalizedDate(value: fixedTestDate) var defaultStyled
+    @LocalizedDate(value: fixedTestDate, dateStyle: .short, timeStyle: .short) var shortStyled
+    @LocalizedDate(value: fixedTestDate, timeStyle: .short) var timeOnly
+    @LocalizedDate(value: fixedTestDate, dateFormat: "yyyy-MM-dd") var isoFormatted
+
+    var vmId = ViewModelId()
+
+    static func stub() -> Self {
+        .init()
+    }
+}

--- a/Tests/FOSMacrosTests/FieldValidationModelMacroTests.swift
+++ b/Tests/FOSMacrosTests/FieldValidationModelMacroTests.swift
@@ -117,6 +117,7 @@ final class FieldValidationModelMacroTests: XCTestCase {
                 @LocalizedString(parentKeys: "aField", "validationMessages") var error2
                 @LocalizedString(propertyName: "pieces", index: 0) var firstPiece
                 @LocalizedInt(value: 42) var aLocalizedInt
+                @LocalizedDate(value: Date(timeIntervalSince1970: 0)) var aLocalizedDate
                 @LocalizedStrings var pieces
                 @LocalizedString var separator
                 @LocalizedCompoundString(pieces: \._pieces) var aLocalizedCompoundNoSep
@@ -141,6 +142,7 @@ final class FieldValidationModelMacroTests: XCTestCase {
                 @LocalizedString(parentKeys: "aField", "validationMessages") var error2
                 @LocalizedString(propertyName: "pieces", index: 0) var firstPiece
                 @LocalizedInt(value: 42) var aLocalizedInt
+                @LocalizedDate(value: Date(timeIntervalSince1970: 0)) var aLocalizedDate
                 @LocalizedStrings var pieces
                 @LocalizedString var separator
                 @LocalizedCompoundString(pieces: \._pieces) var aLocalizedCompoundNoSep
@@ -156,7 +158,7 @@ final class FieldValidationModelMacroTests: XCTestCase {
                 }
 
                 public func propertyNames() -> [LocalizableId: String] {
-                    [_aLocalizedString.localizationId: "aLocalizedString", _title.localizationId: "title", _aFieldTitle.localizationId: "aFieldTitle", _error1.localizationId: "error1", _error2.localizationId: "error2", _firstPiece.localizationId: "firstPiece", _aLocalizedInt.localizationId: "aLocalizedInt", _pieces.localizationId: "pieces", _separator.localizationId: "separator", _aLocalizedCompoundNoSep.localizationId: "aLocalizedCompoundNoSep", _aLocalizedCompoundSep.localizationId: "aLocalizedCompoundSep", _aLocalizedSubstitution.localizationId: "aLocalizedSubstitution"]
+                    [_aLocalizedString.localizationId: "aLocalizedString", _title.localizationId: "title", _aFieldTitle.localizationId: "aFieldTitle", _error1.localizationId: "error1", _error2.localizationId: "error2", _firstPiece.localizationId: "firstPiece", _aLocalizedInt.localizationId: "aLocalizedInt", _aLocalizedDate.localizationId: "aLocalizedDate", _pieces.localizationId: "pieces", _separator.localizationId: "separator", _aLocalizedCompoundNoSep.localizationId: "aLocalizedCompoundNoSep", _aLocalizedCompoundSep.localizationId: "aLocalizedCompoundSep", _aLocalizedSubstitution.localizationId: "aLocalizedSubstitution"]
                 }
             }
 

--- a/Tests/FOSMacrosTests/ViewModelMacroTests.swift
+++ b/Tests/FOSMacrosTests/ViewModelMacroTests.swift
@@ -143,6 +143,7 @@ final class ViewModelMacroTests: XCTestCase {
                 @LocalizedString(parentKeys: "aField", "validationMessages") var error2
                 @LocalizedString(propertyName: "pieces", index: 0) var firstPiece
                 @LocalizedInt(value: 42) var aLocalizedInt
+                @LocalizedDate(value: Date(timeIntervalSince1970: 0)) var aLocalizedDate
                 @LocalizedStrings var pieces
                 @LocalizedString var separator
                 @LocalizedCompoundString(pieces: \._pieces) var aLocalizedCompoundNoSep
@@ -177,6 +178,7 @@ final class ViewModelMacroTests: XCTestCase {
                 @LocalizedString(parentKeys: "aField", "validationMessages") var error2
                 @LocalizedString(propertyName: "pieces", index: 0) var firstPiece
                 @LocalizedInt(value: 42) var aLocalizedInt
+                @LocalizedDate(value: Date(timeIntervalSince1970: 0)) var aLocalizedDate
                 @LocalizedStrings var pieces
                 @LocalizedString var separator
                 @LocalizedCompoundString(pieces: \._pieces) var aLocalizedCompoundNoSep
@@ -200,7 +202,7 @@ final class ViewModelMacroTests: XCTestCase {
                 }
 
                 public func propertyNames() -> [LocalizableId: String] {
-                    [_aLocalizedString.localizationId: "aLocalizedString", _title.localizationId: "title", _aFieldTitle.localizationId: "aFieldTitle", _error1.localizationId: "error1", _error2.localizationId: "error2", _firstPiece.localizationId: "firstPiece", _aLocalizedInt.localizationId: "aLocalizedInt", _pieces.localizationId: "pieces", _separator.localizationId: "separator", _aLocalizedCompoundNoSep.localizationId: "aLocalizedCompoundNoSep", _aLocalizedCompoundSep.localizationId: "aLocalizedCompoundSep", _aLocalizedSubstitution.localizationId: "aLocalizedSubstitution"]
+                    [_aLocalizedString.localizationId: "aLocalizedString", _title.localizationId: "title", _aFieldTitle.localizationId: "aFieldTitle", _error1.localizationId: "error1", _error2.localizationId: "error2", _firstPiece.localizationId: "firstPiece", _aLocalizedInt.localizationId: "aLocalizedInt", _aLocalizedDate.localizationId: "aLocalizedDate", _pieces.localizationId: "pieces", _separator.localizationId: "separator", _aLocalizedCompoundNoSep.localizationId: "aLocalizedCompoundNoSep", _aLocalizedCompoundSep.localizationId: "aLocalizedCompoundSep", _aLocalizedSubstitution.localizationId: "aLocalizedSubstitution"]
                 }
             }
 

--- a/docs/superpowers/plans/2026-07-04-localized-date-wrapper.md
+++ b/docs/superpowers/plans/2026-07-04-localized-date-wrapper.md
@@ -1,0 +1,151 @@
+# @LocalizedDate Wrapper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the missing `@LocalizedDate` property wrapper to the `Localized*` family (confirmed library bug — the family and two doc surfaces already reference it), plus macro recognition, contract tests, and the catalog correction.
+
+**Architecture:** Mirror the existing `_LocalizedProperty` family pattern exactly: a `RetrievablePropertyNames` typealias + a constrained `init where Value == LocalizableDate` that delegates all formatting semantics to `LocalizableDate` (styles default in ONE home — the owner). Both macros' `knownLocalizedPropertyNames` lists must include the new name (the NOTE at the typealias site requires it; without it, `@ViewModel`/`@FieldValidationModel` expansion skips the property's `localizationId` registration).
+
+**Tech Stack:** Swift 6, FOSMVVM + FOSMacros, Swift Testing (FOSMVVMTests) + XCTest (macro tests, macOS-only), the api-catalog update workflow from PR #105 (this branch stacks on `feature/api-catalog`).
+
+---
+
+## Design decisions (rationale — implementer context, gated via fosmvvm-planning)
+
+1. **`value: Date` is REQUIRED** — deliberate deviation from `LocalizedInt`/`LocalizedDouble`'s `value: X? = nil`. Ints/doubles have a natural identity fallback (`0`); a date has no meaningful zero, and an implicit `Date()` would bake a nondeterministic encode-time value into ViewModels. (Base-type discipline: minimize options, not meanings.)
+2. **No style-default logic in the wrapper init.** `LocalizableDate.init(value:dateStyle:timeStyle:dateFormat:)` already implements "`.medium` date style when nothing is specified" — the wrapper passes optionals through untouched. One home for the default (derive on the owner).
+3. **`LocalizableValue.swift:24` DocC needs NO edit** — it already lists `@LocalizedDate`; it becomes true when this lands. Same for `.claude/CLAUDE.md:153` (Key Patterns). The only doc that must CHANGE is the catalog (`FOSMVVM.md`), which currently documents the absence.
+4. **Dedicated test ViewModel** — do NOT add properties to the shared `Tests/FOSMVVMTests/TestViewModel.swift`: `expectVersionedViewModel` compares against committed `.VersionedTestJSON` baselines and a new property invalidates them.
+5. **Macro snapshot tests:** the existing `ViewModelMacroTests`/`FieldValidationModelMacroTests` fixtures embed full expected expansions. Add `@LocalizedDate` to those fixtures and update the expected strings — the diff must be ONLY the new property's entries (`_aLocalizedDate.localizationId: "aLocalizedDate"` etc.). If the snapshot churn turns out larger than the new-property entries, STOP and report (something else is wrong).
+
+## File structure
+
+```
+Sources/FOSMVVM/Localization/LocalizedProperty.swift      modify (typealias ~line 167; init after the LocalizedDouble init ~line 349)
+Sources/FOSMacros/ViewModelMacro.swift                    modify (~line 54 list)
+Sources/FOSMacros/FieldValidationModelMacro.swift         modify (~line 49 list)
+Tests/FOSMVVMTests/Localization/LocalizedDateTests.swift  create (contract tests, Swift Testing)
+Tests/FOSMacrosTests/ViewModelMacroTests.swift            modify (fixture + expected expansion)
+Tests/FOSMacrosTests/FieldValidationModelMacroTests.swift modify (fixture + expected expansion)
+.claude/skills/shared/api-catalog/FOSMVVM.md              modify (wrapper-family entry, via update-skill rules)
+.claude-plugin/plugin.json                                modify (2.7.0 → 2.8.0, catalog content change = minor)
+CHANGELOG.md                                              modify (new API entry — follow the file's existing conventions)
+```
+
+---
+
+### Task 1: Wrapper + macro recognition (TDD; red = compile failure)
+
+**Files:**
+- Test: `Tests/FOSMVVMTests/Localization/LocalizedDateTests.swift` (create)
+- Modify: `Sources/FOSMVVM/Localization/LocalizedProperty.swift`
+- Modify: `Sources/FOSMacros/ViewModelMacro.swift`, `Sources/FOSMacros/FieldValidationModelMacro.swift`
+
+- [ ] **Step 1: Write the failing test.** Model the file on `Tests/FOSMVVMTests/Localization/LocalizableDateTests.swift` (locale setup) and `LocalizablePropertyTests.swift` (wrapper round-trips). Structure:
+
+```swift
+// LocalizedDateTests.swift  (license header via swiftformat)
+import FOSFoundation
+import FOSTesting          // LocalizableTestCase
+@testable import FOSMVVM   // mirror LocalizablePropertyTests' imports exactly; contract assertions must not reach internals
+import Foundation
+import Testing
+
+struct LocalizedDateTests: LocalizableTestCase {
+    // 1. Wrapper init: wrappedValue carries value + styles through to LocalizableDate
+    @Test func wrapperInitPassesThrough() { ... @LocalizedDate(value: fixedDate, dateStyle: .short) ... }
+
+    // 2. Default styling: no style args → LocalizableDate's .medium default applies
+    // 3. Codable round-trip via try vm.toJSON().fromJSON() after localized encode:
+    //    localizedString differs per locale (en vs es), matching LocalizableDateTests' expectations
+    // 4. Versioning: vFirst/vLast flow through like the LocalizedInt tests
+    let locStore: LocalizationStore
+    init() throws { self.locStore = try Self.loadLocalizationStore(bundle: .module, resourceDirectoryName: "TestYAML") }
+    // ^ loadLocalizationStore is synchronous `throws` — no await; no @Suite attribute (siblings use none;
+    //   each suite loads its own locStore, no shared singleton)
+}
+```
+
+Use a `@ViewModel struct DateTestViewModel` fixture (private to the test file, NOT the shared TestViewModel) with `@LocalizedDate(value:)`, `@LocalizedDate(value:dateStyle:)`, and `@LocalizedDate(value:dateFormat:)` properties, a fixed `Date(timeIntervalSince1970: 1_720_000_000)`, `vmId`, `stub()` per the `@ViewModel` requirements (crib the minimal shape from an existing small test VM in this test target).
+
+- [ ] **Step 2: Run to verify it fails** — `swift test --filter LocalizedDateTests` → expect COMPILE failure: `LocalizedDate` not found.
+- [ ] **Step 3: Minimal implementation.**
+  - `LocalizedProperty.swift` typealias block (after `LocalizedDouble`, before `LocalizedCompoundString`, keeping the family's order sensible): `typealias LocalizedDate = _LocalizedProperty<Self, LocalizableDate>` — and heed the adjacent NOTE comment (next bullet).
+  - Both macro files: add `"LocalizedDate"` to `knownLocalizedPropertyNames` (after `"LocalizedDouble"`).
+  - The init, after the `LocalizedDouble` init, DocC first (drafted at the gate — call-site framed):
+
+```swift
+    /// Initializes the ``LocalizedDate`` property wrapper
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// @ViewModel struct MyViewModel {
+    ///     @LocalizedDate(value: order.placedAt, dateStyle: .short) var placedAt
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - value: The date to localize; formatted for the receiving **Locale** during encoding
+    ///   - dateStyle: The **DateFormatter.Style** for the date portion (when no style or
+    ///      format is provided, ``LocalizableDate`` defaults to `.medium`)
+    ///   - timeStyle: The **DateFormatter.Style** for the time portion (default: none)
+    ///   - dateFormat: A fixed date-format string that overrides the styles (default: none)
+    ///   - vFirst: The first *SystemVersion* that this property is valid in
+    ///   - vLast: The last *SystemVersion* that this property is valid in
+    public init(value: Date, dateStyle: DateFormatter.Style? = nil, timeStyle: DateFormatter.Style? = nil, dateFormat: String? = nil, vFirst: SystemVersion? = nil, vLast: SystemVersion? = nil) where Value == LocalizableDate {
+        self.localizationId = .random(length: 10)
+        self.wrappedValue = .init(
+            value: value,
+            dateStyle: dateStyle,
+            timeStyle: timeStyle,
+            dateFormat: dateFormat
+        )
+        self.bindWrappedValue = nil
+        self.vFirst = vFirst ?? .vInitial
+        self.vLast = vLast
+    }
+```
+
+- [ ] **Step 4: Run to verify green** — `swift test --filter LocalizedDateTests` → PASS; then full `swift test` → 331+new pass (baselines untouched).
+- [ ] **Step 5: swiftformat the touched files (license header rule); verify stable; commit**
+
+```bash
+git add Sources/FOSMVVM/Localization/LocalizedProperty.swift Sources/FOSMacros/ViewModelMacro.swift Sources/FOSMacros/FieldValidationModelMacro.swift Tests/FOSMVVMTests/Localization/LocalizedDateTests.swift
+git commit -m "feat(FOSMVVM): add missing @LocalizedDate property wrapper"
+```
+
+### Task 2: Macro expansion snapshot tests
+
+**Files:** Modify `Tests/FOSMacrosTests/ViewModelMacroTests.swift`, `Tests/FOSMacrosTests/FieldValidationModelMacroTests.swift`
+
+- [ ] Add `@LocalizedDate(value: Date(timeIntervalSince1970: 0)) var aLocalizedDate` to the fixture VM in each test (next to the existing `@LocalizedInt(value: 42) var aLocalizedInt`), and add the matching `_aLocalizedDate.localizationId: "aLocalizedDate"` entry to each expected `localizationIds` dictionary string (match the dict's existing ordering convention — read the actual failure diff to place it exactly).
+- [ ] Run `swift test --filter ViewModelMacroTests && swift test --filter FieldValidationModelMacroTests` — first run shows the expected-vs-actual diff; confirm the ONLY delta is the new property's entries (design decision 5: larger churn = STOP and report), fix expected strings, re-run → PASS.
+- [ ] Commit: `git add Tests/FOSMacrosTests/... && git commit -m "test(FOSMacros): cover @LocalizedDate in macro expansion tests"`
+
+### Task 3: Catalog correction + plugin bump + CHANGELOG (the update-skill workflow, for real)
+
+**Files:** Modify `.claude/skills/shared/api-catalog/FOSMVVM.md`, `.claude-plugin/plugin.json`, `CHANGELOG.md`
+
+- [ ] Follow `.claude/skills/fosutilities-api-catalog-update/SKILL.md` (it is on this branch): run `swift scripts/api-catalog-audit.swift` (rebuilds symbol graphs with the new API). Expected: 0 stale; `LocalizedDate` is likely parent-covered (member of catalogued `RetrievablePropertyNames`) so possibly 0 gaps — the catalog edit is still REQUIRED because the prose is now wrong.
+- [ ] Edit the `@Localized*` wrapper-family entry in `FOSMVVM.md` (§ Localization, ~line 100–115): add `LocalizedDate` to the title backticks; replace the "There is no `@LocalizedDate` wrapper — carry a `LocalizableDate` property instead" limitation note with a normal family mention (dateStyle/timeStyle/dateFormat pass-through, `.medium` default; value is required — no zero date). Keep entry-format rules (task-framed title, label-free symbols, ≤~8-line example).
+- [ ] Re-run the audit → 0 gaps / 0 stale / exit 0 (paste summary). Confirm `.claude/CLAUDE.md:153` Key Patterns line (`@LocalizedDate`) is now TRUE — no edit.
+- [ ] Fix `.claude/docs/FOSMVVMArchitecture.md:920`: `@LocalizedDate var createdAt` doesn't compile (value is required) → `@LocalizedDate(value: model.createdAt) var createdAt` (Task 1 review finding — Architecture is Truth; a truth doc must not demo an invalid call).
+- [ ] `CHANGELOG.md`: add the new-API entry following the file's existing section conventions (read the top of the file first).
+- [ ] `plugin.json`: 2.7.0 → 2.8.0 (catalog content change = minor, per the update skill's semver guidance).
+- [ ] Commit: `git add .claude/skills/shared/api-catalog/FOSMVVM.md .claude-plugin/plugin.json CHANGELOG.md && git commit -m "docs(api-catalog): @LocalizedDate exists now; bump plugin to 2.8.0"`
+
+### Task 4: End-to-end verification
+
+- [ ] `swift test` — full suite green (paste tail).
+- [ ] `swift scripts/api-catalog-audit.swift; echo $?` — 0 gaps / 0 stale / exit 0 (paste summary).
+- [ ] `grep -rn "no .*LocalizedDate\|LocalizedDate.*does not exist\|there is no" .claude/skills/shared/api-catalog/ .claude/CLAUDE.md .claude/docs/` — nothing claiming absence remains; and `grep -n "@LocalizedDate var" .claude/docs/FOSMVVMArchitecture.md` returns nothing (all examples use the required value form).
+- [ ] No commit (verification only); report results.
+
+---
+
+## Execution notes
+
+- Branch `fix/localized-date-wrapper` stacks on `feature/api-catalog` (PR #105). The PR for this branch targets `feature/api-catalog` (or retargets `main` after #105 merges).
+- Macro tests are XCTest and compile on macOS — fine locally; ubuntu CI also builds macros.
+- If `swift test --filter` misbehaves with macro targets, run the full suite — it's ~5 min.


### PR DESCRIPTION
## Summary
- Completes the `Localized*` wrapper family: `@LocalizedDate` (typealias + constrained init) with a **required** `value: Date` — ints/doubles have a natural zero, dates don't, and an implicit `Date()` would bake nondeterministic encode-time values into ViewModels. Style parameters (`dateStyle`/`timeStyle`/`dateFormat`) pass through untouched to `LocalizableDate`, which owns the `.medium` default.
- `"LocalizedDate"` added to `knownLocalizedPropertyNames` in both `ViewModelMacro` and `FieldValidationModelMacro` (per the NOTE at the typealias site), with macro expansion test coverage.
- Docs reconciled: the API catalog's wrapper-family entry no longer documents the absence; `FOSMVVMArchitecture.md`'s example now shows the compiling call form; CHANGELOG entry added; plugin 2.7.0 → 2.8.0. The previously-stale mentions in `CLAUDE.md` Key Patterns and `LocalizableValue.swift` DocC are now true as written.

**Stacked on #105** (`feature/api-catalog`) — it uses the catalog + update-skill workflow from that branch. Retarget to `main` after #105 merges.

## Test Plan
- [x] `swift test` — 336 Swift Testing tests (5 new contract tests: pass-through incl. `timeStyle`, `.medium` default, per-locale localization, codable round-trip, versioning) + 19 XCTest macro tests, all green
- [x] Macro snapshot delta verified to be exactly the new property's entries in both fixtures
- [x] `swift scripts/api-catalog-audit.swift` — 0 gaps, 0 stale, exit 0
- [x] Absence-claim greps across catalog/CLAUDE.md/docs return nothing; shared `TestViewModel` and `.VersionedTestJSON` baselines untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6qRyM2K5f4RJZnUdeLyD1