### PR TITLE
Fix stale DocC examples + FOSVaporServerError debugDescription label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LocalizableDate` (`.medium` date style when nothing is specified); `value:`
   is required.
 
+### Fixed
+
+- `FOSVaporServerError.debugDescription` now correctly labels itself (it
+  previously printed `FOSLocalizableError:`).
+- Corrected stale documentation examples: `PDFRenderer.render` shown with
+  `try` (both overloads are synchronous), `register(viewModel:)` label,
+  `FormFieldView` example includes the required `focusField:` parameter,
+  `hexString()` example values, and two `@Localized*` example typos.
+
 ## [0.4.0] - 2026-07-03
 
 ### Added

--- a/Sources/FOSFoundation/Numbers/Int+Hex.swift
+++ b/Sources/FOSFoundation/Numbers/Int+Hex.swift
@@ -38,7 +38,7 @@ public extension UInt64 {
     /// ## Example:
     ///
     /// ```swift
-    /// print(256.hexString()) // Prints: 0xFF
+    /// print(255.hexString()) // Prints: 0xFF
     /// ```
     ///
     /// - Parameters:
@@ -55,7 +55,7 @@ public extension Int64 {
     /// ## Example:
     ///
     /// ```swift
-    /// print(256.hexString()) // Prints: 0xFF
+    /// print(255.hexString()) // Prints: 0xFF
     /// ```
     ///
     /// - Parameters:
@@ -72,7 +72,7 @@ public extension UInt {
     /// ## Example:
     ///
     /// ```swift
-    /// print(256.hexString()) // Prints: 0xFF
+    /// print(255.hexString()) // Prints: 0xFF
     /// ```
     ///
     /// - Parameters:
@@ -89,7 +89,7 @@ public extension Int {
     /// ## Example:
     ///
     /// ```swift
-    /// print(256.hexString()) // Prints: 0xFF
+    /// print(255.hexString()) // Prints: 0xFF
     /// ```
     ///
     /// - Parameters:

--- a/Sources/FOSMVVM/FOSMVVM.docc/ServerOverview.md
+++ b/Sources/FOSMVVM/FOSMVVM.docc/ServerOverview.md
@@ -38,11 +38,11 @@ For each ``ViewModel``, an entry needs to be added to the servers [Routing](http
 func routes(_ app: Application) throws {
     let routes = app.routes
 
-    try routes.register(model: LandingPageViewModel.self)
+    try routes.register(viewModel: LandingPageViewModel.self)
 
     let secureRoutes = routes
         .grouped(AuthMiddleware())
-    try secureRoutes.register(model: DashboardPagePageViewModel.self)
+    try secureRoutes.register(viewModel: DashboardPagePageViewModel.self)
 }
 ```
 

--- a/Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md
+++ b/Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md
@@ -136,7 +136,7 @@ import Vapor
 import ViewModels
 
 func routes(_ app: Application) throws {
-    try app.routes.register(model: LandingPageViewModel.self)
+    try app.routes.register(viewModel: LandingPageViewModel.self)
 }
 ```
 

--- a/Sources/FOSMVVM/Localization/LocalizedProperty.swift
+++ b/Sources/FOSMVVM/Localization/LocalizedProperty.swift
@@ -249,7 +249,7 @@ public extension RetrievablePropertyNames {
     ///
     /// ```swift
     /// @ViewModel struct MyViewModel {
-    ///     @LocalizedString var aLocalizedSting
+    ///     @LocalizedString var aLocalizedString
     /// }
     /// ```
     ///
@@ -289,7 +289,7 @@ public extension RetrievablePropertyNames {
     ///
     /// ```swift
     /// @ViewModel struct MyViewModel {
-    ///     @LocalizeInt(value: 42) var aLocalizedInt
+    ///     @LocalizedInt(value: 42) var aLocalizedInt
     /// }
     /// ```
     ///

--- a/Sources/FOSMVVM/SwiftUI Support/FormFieldView.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/FormFieldView.swift
@@ -32,12 +32,13 @@ import SwiftUI
 /// ```swift
 /// public struct UserFormView: ViewModelView {
 ///     let viewModel: UserFormModel
+///     @FocusState private var focusedField: FormFieldIdentifier?
 ///
 ///     var body: some View {
 ///         Form {
-///           FormFieldView(fieldModel: viewModel.$email)
-///           FormFieldView(fieldModel: viewModel.$firstName)
-///           FormFieldView(fieldModel: viewModel.$lastName)
+///           FormFieldView(fieldModel: viewModel.$email, focusField: $focusedField)
+///           FormFieldView(fieldModel: viewModel.$firstName, focusField: $focusedField)
+///           FormFieldView(fieldModel: viewModel.$lastName, focusField: $focusedField)
 ///         }
 ///     }
 /// }
@@ -71,7 +72,7 @@ public struct FormFieldView<Value: Codable & Hashable>: View {
                 onNewValue?(newValue)
             }
             .onChange(of: isFocused) {
-                if !isFocused && hasChanged {
+                if !isFocused, hasChanged {
                     Self.validateIt(
                         fieldModel: fieldModel,
                         fieldValidator: fieldValidator,
@@ -167,12 +168,11 @@ public struct FormFieldView<Value: Codable & Hashable>: View {
                 }
 
                 // Only the value forwarded downstream (debounced onNewValue) is trimmed.
-                let valueToSend: Value
-                if let str = newValue as? String {
+                let valueToSend: Value = if let str = newValue as? String {
                     // swiftlint:disable:next force_cast
-                    valueToSend = str.trimmingCharacters(in: .whitespaces) as! Value
+                    str.trimmingCharacters(in: .whitespaces) as! Value
                 } else {
-                    valueToSend = newValue
+                    newValue
                 }
                 coordinator.subject.send(valueToSend)
             }

--- a/Sources/FOSMVVMVapor/Vapor Support/ViewModelRequest.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/ViewModelRequest.swift
@@ -33,7 +33,7 @@ public extension RoutesBuilder {
     ///
     /// ```swift
     /// func routes(_ app: Application) throws {
-    ///    try app.routes.register(model: LandingPageViewModel.self)
+    ///    try app.routes.register(viewModel: LandingPageViewModel.self)
     /// }
     /// ```
     ///

--- a/Sources/FOSReporting/FOSReporting.docc/FOSReporting.md
+++ b/Sources/FOSReporting/FOSReporting.docc/FOSReporting.md
@@ -23,7 +23,7 @@ import FOSReporting
 import SwiftUI
 
 // Generate a simple PDF
-let pdfData = try await PDFRenderer.render(
+let pdfData = try PDFRenderer.render(
     pageSize: .a4(),
     pageCount: 1
 ) { pageIndex in

--- a/Sources/FOSReporting/PDFRenderer.swift
+++ b/Sources/FOSReporting/PDFRenderer.swift
@@ -42,7 +42,7 @@ import UIKit
 ///
 /// ```swift
 /// // Create a single-page PDF
-/// let pdfData = try await PDFRenderer.render(
+/// let pdfData = try PDFRenderer.render(
 ///     pageSize: .a4(),
 ///     pageCount: 1
 /// ) { _ in
@@ -51,7 +51,7 @@ import UIKit
 /// }
 ///
 /// // Create a multi-page document
-/// let multiPagePDF = try await PDFRenderer.render(
+/// let multiPagePDF = try PDFRenderer.render(
 ///     pageSize: .usLetter(orientation: .landscape),
 ///     pageCount: 10
 /// ) { pageIndex in
@@ -192,7 +192,7 @@ public enum PDFRenderer {
     /// ## Example
     ///
     /// ```swift
-    /// let pdfData = try await PDFRenderer.render(
+    /// let pdfData = try PDFRenderer.render(
     ///     pageSize: .a4(),
     ///     pageCount: 3,
     ///     format: {
@@ -284,7 +284,7 @@ public enum PDFRenderer {
     /// ## Example
     ///
     /// ```swift
-    /// let pdfData = try await PDFRenderer.render(
+    /// let pdfData = try PDFRenderer.render(
     ///     pageSize: .usLetter(orientation: .landscape),
     ///     pageCount: 5
     /// ) { pageIndex in

--- a/Sources/FOSTestingVapor/VaporServerTestCase.swift
+++ b/Sources/FOSTestingVapor/VaporServerTestCase.swift
@@ -105,7 +105,7 @@ public enum FOSVaporServerError: Error, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         switch self {
-        case .error(let message): "FOSLocalizableError: \(message)"
+        case .error(let message): "FOSVaporServerError: \(message)"
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes the documentation-bug batch surfaced by the API catalog reviews (every catalog entry was verified against source, which exposed these):
  - `PDFRenderer.render` examples showed `try await` — both overloads are synchronous (5 spots incl. `FOSReporting.docc`)
  - `register()` examples used `model:` — the real label is `viewModel:` (4 spots incl. two `.docc` articles)
  - `FormFieldView` example omitted the required `focusField:` parameter — now shows the `@FocusState` pattern
  - `hexString()` examples printed `0xFF` for `256` (4 overloads; `0xFF` is 255)
  - Example typos: `aLocalizedSting`, `@LocalizeInt`
- One behavior fix: `FOSVaporServerError.debugDescription` labeled itself `FOSLocalizableError:` (copy-paste) — now `FOSVaporServerError:`; CHANGELOG entry added.

## Test Plan
- [x] `swift test` — 336 tests in 47 suites pass (+ 19 XCTest macro tests)
- [x] All corrected examples verified against real signatures (the catalog reviews had already source-verified each)
- [x] No residual instances (repo-wide grep for each fixed pattern)
- [ ] CI green on this PR (audit unaffected — no API surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6qRyM2K5f4RJZnUdeLyD1