### PR TITLE
FOSNetworkSecurity module + EmptyBody-fetch fix (PL-8) + server-hosted previews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,10 @@ let package = Package(
             .library(
                 name: "FOSTestingUI",
                 targets: ["FOSTestingUI"]
+            ),
+            .library(
+                name: "FOSNetworkSecurity",
+                targets: ["FOSNetworkSecurity"]
             )
         ]
 
@@ -62,6 +66,8 @@ let package = Package(
             .package(url: "https://github.com/apple/swift-docc-plugin", .upToNextMajor(from: "1.4.3")),
             .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "4.1.0")),
             .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "601.0.1"),
+            .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
+            .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMajor(from: "1.0.0")),
 
             // Third 🥳 frameworks
             // NOTE: WASM/WASI support is present but dormant. The WASI URLSession code
@@ -125,6 +131,21 @@ let package = Package(
                 dependencies: [
                     .byName(name: "FOSFoundation"),
                     .byName(name: "FOSMVVM")
+                ]
+            ),
+            .target(
+                name: "FOSNetworkSecurity",
+                dependencies: [
+                    .product(name: "X509", package: "swift-certificates"),
+                    .product(name: "SwiftASN1", package: "swift-asn1"),
+                    // CryptoKit on Apple; swift-crypto's Crypto on Linux (matches FOSFoundation).
+                    .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux]))
+                ]
+            ),
+            .testTarget(
+                name: "FOSNetworkSecurityTests",
+                dependencies: [
+                    .byName(name: "FOSNetworkSecurity")
                 ]
             ),
             .testTarget(

--- a/Sources/FOSFoundation/Networking/DataFetch.swift
+++ b/Sources/FOSFoundation/Networking/DataFetch.swift
@@ -323,7 +323,7 @@ public final class DataFetch<Session: URLSessionProtocol>: Sendable {
     }
 
     /// - Throws: ``DataFetchError`` or **errorType**
-    public func send<ResultValue: Decodable & Sendable>(data: Data? = nil, to url: URL, httpMethod: String, headers: [(field: String, value: String)]?, locale: Locale?) async throws -> ResultValue {
+    public func send<ResultValue: Decodable & Sendable>(data: Data? = nil, to url: URL, httpMethod: String, headers: [(field: String, value: String)]?, locale: Locale?, checkReceivedMimeType: Bool = true) async throws -> ResultValue {
         do {
             return try await send(
                 data: data,
@@ -331,6 +331,7 @@ public final class DataFetch<Session: URLSessionProtocol>: Sendable {
                 httpMethod: httpMethod,
                 headers: headers,
                 locale: locale,
+                checkReceivedMimeType: checkReceivedMimeType,
                 errorType: DummyError.self
             )
         } catch let error as DataFetchError {
@@ -344,7 +345,7 @@ public final class DataFetch<Session: URLSessionProtocol>: Sendable {
     }
 
     /// - Throws: ``DataFetchError`` or **errorType**
-    public func send<ResultValue: Decodable & Sendable>(data: Data? = nil, to url: URL, httpMethod: String, headers: [(field: String, value: String)]?, locale: Locale?, errorType: (some Decodable & Error).Type) async throws -> ResultValue {
+    public func send<ResultValue: Decodable & Sendable>(data: Data? = nil, to url: URL, httpMethod: String, headers: [(field: String, value: String)]?, locale: Locale?, checkReceivedMimeType: Bool = true, errorType: (some Decodable & Error).Type) async throws -> ResultValue {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = httpMethod
 
@@ -391,7 +392,7 @@ public final class DataFetch<Session: URLSessionProtocol>: Sendable {
             urlRequest.httpBody = data
         }
 
-        let responseMimeType = expectedResponseMimeType // Remove mutability
+        let responseMimeType = checkReceivedMimeType ? expectedResponseMimeType : nil // Remove mutability
 
         return try await withCheckedThrowingContinuation { continuation in
             urlSession

--- a/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
+++ b/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
@@ -109,15 +109,24 @@ package extension Bundle {
                 .appending(path: resourceDirectoryName)
         ]
 
-        var result = Set<URL>()
-        for resourceURL in resourceURLs {
-            for file in resourceURL.findFiles(withExtension: "yml") {
-                let url = file.deletingLastPathComponent()
-                result.insert(url.absoluteURL)
-            }
-        }
+        return Set(resourceURLs.flatMap(\.yamlFileURLs))
+    }
+}
 
-        return result
+private extension URL {
+    var yamlFileURLs: [URL] {
+        findFiles(withExtension: "yml").map {
+            $0.deletingLastPathComponent().absoluteURL
+        }
+    }
+}
+
+package extension URL {
+    /// Initializes a ``LocalizationStore`` when the given URL roots the Resources
+    ///
+    /// > Only currently used for server-based previews
+    func yamlLocalizationStore() throws -> LocalizationStore {
+        try YamlStoreConfig(searchPaths: yamlFileURLs).localizationStore()
     }
 }
 

--- a/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
+++ b/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
@@ -96,14 +96,34 @@ public extension ServerRequest {
             try requestBody?.toJSONData() ?? Data()
         }
 
-        responseBody = try await dataFetch.send(
-            data: requestData,
-            to: requestURL(baseURL: baseURL),
-            httpMethod: action.httpMethod,
-            headers: requestHeaders,
-            locale: Locale.current,
-            errorType: Self.ResponseError.self
-        )
+        if ResponseBody.self == EmptyBody.self {
+            // An `EmptyBody` response carries no meaningful content, so its media type is irrelevant.
+            // Fetch it as `String` (the one decode path that accepts ANY 2xx body) with the
+            // received-MIME check disabled, discard the body, and synthesize the empty response. This
+            // round-trips against a server that answers `application/json` `{}` (`buildResponse`) AND
+            // one that answers `text/plain`/empty (a plain REST API) — neither type is
+            // enforced, because there is nothing to type. A non-2xx still decodes the typed
+            // `ResponseError` via `errorType`, unchanged.
+            let _: String = try await dataFetch.send(
+                data: requestData,
+                to: requestURL(baseURL: baseURL),
+                httpMethod: action.httpMethod,
+                headers: requestHeaders,
+                locale: Locale.current,
+                checkReceivedMimeType: false,
+                errorType: Self.ResponseError.self
+            )
+            responseBody = EmptyBody() as? ResponseBody
+        } else {
+            responseBody = try await dataFetch.send(
+                data: requestData,
+                to: requestURL(baseURL: baseURL),
+                httpMethod: action.httpMethod,
+                headers: requestHeaders,
+                locale: Locale.current,
+                errorType: Self.ResponseError.self
+            )
+        }
 
         return responseBody
     }

--- a/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
@@ -124,7 +124,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
 
     /// A ``LocalizationStore`` instance that provides access to the localization data
     ///
-    /// > This is only provided/necessary for applications that created ``ViewModel``s
+    /// > This is only provided/necessary for applications that create ``ViewModel``s
     /// > in the application as opposed on the server.
     public var clientLocalizationStore: LocalizationStore? {
         get throws {
@@ -140,7 +140,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
 
     /// Returns a ``LocalizationStore`` instance that provides access to the localization data
     ///
-    /// > This is only provided/necessary for applications that created ``ViewModel``s
+    /// > This is only provided/necessary for applications that create ``ViewModel``s
     /// > in the application as opposed on the server.
     ///
     /// > The result of this function is **uncached** as opposed to ``clientLocalizationStore``

--- a/Sources/FOSMVVM/SwiftUI Support/PreviewHostingView.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/PreviewHostingView.swift
@@ -103,6 +103,96 @@ public extension ViewModelView {
             inner: Self.self,
             bundle: bundle,
             resourceDirectoryName: resourceDirectoryName,
+            serverHostedResourcesPath: nil,
+            locale: locale,
+            viewModel: viewModel,
+            setStates: setStates
+        )
+    }
+
+    /// Creates an instance of the ``ViewModelView`` and it's corresponding ``ViewModel`` that
+    /// will be bound with stub data and with all ``LocalizedString`` values bound to their localized
+    /// values, loading localization resources from a server-hosted path on the local filesystem
+    ///
+    /// ## Example:
+    ///
+    /// ```swift
+    /// public struct MyViewModel: ViewModel {
+    ///     @LocalizedString public var title
+    /// }
+    ///
+    /// struct MyView: ViewModelView {
+    ///
+    ///     let viewModel: MyViewModel
+    ///
+    ///     var body: some View {
+    ///         Text(viewModel.title)
+    ///     }
+    /// }
+    ///
+    /// #Preview {
+    ///     MyView.previewHost(serverHostedResourcesPath: myResourcesURL)
+    /// }
+    /// ```
+    ///
+    /// ## Example - Setting States
+    ///
+    /// At times it is advantageous to be able to set the @State variables of a view that is being previewed.
+    /// The *setStates:* function provides for this option.
+    ///
+    /// ```swift
+    /// public struct MyViewModel: ViewModel {
+    ///     @LocalizedString public var title
+    /// }
+    ///
+    /// struct MyView: ViewModelView {
+    ///     @State private isTitleShowing = true
+    ///
+    ///     let viewModel: MyViewModel
+    ///
+    ///     var body: some View {
+    ///         if isTitleShowing {
+    ///             Text(viewModel.title)
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// private extension MyView {
+    ///     mutating func setStates(
+    ///         isTitleShowing: Bool
+    ///     ) {
+    ///         _isTitleShowing = State(initialValue: isTitleShowing)
+    ///     }
+    /// }
+    ///
+    /// #Preview("Hidden Title") {
+    ///     MyView.previewHost(
+    ///         serverHostedResourcesPath: myResourcesURL,
+    ///         setStates: { view in
+    ///             view.setStates(
+    ///                 isTitleShowing: false
+    ///             )
+    ///         }
+    ///    )
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - serverHostedResourcesPath: A URL to a directory on the local filesystem containing YAML localization resources served by the Server
+    ///   - locale: The locale to lookup the YAML bindings for (default: Locale.current)
+    ///   - viewModel: A ViewModel that will be provided to the ViewModelView (default: .stub())
+    ///   - setStates: A function that can modify the ViewModelView instance (default: nil)
+    static func previewHost(
+        serverHostedResourcesPath: URL,
+        locale: Locale = .current,
+        viewModel: VM = .stub(),
+        setStates: ((inout Self) -> Void)? = nil
+    ) -> some View {
+        PreviewHostingView(
+            inner: Self.self,
+            bundle: .main,
+            resourceDirectoryName: "",
+            serverHostedResourcesPath: serverHostedResourcesPath,
             locale: locale,
             viewModel: viewModel,
             setStates: setStates
@@ -125,6 +215,7 @@ private struct PreviewHostingView<Inner: ViewModelView>: View {
     let inner: Inner.Type
     let bundle: Bundle
     let resourceDirectoryName: String
+    let serverHostedResourcesPath: URL?
     let locale: Locale
     let viewModel: Inner.VM
     let setStates: ((inout Inner) -> Void)?
@@ -140,17 +231,28 @@ private struct PreviewHostingView<Inner: ViewModelView>: View {
         } else {
             Text(loadingText)
                 .onAppear {
-                    do {
-                        localizationStore = try bundle.yamlLocalization(
-                            resourceDirectoryName: resourceDirectoryName
-                        )
-                    } catch {
-                        loadingText = """
-                            Unable to initialize the localization store: \(error)
+                    if let serverHostedResourcesPath {
+                        do {
+                            localizationStore = try serverHostedResourcesPath
+                                .yamlLocalizationStore()
+                        } catch {
+                            loadingText = """
+                                Unable to find serverHostedResourcesPath: \(serverHostedResourcesPath)
+                            """
+                        }
+                    } else {
+                        do {
+                            localizationStore = try bundle.yamlLocalization(
+                                resourceDirectoryName: resourceDirectoryName
+                            )
+                        } catch {
+                            loadingText = """
+                                Unable to initialize the localization store: \(error)
 
-                              - Bundle: \(bundle.bundlePath)
-                              - resourceDirectoryName: \(resourceDirectoryName.isEmpty ? "<Empty>" : resourceDirectoryName)
-                        """
+                                  - Bundle: \(bundle.bundlePath)
+                                  - resourceDirectoryName: \(resourceDirectoryName.isEmpty ? "<Empty>" : resourceDirectoryName)
+                            """
+                        }
                     }
                 }
         }

--- a/Sources/FOSNetworkSecurity/MutualTLS.swift
+++ b/Sources/FOSNetworkSecurity/MutualTLS.swift
@@ -1,0 +1,157 @@
+// MutualTLS.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(Security)
+import Security
+#endif
+
+#if !os(WASI)
+
+// MARK: - MutualTLS
+
+/// A client-side **mutual-TLS** policy for a `URLSession`: the server certificate pin(s) to verify,
+/// and an optional client identity to present when the server requests one.
+///
+/// Mutual TLS authenticates *both* ends of the connection: ordinary TLS proves only the server's
+/// identity, while mutual TLS additionally has the client present a certificate the server verifies.
+/// This policy declares the client's half — *pin the server, present my identity* — and is wired
+/// into a session by ``Foundation/URLSession/session(config:mutualTLS:)``; the caller supplies only
+/// the policy values (which pins, which identity), never the handshake mechanics.
+///
+/// With ``clientIdentity`` `nil` the policy is **server-pinning-only** (no client authentication) —
+/// the correct shape for a bearer-authenticated surface that still pins its server.
+public struct MutualTLS: Sendable {
+    /// The set of acceptable server ``SPKIPin``s. The handshake succeeds only if the server leaf's
+    /// pin is a member.
+    public let serverPins: Set<SPKIPin>
+
+    /// The identity presented at the server's client-certificate challenge, or `nil` for
+    /// server-pinning-only (no client authentication).
+    public let clientIdentity: (any ClientIdentityProvider)?
+
+    public init(serverPins: Set<SPKIPin>, clientIdentity: (any ClientIdentityProvider)? = nil) {
+        self.serverPins = serverPins
+        self.clientIdentity = clientIdentity
+    }
+}
+
+// MARK: - ClientIdentityProvider
+
+/// Supplies the client identity (certificate + private key) presented during a mutual-TLS
+/// handshake, as a `URLCredential`. Abstracted so the transport depends on a seam rather than a
+/// specific keystore (e.g. a Keychain-backed provider on Apple platforms).
+public protocol ClientIdentityProvider: Sendable {
+    /// Returns the `URLCredential` to present at the client-certificate challenge.
+    ///
+    /// - Throws: if the identity cannot be located or loaded.
+    func clientCredential() throws -> URLCredential
+}
+
+#endif
+
+// MARK: - URLSession factory + delegate
+
+#if canImport(Security)
+
+public extension URLSession {
+    /// Builds a `URLSession` that enforces `mutualTLS` on every request: it SPKI-pins the server
+    /// certificate to ``MutualTLS/serverPins`` and, when the policy carries one, presents
+    /// ``MutualTLS/clientIdentity`` at the client-certificate challenge.
+    ///
+    /// This is the mutual-TLS sibling of `DataFetch.urlSessionConfiguration(forUserToken:)`: bearer
+    /// auth rides the configuration (a header), but mutual TLS needs a `URLSessionDelegate` to answer
+    /// the handshake challenges, so it is attached here at session construction. Hand the returned
+    /// session to `MVVMEnvironment(session:)` or `processRequest(session:)`.
+    ///
+    /// The returned session **owns** the pinning delegate for its lifetime; keep the session alive
+    /// for as long as its requests are in flight.
+    ///
+    /// - Parameters:
+    ///   - config: The base session configuration (e.g. from
+    ///     `DataFetch.urlSessionConfiguration()`).
+    ///   - mutualTLS: The pin/identity policy to enforce.
+    static func session(config: URLSessionConfiguration, mutualTLS: MutualTLS) -> URLSession {
+        URLSession(
+            configuration: config,
+            delegate: MutualTLSSessionDelegate(policy: mutualTLS),
+            delegateQueue: nil
+        )
+    }
+}
+
+/// The `URLSession` delegate that enforces a ``MutualTLS`` policy. **Fails closed**: a server whose
+/// leaf SPKI pin is not in ``MutualTLS/serverPins`` is rejected, and a client identity that cannot
+/// be loaded cancels the handshake rather than proceeding anonymously.
+///
+/// The server-trust branch alone (policy ``MutualTLS/clientIdentity`` `nil`) is the
+/// server-pinning-only case; a non-nil identity makes it full mutual TLS.
+private final class MutualTLSSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+    private let policy: MutualTLS
+
+    init(policy: MutualTLS) {
+        self.policy = policy
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        switch challenge.protectionSpace.authenticationMethod {
+        case NSURLAuthenticationMethodClientCertificate:
+            guard let clientIdentity = policy.clientIdentity else {
+                // Server-pinning-only: no identity to present. Let default handling proceed — the
+                // server may not actually require a client certificate.
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+            do {
+                try completionHandler(.useCredential, clientIdentity.clientCredential())
+            } catch {
+                // Fail closed: cancel rather than proceed anonymously.
+                completionHandler(.cancelAuthenticationChallenge, nil)
+            }
+
+        case NSURLAuthenticationMethodServerTrust:
+            // Pin the server's leaf by SPKI. Mismatch (or no trust/leaf) ⇒ cancel ⇒ fail closed.
+            guard let trust = challenge.protectionSpace.serverTrust,
+                  let leafDER = Self.leafCertificateDER(from: trust),
+                  let pin = try? ServerCertPinning.spkiPin(ofCertificateDER: leafDER),
+                  policy.serverPins.contains(pin) else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+                return
+            }
+            completionHandler(.useCredential, URLCredential(trust: trust))
+
+        default:
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
+
+    /// The DER of the leaf certificate from `trust` (the chain is leaf-first).
+    private static func leafCertificateDER(from trust: SecTrust) -> Data? {
+        guard let leaf = (SecTrustCopyCertificateChain(trust) as? [SecCertificate])?.first else {
+            return nil
+        }
+        return SecCertificateCopyData(leaf) as Data
+    }
+}
+
+#endif

--- a/Sources/FOSNetworkSecurity/ServerCertPinning.swift
+++ b/Sources/FOSNetworkSecurity/ServerCertPinning.swift
@@ -1,0 +1,83 @@
+// ServerCertPinning.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import SwiftASN1
+import X509
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+
+/// The SPKI-SHA256 **pin** of a certificate (RFC 7469 form): `base64(SHA256(SubjectPublicKeyInfo))`.
+///
+/// SPKI pinning hashes the certificate's public-key info — algorithm identifier + key bits — not the
+/// whole certificate, so a pin survives a renewal that keeps the same key. A pin computed on the
+/// client and on the server are equal iff they hash identical canonical SPKI DER.
+///
+/// The pin is an opaque digest; its only representation is the base64 string it wraps. It is
+/// `Hashable` so it can be a member of a pin set (``MutualTLS/serverPins``) and encodes as a **bare
+/// string** so pins ride a flat configuration/JSON value.
+public struct SPKIPin: Hashable, Sendable, Codable, CustomStringConvertible {
+    /// The base64-encoded `SHA256(SubjectPublicKeyInfo)` digest.
+    public let base64: String
+
+    public var description: String {
+        base64
+    }
+
+    public init(base64: String) {
+        self.base64 = base64
+    }
+
+    public init(from decoder: any Decoder) throws {
+        self.base64 = try decoder.singleValueContainer().decode(String.self)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(base64)
+    }
+}
+
+/// Computes the ``SPKIPin`` of an X.509 certificate.
+public enum ServerCertPinning {
+    /// The ``SPKIPin`` of the certificate encoded in `der`.
+    ///
+    /// - Parameter der: The DER-encoded X.509 certificate (e.g. a server leaf extracted from a
+    ///   `SecTrust` via `SecCertificateCopyData`).
+    /// - Returns: The certificate's ``SPKIPin``.
+    /// - Throws: A parsing/serialization error if `der` is not a valid X.509 certificate.
+    public static func spkiPin(ofCertificateDER der: Data) throws -> SPKIPin {
+        try spkiPin(of: Certificate(derEncoded: Array(der)))
+    }
+
+    /// The ``SPKIPin`` of an already-parsed X.509 `Certificate` — for callers holding a
+    /// `Certificate` rather than raw DER (e.g. a Vapor server verifying a TLS peer chain).
+    ///
+    /// - Returns: The certificate's ``SPKIPin``.
+    /// - Throws: A serialization error if the public key cannot be serialized.
+    public static func spkiPin(of certificate: Certificate) throws -> SPKIPin {
+        // Serialize the SubjectPublicKeyInfo to canonical DER, then SHA256 + base64 (RFC 7469).
+        // Canonical SPKI bytes are platform-independent, so a pin computed here matches one
+        // computed anywhere else — client or server.
+        var serializer = DER.Serializer()
+        try serializer.serialize(certificate.publicKey)
+        let digest = SHA256.hash(data: Data(serializer.serializedBytes))
+        return SPKIPin(base64: Data(digest).base64EncodedString())
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Protocols/ServerRequestRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/ServerRequestRoundTripTests.swift
@@ -26,6 +26,9 @@ import FOSFoundation
 import FOSMVVM
 import FOSMVVMVapor
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import NIOCore
 import Testing
 import Vapor

--- a/Tests/FOSMVVMVaporTests/Protocols/ServerRequestRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/ServerRequestRoundTripTests.swift
@@ -1,0 +1,220 @@
+// ServerRequestRoundTripTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end round-trip: the REAL client (`ServerRequest.processRequest` → `DataFetch` → a live
+// `URLSession`) against a REAL server bound to an OS-assigned port. This is the contract the rest of
+// the suite never exercises — `ServerRequestControllerTests` drives the server in-memory
+// (`app.responder.respond`) and the client is only tested against mocked responses, so a client↔server
+// *content-negotiation* mismatch is invisible to every other test. This harness closes that gap: it
+// sends real bytes over a socket and decodes the real response, so the `Accept`/`Content-Type`
+// contract between `processRequest` and `buildResponse` is actually verified.
+
+import FOSFoundation
+import FOSMVVM
+import FOSMVVMVapor
+import Foundation
+import NIOCore
+import Testing
+import Vapor
+
+@Suite("ServerRequest round-trip (real processRequest ↔ running server)", .serialized)
+struct ServerRequestRoundTripTests {
+    /// A response body carrying real content decodes through the live client — the control case that
+    /// proves this harness drives `DataFetch`/`URLSession` end-to-end (not the in-memory responder).
+    @Test func realBodyResponseRoundTrips() async throws {
+        try await withRunningServer { app in
+            let controller = RoundTripController<ShowMarkerRequest>(actions: [
+                .show: { _, bound in RoundTripMarker(marker: bound.query?.text ?? "<nil>") }
+            ])
+            try app.routes.register(collection: controller)
+        } _: { base in
+            let request = ShowMarkerRequest(query: RoundTripQuery(text: "ahoy"))
+            let response = try await request.processRequest(baseURL: base)
+            #expect(response?.marker == "ahoy")
+        }
+    }
+
+    /// An `EmptyBody` response must round-trip through the real client too. This drives the exact
+    /// header `processRequest(mvvmEnv:)` injects for an `EmptyBody` response — `Accept: text/plain`
+    /// (`ServerRequest+Fetch.swift:122`) — which is what a real consumer sends.
+    ///
+    /// It currently FAILS (`DataFetchError.badResponseMimeType`): `buildResponse` answers
+    /// `application/json` (`EmptyBody` → `{}`) regardless of `Accept`, and `DataFetch.checkMimeType`
+    /// rejects `application/json` against the expected `text/plain`. That is the content-negotiation
+    /// gap (PL-8): one fixed `Accept` for `EmptyBody` cannot satisfy both a `text/plain` (plain REST)
+    /// server and an `application/json` (`buildResponse`) server. The fix should make an `EmptyBody`
+    /// response content-agnostic (on 2xx, decode to `EmptyBody()` without a MIME gate).
+    @Test func emptyBodyResponseRoundTrips() async throws {
+        try await withRunningServer { app in
+            let controller = RoundTripController<EmptyAckRequest>(actions: [
+                .create: { _, _ in EmptyBody() }
+            ])
+            try app.routes.register(collection: controller)
+        } _: { base in
+            let request = EmptyAckRequest(requestBody: EmptyBody())
+            // The `Accept: text/plain` that `processRequest(mvvmEnv:)` adds for an EmptyBody response.
+            try await request.processRequest(
+                baseURL: base,
+                headers: [(field: "Accept", value: "text/plain")]
+            )
+        }
+    }
+
+    /// Probes what `checkReceivedMimeType: false` alone buys us, directly against `DataFetch` (no
+    /// `processRequest`), so the two gates are visible separately:
+    ///   • gate 1 — `checkMimeType`: the flag skips it (no more `badResponseMimeType` at the check).
+    ///   • gate 2 — the decode ladder: still can't turn the server's `{}` body into an `EmptyBody`
+    ///     (no branch yields it), so it throws at the `else`. The flag is necessary, not sufficient.
+    ///   • Requesting `String` (the first decode branch, which decodes ANY 2xx body) closes gate 2.
+    @Test func checkReceivedMimeTypeFalseIsNecessaryButNotSufficientForEmptyBody() async throws {
+        try await withRunningServer { app in
+            let controller = RoundTripController<EmptyAckRequest>(actions: [
+                .create: { _, _ in EmptyBody() }
+            ])
+            try app.routes.register(collection: controller)
+        } _: { base in
+            let url = try EmptyAckRequest(requestBody: EmptyBody()).requestURL(baseURL: base)
+            let fetch = DataFetch<URLSession>.default
+
+            // Flag off the MIME check, but ask for `EmptyBody` → gate 2 still throws.
+            await #expect(throws: (any Error).self) {
+                let _: EmptyBody = try await fetch.send(
+                    data: Data(), to: url, httpMethod: "POST",
+                    headers: [(field: "Accept", value: "text/plain")], locale: nil,
+                    checkReceivedMimeType: false
+                )
+            }
+
+            // Same call, but ask for `String` (decodes any body) → succeeds; the caller would map
+            // the discarded body to `EmptyBody()`.
+            let body: String = try await fetch.send(
+                data: Data(), to: url, httpMethod: "POST",
+                headers: [(field: "Accept", value: "text/plain")], locale: nil,
+                checkReceivedMimeType: false
+            )
+            #expect(body == "{}")
+        }
+    }
+
+    // MARK: - Harness
+
+    /// Boots a real listening `Application` on an OS-assigned port (`127.0.0.1:0`), registers routes
+    /// via `register`, yields the base URL (`http://127.0.0.1:<port>`) to `body`, then tears the
+    /// server down. Localization is initialized so `buildResponse`'s `localizingEncoder` resolves.
+    private func withRunningServer(
+        register: (Application) throws -> Void,
+        _ body: (URL) async throws -> Void
+    ) async throws {
+        let app = try await Application.make(.testing)
+        do {
+            // A stub store so `buildResponse`'s `localizingEncoder` resolves (keys fall back to
+            // default). The live server needs this; the round-trip asserts transport, not localization.
+            app.localizationStore = RoundTripLocalizationStore()
+            try register(app)
+
+            try await app.server.start(address: .hostname("127.0.0.1", port: 0))
+            let port = try #require(
+                app.http.server.shared.localAddress?.port,
+                "Failed to read OS-assigned port after server.start"
+            )
+            let base = try #require(URL(string: "http://127.0.0.1:\(port)"))
+
+            try await body(base)
+
+            await app.server.shutdown()
+            try await app.asyncShutdown()
+        } catch {
+            await app.server.shutdown()
+            try await app.asyncShutdown()
+            throw error
+        }
+    }
+}
+
+// MARK: - Fixtures
+
+/// A no-op `LocalizationStore` so `req.localizingEncoder` resolves on the live server; every key
+/// falls back to its `default`.
+private struct RoundTripLocalizationStore: LocalizationStore {
+    func value(_ key: String, locale: Locale, default defaultValue: Any?, index: Int?) -> Any? {
+        defaultValue
+    }
+}
+
+/// A query carrying a single string, so a `.show` processor can echo it back over the wire.
+private struct RoundTripQuery: ServerRequestQuery {
+    let text: String
+}
+
+/// A marker response body — the processor writes what it observed; the client decodes it off the wire.
+private struct RoundTripMarker: ServerRequestBody {
+    let marker: String
+}
+
+/// A hand-written controller: one processor per action, over any `ServerRequest`.
+private final class RoundTripController<R: ServerRequest>: ServerRequestController, @unchecked Sendable {
+    typealias TRequest = R
+
+    let actions: [ServerRequestAction: ActionProcessor]
+
+    init(actions: [ServerRequestAction: ActionProcessor]) {
+        self.actions = actions
+    }
+}
+
+/// `.show` fixture with a real (`RoundTripMarker`) response body — the control case.
+private final class ShowMarkerRequest: ServerRequest, @unchecked Sendable {
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = RoundTripMarker
+    typealias ResponseError = EmptyError
+
+    var action: ServerRequestAction {
+        .show
+    }
+
+    let query: RoundTripQuery?
+    var responseBody: RoundTripMarker?
+
+    init(query: RoundTripQuery?, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: RoundTripMarker? = nil) {
+        self.query = query
+        self.responseBody = responseBody
+    }
+}
+
+/// `.create` fixture whose `ResponseBody == EmptyBody`: an ack-shaped write (mirrors Harbor's
+/// `AgentTokenRevokeRequest` / `SecretReplaceRequest`), the case the content-negotiation gap breaks.
+private final class EmptyAckRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = EmptyBody
+    typealias ResponseError = EmptyError
+
+    var action: ServerRequestAction {
+        .create
+    }
+
+    let requestBody: EmptyBody?
+    var responseBody: EmptyBody?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: EmptyBody? = nil) {
+        self.requestBody = requestBody
+        self.responseBody = responseBody
+    }
+}

--- a/Tests/FOSNetworkSecurityTests/ServerCertPinningTests.swift
+++ b/Tests/FOSNetworkSecurityTests/ServerCertPinningTests.swift
@@ -1,0 +1,52 @@
+// ServerCertPinningTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The SPKI pin computed over a certificate DER must equal the value derived INDEPENDENTLY by
+// openssl from the same certificate's public key — so the assertion is not circular, and a pin
+// computed here matches one computed by any other RFC-7469 implementation (client or server).
+//
+// Fixture provenance (regenerable):
+//   openssl req -x509 -newkey rsa:2048 -keyout k.pem -out c.pem -days 1 -nodes \
+//       -subj "/CN=harbor-test"
+//   openssl x509 -in c.pem -outform DER -out c.der
+//   base64 -i c.der                                            → certB64
+//   openssl x509 -in c.der -inform DER -pubkey -noout \
+//       | openssl pkey -pubin -outform DER \
+//       | openssl dgst -sha256 -binary | openssl enc -base64   → expectedPin
+
+import FOSNetworkSecurity
+import Foundation
+import Testing
+
+/// A self-signed `CN=harbor-test` certificate (RSA-2048), DER, base64-encoded.
+private let certB64 = """
+MIIDDTCCAfWgAwIBAgIUVqX8ro252adaSXxeIvKKNkcAYFEwDQYJKoZIhvcNAQELBQAwFjEUMBIGA1UEAwwLaGFyYm9yLXRlc3QwHhcNMjYwNjE5MDc1ODMxWhcNMjYwNjIwMDc1ODMxWjAWMRQwEgYDVQQDDAtoYXJib3ItdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOGPqeGOuLC/jxhj3/evHGKSvzdrq1E5m9O1wRWnHwdewFHtK9GuJi7JBXfS3vWPI+vlOe3v7oT0kmXyS2/ZLUM/GNYM+V2ySriWKdMchndPiECYgRP9v1flAI2eEo38d6mskr4TF3cHzySNl5vv0TC5yyWw+VQhr6E2KLi2Q8da0E34E2wUoVcXYW/2kfCewqKz+nLtXSN7rf+Yy30aDRFqbj6yL/+xyaYozJgjLGXpGiIeadFxXKQHT95gjvr9x1KTPTwLfjBTFKGGN2G63ulGmlJ2dD20sFPNTLn1pe2C9wVzm2lL261MYqwNqysU4nSjEp+GdNGIZ5GLwGbO/FkCAwEAAaNTMFEwHQYDVR0OBBYEFI5EsWMyAvDAKgvDfKxcJkv9XXhyMB8GA1UdIwQYMBaAFI5EsWMyAvDAKgvDfKxcJkv9XXhyMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAMRszQ+scO4p/PG1oq7gnlMo4spM/O+yRwBRJBqQJsu0c3Hn2JAFVeZWtHbWNqjvxiy/XToZR1eP7XHj0ojwc5/oXMPF3dF+GBpiigiYAfdXc+8H21b6N5UzMuUk95cIWhDHNwud83Eo1mybDws/Xyj41EmPH5y42O8lR3U3vjBEL8Ry14ggzcwmfr39bGAMTrhrWuwYiGUaq4bth5V1Qen+4ezwVtaFUBbBKOLi6j/1RwzTef0YGGISLouEHmzMDcclX37/F2VzDp4bH0zag5vLvb9zkJjJ/+u0UPxLS++s7dDhqIl6b4cH92qeAaSmZpJ4OgEoFDjJcYuIspDSzm0=
+"""
+
+/// The canonical SPKI pin of `certB64`, computed independently by openssl (see header).
+private let expectedPin = "KbA9PQtIGba3/nsl+0V3boi1Zxi/XV6DGsoTZx6Gveo="
+
+@Test func spkiPinMatchesOpenSSLCanonicalPin() throws {
+    let der = try #require(Data(base64Encoded: certB64))
+    let pin = try ServerCertPinning.spkiPin(ofCertificateDER: der)
+    #expect(pin.base64 == expectedPin)
+}
+
+@Test func spkiPinThrowsOnNonCertificateData() {
+    #expect(throws: (any Error).self) {
+        _ = try ServerCertPinning.spkiPin(ofCertificateDER: Data([0x00, 0x01, 0x02]))
+    }
+}


### PR DESCRIPTION
Bundles three independent client-side changes (kept as three clean commits for review/revert).

### ① `feat` — FOSNetworkSecurity module (`548595a`)
New library for TLS hardening:
- **`SPKIPin`** — RFC 7469 SPKI-SHA256 server-cert pins; survives same-key renewals; opaque, `Codable` as a bare string.
- **`MutualTLS`** — client-side mTLS policy (server pins + optional client identity) wired into a `URLSession`; `clientIdentity == nil` ⇒ server-pinning-only.
- Adds `swift-certificates` + `swift-asn1`; `CryptoKit` on Apple, `Crypto` on Linux. Standalone — nothing imports it yet.

### ② `fix` — EmptyBody responses content-agnostic on fetch (PL-8) (`cd801ab`)
One fixed `Accept` couldn't satisfy both a `text/plain` and an `application/json {}` server. `DataFetch.send` gains `checkReceivedMimeType` (default `true`); the `EmptyBody` path decodes a 2xx body with the MIME gate off and synthesizes `EmptyBody()`. Typed `ResponseError` on non-2xx unchanged. Adds `ServerRequestRoundTripTests` (real server round-trip).

### ③ `feat` — server-hosted localization paths in previews (`9a0f17a`)
`previewHost(serverHostedResourcesPath:)` + `URL.yamlLocalizationStore()` to preview server-localized views against on-disk YAML.

---

Build green; new suites pass (FOSNetworkSecurity ×2, round-trip ×3); `swiftformat` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
