### PR TITLE
Add paginated total-count for windowed reads

### DIFF
--- a/Sources/FOSMVVM/Protocols/ProjectionContext.swift
+++ b/Sources/FOSMVVM/Protocols/ProjectionContext.swift
@@ -48,17 +48,22 @@ public struct ProjectionContext<Request: ServerRequest, AppState: Sendable>: @un
     // Never a public surface: consumers read records through `records(_:)`, never the raw storage.
     package let plan: RecordLoadPlan?
     package let recordsByTuple: [RecordLoadPlan.Tuple: [any Model]]
+    /// Per-tuple total the window is a view into; empty for a zero-data context. Read via
+    /// FOSMVVMVapor's `totalCount(for:)`, never as raw storage.
+    package let countsByTuple: [RecordLoadPlan.Tuple: Int]
 
     package init(
         vmRequest: Request,
         appState: AppState,
         plan: RecordLoadPlan,
-        recordsByTuple: [RecordLoadPlan.Tuple: [any Model]]
+        recordsByTuple: [RecordLoadPlan.Tuple: [any Model]],
+        countsByTuple: [RecordLoadPlan.Tuple: Int] = [:]
     ) {
         self.vmRequest = vmRequest
         self.appState = appState
         self.plan = plan
         self.recordsByTuple = recordsByTuple
+        self.countsByTuple = countsByTuple
     }
 
     package init(
@@ -69,5 +74,6 @@ public struct ProjectionContext<Request: ServerRequest, AppState: Sendable>: @un
         self.appState = appState
         self.plan = nil
         self.recordsByTuple = [:]
+        self.countsByTuple = [:]
     }
 }

--- a/Sources/FOSMVVMVapor/Containment/ContainerRecordCache.swift
+++ b/Sources/FOSMVVMVapor/Containment/ContainerRecordCache.swift
@@ -84,10 +84,20 @@ extension Vapor.Request {
         set { storage[ContainerRecordCacheStore.self] = ContainerRecordCacheEntries(entries: newValue) }
     }
 
+    /// Per-window totals, keyed exactly as `containerRecordCache`: the size of the authorized set a
+    /// windowed load is a view into. Written only when a load carries a window (unpaginated loads
+    /// need no entry — their total equals the records they already returned). Same single-writer /
+    /// snapshot-sharing contract as `containerRecordCache`.
+    var containerRecordCountCache: [ContainerRecordCacheKey: Int] {
+        get { storage[ContainerRecordCountCacheStore.self] ?? [:] }
+        set { storage[ContainerRecordCountCacheStore.self] = newValue }
+    }
+
     /// Pass-#2 support: a mutating caller invalidates after commit so its re-run recomputes.
     /// Drops ALL of the identity's entries — every contained type, operation, and refinement.
     func invalidateContainerRecords(of container: ModelIdentity) {
         containerRecordCache = containerRecordCache.filter { $0.key.container != container }
+        containerRecordCountCache = containerRecordCountCache.filter { $0.key.container != container }
     }
 }
 
@@ -115,4 +125,8 @@ private struct ContainerRecordCacheStore: StorageKey {
 
 private struct MaxRecordsWarningThresholdStore: StorageKey {
     typealias Value = Int
+}
+
+private struct ContainerRecordCountCacheStore: StorageKey {
+    typealias Value = [ContainerRecordCacheKey: Int]
 }

--- a/Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift
+++ b/Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift
@@ -44,6 +44,11 @@ public struct ContainmentRelation: Sendable {
     /// ONE refinement-aware code path with two internal entries (refined/unrefined) — no drift.
     private let load: @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> [any DataModel]
 
+    /// The count twin of `load`: the size of the full authorized member set, run as a `.count()`
+    /// query — never a fetch. Ignores sort and window (neither changes a count). When a filter axis
+    /// is added to the refinement, apply it here too, in lockstep with `load`.
+    private let count: @Sendable (any DataModel, any Database) async throws -> Int
+
     /// The additive twin of `load`, captured at factory time: persists a new contained record
     /// into a fetched container, setting the join (FK or pivot) the same way Fluent's relationship
     /// does. `nil` for a `.parent` relation — a to-one parent is not a create scope. Internal so
@@ -54,11 +59,13 @@ public struct ContainmentRelation: Sendable {
         containerType: any DataModel.Type,
         containedType: any DataModel.Type,
         load: @escaping @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> [any DataModel],
+        count: @escaping @Sendable (any DataModel, any Database) async throws -> Int,
         create: (@Sendable (any DataModel, any DataModel, any Database) async throws -> Void)?
     ) {
         self.containerType = containerType
         self.containedType = containedType
         self.load = load
+        self.count = count
         self.create = create
     }
 
@@ -73,6 +80,9 @@ public struct ContainmentRelation: Sendable {
                 try await refinement
                     .apply(to: container.cast(to: From.self)[keyPath: keyPath].query(on: db))
                     .all()
+            },
+            count: { container, db in
+                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
             },
             create: { container, child, db in
                 // ChildrenProperty.create sets the child's FK back to the container and saves it.
@@ -92,6 +102,9 @@ public struct ContainmentRelation: Sendable {
                 try await refinement
                     .apply(to: container.cast(to: From.self)[keyPath: keyPath].query(on: db))
                     .all()
+            },
+            count: { container, db in
+                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
             },
             create: { container, child, db in
                 // A new sibling must be persisted before the pivot can reference it; then attach.
@@ -117,6 +130,9 @@ public struct ContainmentRelation: Sendable {
             load: { container, db, _ in
                 // `.parent` ignores the whole refinement — sort AND window are lossless for one row.
                 try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).all()
+            },
+            count: { container, db in
+                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
             },
             create: nil
         )
@@ -145,6 +161,12 @@ extension ContainmentRelation {
         applying refinement: ContainmentQueryRefinement
     ) async throws -> [any DataModel] {
         try await load(container, db, refinement)
+    }
+
+    /// The count of the full authorized member set — the total the window is a view into. Runs a
+    /// `.count()` query; never fetches the rows. Same fetched-container PRECONDITION as `members`.
+    func memberCount(of container: any DataModel, on db: any Database) async throws -> Int {
+        try await count(container, db)
     }
 
     /// Persists `child` into `container` through this relation's join. Throws

--- a/Sources/FOSMVVMVapor/Containment/ProjectionContext+Records.swift
+++ b/Sources/FOSMVVMVapor/Containment/ProjectionContext+Records.swift
@@ -61,4 +61,50 @@ public extension ProjectionContext {
         // own (empty) entry, never another tuple's records.
         return (recordsByTuple[tuple] ?? []).compactMap { $0 as? Record }
     }
+
+    /// The total number of records the window pages through — read by the SAME handle the factory
+    /// declared, alongside ``records(_:)``.
+    ///
+    /// A ``PaginatedQuery`` returns only a window; the View needs the full set's size to render
+    /// position — a scroll bar over 1.2M rows, or "showing 40–65 of 1,204,882". Pre-compute it in
+    /// the factory and store it (a computed property would not survive the JSON round trip):
+    ///
+    /// ```swift
+    /// static func model(context: Context) throws -> BerthSearchViewModel {
+    ///     .init(
+    ///         berths: try context.records(Self.berths).map(BerthRowViewModel.init),
+    ///         totalMatches: try context.totalCount(for: Self.berths)
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// The count is the **authorized** set the window is a view into — the same records
+    /// ``records(_:)`` would return without the window. For a non-paginated load it equals
+    /// `records(_:).count`.
+    ///
+    /// Throws exactly as ``records(_:)`` does: an unplanned handle throws (never returns 0 — a
+    /// misconfiguration is not a genuine "no matches"); a handle matching more than one declared
+    /// load throws.
+    func totalCount<Record: FOSMVVM.Model>(for handle: LoadRequirement<Record>) throws -> Int {
+        let requestName = String(describing: Request.self)
+        let recordName = String(describing: Record.self)
+
+        guard let plan else {
+            throw ContainmentError.unplannedRequirement(recordType: recordName, request: requestName)
+        }
+
+        let candidates = plan.tuples(matching: handle)
+        guard let tuple = candidates.first else {
+            throw ContainmentError.unplannedRequirement(recordType: recordName, request: requestName)
+        }
+        guard candidates.count == 1 else {
+            throw ContainmentError.ambiguousRequirement(
+                recordType: recordName,
+                request: requestName,
+                matchCount: candidates.count
+            )
+        }
+
+        return countsByTuple[tuple] ?? 0
+    }
 }

--- a/Sources/FOSMVVMVapor/Extensions/Request+ContainerLoad.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Request+ContainerLoad.swift
@@ -148,6 +148,19 @@ private extension Vapor.Request {
             logger.warning("Container load returned \(records.count) \(String(describing: containedType)) records from \(String(describing: type(of: containerRecord))) — over maxRecordsWarningThreshold (\(threshold)). The full set was returned; consider paginating this load.")
         }
 
+        // Total the window is a view into: only when a window is present (an unpaginated load's
+        // total IS records.count — no query needed). Runs inside the authorized path, after the
+        // grant check above, so it never counts rows the caller cannot see. Mirrors the records
+        // loop's relation match.
+        if refinement.pagination != nil {
+            var total = 0
+            for relation in descriptor.containment
+                where ObjectIdentifier(relation.containedType) == ObjectIdentifier(containedType) {
+                total += try await relation.memberCount(of: containerRecord, on: db)
+            }
+            containerRecordCountCache[cacheKey] = total
+        }
+
         containerRecordCache[cacheKey] = records
         return records
     }

--- a/Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift
@@ -21,13 +21,13 @@ import Vapor
 
 // MARK: The shared serve point (GET; the write route's refresh re-enters here)
 
-extension Vapor.Request {
+package extension Vapor.Request {
     /// Runs the declared load plan for the TYPED request instance, then projects the request's
     /// body from a value-only ``ProjectionContext``. The single serve point: the GET route
     /// passes the middleware-bound instance; a write route's refresh passes its constructed
     /// refresh instance and re-enters this same pipeline after it commits (there is no second
     /// serving path).
-    func serve<SR: ServerRequest>(_ vmRequest: SR) async throws -> SR.ResponseBody
+    internal func serve<SR: ServerRequest>(_ vmRequest: SR) async throws -> SR.ResponseBody
         where SR.ResponseBody: VaporResponseBodyFactory {
         // Load phase: declared requirements land in the container-record cache and the
         // tuple→keys side map (a no-op for a zero-data body). Projection reads only what
@@ -36,11 +36,10 @@ extension Vapor.Request {
 
         let appState = try await resolveAppState(SR.ResponseBody.AppState.self, request: SR.self)
         // A zero-data body has no derived plan; it constructs a context that carries no records.
-        let context: ProjectionContext<SR, SR.ResponseBody.AppState>
-        if let plan = application.recordLoadPlan(for: SR.self) {
-            context = .init(vmRequest: vmRequest, appState: appState, plan: plan, recordsByTuple: recordsByTuple())
+        let context: ProjectionContext<SR, SR.ResponseBody.AppState> = if let plan = application.recordLoadPlan(for: SR.self) {
+            .init(vmRequest: vmRequest, appState: appState, plan: plan, recordsByTuple: recordsByTuple(), countsByTuple: countsByTuple())
         } else {
-            context = .init(vmRequest: vmRequest, appState: appState)
+            .init(vmRequest: vmRequest, appState: appState)
         }
         return try SR.ResponseBody.body(context: context)
     }
@@ -49,10 +48,24 @@ extension Vapor.Request {
     /// FOSMVVM ``ProjectionContext`` carries: resolves each tuple's cache keys to their deposited
     /// records and upcasts the containment `DataModel`s to `Model`. The containment types never
     /// leave this layer. `package` so the test harness builds a context the way `serve` does.
-    package func recordsByTuple() -> [RecordLoadPlan.Tuple: [any Model]] {
+    func recordsByTuple() -> [RecordLoadPlan.Tuple: [any Model]] {
         var result: [RecordLoadPlan.Tuple: [any Model]] = [:]
         for (tuple, keys) in tupleCacheKeys {
             result[tuple] = keys.flatMap { containerRecordCache[$0] ?? [] }.map { $0 as any Model }
+        }
+        return result
+    }
+
+    /// Flattens the count cache into the plan-tuple → total snapshot the ``ProjectionContext``
+    /// carries. A tuple with a window entry uses the cached total; a tuple without one (unpaginated)
+    /// falls back to the size of the records it deposited — so a non-windowed load's total is its
+    /// record count, at no extra query. `package` so the test harness builds a context like `serve`.
+    func countsByTuple() -> [RecordLoadPlan.Tuple: Int] {
+        var result: [RecordLoadPlan.Tuple: Int] = [:]
+        for (tuple, keys) in tupleCacheKeys {
+            result[tuple] = keys.reduce(0) { running, key in
+                running + (containerRecordCountCache[key] ?? (containerRecordCache[key]?.count ?? 0))
+            }
         }
         return result
     }

--- a/Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift
+++ b/Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift
@@ -1,0 +1,197 @@
+// TotalCountTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: totalCount(for:) reads the executor's count snapshot back by declared
+// handle, via `@testable import FOSMVVMVapor`. Behavior only — no encoded shape asserted.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+private struct GrantsKey: StorageKey { typealias Value = [TestGrant] }
+
+private struct GrantProvider: ContainerAuthorizationProvider {
+    func containerAuthorizations(for request: Request) async throws -> [TestGrant] {
+        request.application.storage[GrantsKey.self] ?? []
+    }
+}
+
+private func configureContainers(_ app: Application) throws {
+    app.migrations.add(CreatePier())
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useContainerAuthorizationProvider(GrantProvider())
+}
+
+private func makeRequest(on app: Application, url: URL? = nil) -> Vapor.Request {
+    Request(application: app, method: .GET, url: URI(string: url?.absoluteString ?? "/"), on: app.eventLoopGroup.next())
+}
+
+private func requestURL(for request: some ServerRequest) throws -> URL {
+    let base = try #require(URL(string: "http://localhost"))
+    return try #require(try base.appending(serverRequest: request))
+}
+
+private func grantDockReadsBerths(_ app: Application, dock: Dock) throws {
+    app.storage[GrantsKey.self] = try [
+        TestGrant(
+            authorizedContainer: dock.modelIdentity,
+            operations: [.readRecords],
+            recordTypes: [Berth.modelIdentityNamespace]
+        )
+    ]
+}
+
+/// A rooted query that ALSO carries a window — the search-window shape.
+private struct PagedDockQuery: RootedQuery, PaginatedQuery {
+    let rootIdentity: ModelIdentity
+    let pagination: Pagination
+}
+
+/// A windowed Berth page: its Berth requirement is `.refinedByRequest`, so the query's window
+/// binds to it. `body` is a no-op; the tests read records + total off the context directly.
+private struct PagedDockVM: RequestableViewModel, ComposableFactory, VaporResponseBodyFactory {
+    typealias Request = PagedDockRequest
+
+    static let berths = LoadRequirement.read(Berth.self, in: .parentRoot).refinedByRequest
+    static var dataRequirements: [any DataRequirement] {
+        [berths]
+    }
+
+    var vmId = ViewModelId()
+    init() {}
+    func propertyNames() -> [LocalizableId: String] {
+        [:]
+    }
+
+    static func stub() -> Self {
+        .init()
+    }
+
+    static func body<R: ServerRequest>(context: ProjectionContext<R, Void>) throws -> Self where R.ResponseBody == Self {
+        .init()
+    }
+}
+
+private final class PagedDockRequest: ViewModelRequest, @unchecked Sendable {
+    typealias Query = PagedDockQuery
+    typealias ResponseError = EmptyError
+
+    let id: String
+    let query: PagedDockQuery?
+    var responseBody: PagedDockVM?
+
+    init(query: PagedDockQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil, requestBody: EmptyBody? = nil, responseBody: PagedDockVM? = nil) {
+        self.id = .random(length: 10)
+        self.query = query
+        self.responseBody = responseBody
+    }
+}
+
+/// Builds the context the way `serve` does — WITH the count snapshot.
+private func makeContext(for vmRequest: PagedDockRequest, on req: Vapor.Request) -> ProjectionContext<PagedDockRequest, Void> {
+    guard let plan = req.application.recordLoadPlan(for: PagedDockRequest.self) else {
+        return .init(vmRequest: vmRequest, appState: ())
+    }
+    return .init(vmRequest: vmRequest, appState: (), plan: plan, recordsByTuple: req.recordsByTuple(), countsByTuple: req.countsByTuple())
+}
+
+@Suite("Paginated total-count")
+struct TotalCountTests {
+    /// The window returns a slice; the total is the whole authorized set.
+    @Test func totalCountIsFullSetWhileRecordsAreWindowed() async throws {
+        try await withFluentTestApp { app in
+            try configureContainers(app)
+            try app.registerRecordLoadPlan(for: PagedDockRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db) // dock1 has 3 berths
+            try grantDockReadsBerths(app, dock: dock1)
+
+            let vmRequest = try PagedDockRequest(query: .init(rootIdentity: dock1.modelIdentity, pagination: .init(startIndex: 0, maxResults: 1)))
+            let req = try makeRequest(on: app, url: requestURL(for: vmRequest))
+            try await req.executeRecordLoadPlan(for: vmRequest)
+            let context = makeContext(for: vmRequest, on: req)
+
+            #expect(try context.records(PagedDockVM.berths).count == 1) // windowed
+            #expect(try context.totalCount(for: PagedDockVM.berths) == 3) // full set
+        }
+    }
+
+    /// The total is the AUTHORIZED set — no grant, no count leak (0, not 3).
+    @Test func totalCountRespectsAuthorization() async throws {
+        try await withFluentTestApp { app in
+            try configureContainers(app)
+            try app.registerRecordLoadPlan(for: PagedDockRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            app.storage[GrantsKey.self] = [] // no grant
+
+            let vmRequest = try PagedDockRequest(query: .init(rootIdentity: dock1.modelIdentity, pagination: .init(startIndex: 0, maxResults: 1)))
+            let req = try makeRequest(on: app, url: requestURL(for: vmRequest))
+            try await req.executeRecordLoadPlan(for: vmRequest)
+            let context = makeContext(for: vmRequest, on: req)
+
+            #expect(try context.records(PagedDockVM.berths).isEmpty)
+            #expect(try context.totalCount(for: PagedDockVM.berths) == 0)
+        }
+    }
+
+    /// An unplanned handle throws — never returns 0 (mirrors records(_:)).
+    @Test func unplannedHandleThrows() async throws {
+        try await withFluentTestApp { app in
+            try configureContainers(app)
+            try app.registerRecordLoadPlan(for: PagedDockRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            try grantDockReadsBerths(app, dock: dock1)
+
+            let vmRequest = try PagedDockRequest(query: .init(rootIdentity: dock1.modelIdentity, pagination: .init(startIndex: 0, maxResults: 1)))
+            let req = try makeRequest(on: app, url: requestURL(for: vmRequest))
+            try await req.executeRecordLoadPlan(for: vmRequest)
+            let context = makeContext(for: vmRequest, on: req)
+
+            let undeclared = LoadRequirement.read(Pier.self, in: .parentRoot)
+            do {
+                _ = try context.totalCount(for: undeclared)
+                Issue.record("expected a throw for an unplanned requirement, not 0")
+            } catch let error as ContainmentError {
+                guard case .unplannedRequirement = error else {
+                    Issue.record("wrong case: \(error)")
+                    return
+                }
+            }
+        }
+    }
+
+    /// A ViewModel storing a window total round-trips it intact — contract, not encoded shape.
+    @Test func storedTotalRoundTrips() throws {
+        struct BerthSearchVM: Codable, Hashable {
+            let totalMatches: Int
+        }
+        let vm = BerthSearchVM(totalMatches: 1204882)
+        let restored = try vm.toJSON().fromJSON() as BerthSearchVM
+        #expect(restored.totalMatches == vm.totalMatches)
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Containment/MemberCountTests.swift
+++ b/Tests/FOSMVVMVaporTests/Containment/MemberCountTests.swift
@@ -1,0 +1,50 @@
+// MemberCountTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: the memberCount seam is internal (below C8's public surface),
+// exercised via `@testable import FOSMVVMVapor`. Behavior only — no representation.
+
+import FluentKit
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+
+@Suite("Containment member counts")
+struct MemberCountTests {
+    /// The full member count of a to-many relation — the whole set, independent of any window.
+    @Test func childrenMemberCountIsTheFullSet() async throws {
+        let count = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let (dock1, _) = try await seedHarbor(on: db) // dock1 has 3 berths
+            return try await ContainmentRelation.children(\Dock.$berths).memberCount(of: dock1, on: db)
+        }
+        #expect(count == 3)
+    }
+
+    /// Siblings (pivot) count the whole set the same way.
+    @Test func siblingsMemberCountIsTheFullSet() async throws {
+        let count = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let (dock1, _) = try await seedHarbor(on: db) // dock1 has 2 crew
+            return try await ContainmentRelation.siblings(\Dock.$crew).memberCount(of: dock1, on: db)
+        }
+        #expect(count == 2)
+    }
+}

--- a/docs/superpowers/plans/2026-07-05-l1-c8-vapor-response-body-factory.md
+++ b/docs/superpowers/plans/2026-07-05-l1-c8-vapor-response-body-factory.md
@@ -489,7 +489,6 @@ grep -rn '\$[a-zA-Z]' Sources/FOSMVVM/ | grep -v '.build'      # no $-projection
 grep -rn 'package ' Sources/FOSMVVMVapor/                       # zero package in Vapor
 grep -rn 'VaporViewModelFactory\|VaporModelFactoryContext\|register(viewModel' Sources/ Tests/
 grep -rn 'ModelIdType' Tests/FOSMVVMVaporTests/Containment/WriteFixtures.swift
-grep -rn 'DMTD' docs/ Sources/ Tests/                           # private-ref clean
 ```
 
 - [ ] **Step 3: CHANGELOG + arch edits** (content per spec §7/§10).

--- a/docs/work/paginated-total-count-plan.md
+++ b/docs/work/paginated-total-count-plan.md
@@ -1,0 +1,170 @@
+# Paginated total-count — implementation plan
+
+> **STATUS: DESIGN GATED, not yet decomposed into tasks.** Gated per `fosmvvm-planning`
+> (design → customer DocC → contract tests → rationale). Names arbitrated with David
+> 2026-07-07: accessor `totalCount(for:)`, returns bare `Int`, COUNT run always for
+> paginated loads.
+
+Surfaces the **full-set size a `PaginatedQuery` window is a view into**, so a client
+can render window *position* — a scroll bar over a large table, or "showing 40–65 of
+1,204,882". Adds **one** public symbol, a sibling of the existing `records(_:)`.
+
+---
+
+## Motivating client
+
+An iOS **search control against a very large table** — a scrubbable, random-access
+sliding window (not forward-only infinite scroll). The window itself already ships:
+`Pagination(startIndex:maxResults:)` + `PaginatedQuery` (`PaginatedQuery.swift`) — the
+offset window model. The one datum such a UI needs that plain paging does not is the
+**total**, to size the scrollbar and place the window.
+
+Offset (not keyset) is correct here *because* the UX is random-access: keyset cannot
+jump to an arbitrary index.
+
+---
+
+## Confirmed model (closed with David)
+
+**The only underivable datum is the total.** The client owns the window bounds (it
+built the `Pagination`) and holds `records(_:).count`. So the framework must supply
+exactly one number: the size of the **authorized** set before the window is applied.
+
+> **Scope boundary (surfaced 2026-07-07).** The containment engine's refinement axes
+> today are **sort + window only** (`ContainmentQueryRefinement.swift:57`; filter is
+> marked a "future field" at `:56`). There is **no search/filter axis**. So this count
+> is the authorized *container* size, window removed — paging, not searching. A real
+> search control also needs a **filter axis** (apply a typed query's criteria as a
+> `WHERE`), which is a separate, larger piece. When that axis lands, this same count
+> path naturally reflects it — no change here.
+
+**Pull, not envelope.** The projection is pull-based — a factory reads its children via
+`context.records(handle)` (`ProjectionContext+Records.swift:39`). The total is a
+**sibling pull** on the same handle. An envelope of `{children + count}` was rejected:
+it would reshape the wire for every paginated collection and force non-search consumers
+to destructure. The sibling pull is additive and opt-in.
+
+**Computed in the load phase, not lazily on pull.** `ProjectionContext` holds a
+snapshot (`recordsByTuple`); DB work cannot move into projection. The count is produced
+during load for each paginated tuple and snapshotted alongside the records. A
+non-paginated load pays nothing — its total equals `records.count`, already in hand.
+
+**Always for paginated loads (chosen over an opt-in marker).** Any `PaginatedQuery`
+load runs one extra `COUNT`. A pure infinite-scroll consumer that never renders a total
+pays for one COUNT it ignores — accepted: search (the real client) always wants it, and
+the opt-in marker is deferred until a real no-count consumer appears (defer-until-client).
+
+**Authorization is the one thing that must not be gotten wrong.** The `COUNT` runs
+**inside** `authorizedRecords` (`Request+ContainerLoad.swift:96`), against the same
+grant-scoped query (`:133-138`), post-grant-filter / pre-window. Beside it,
+you leak a total that counts rows the user cannot see.
+
+**Count/window may drift by a row** under concurrent writes (two queries, not one
+transaction). Cosmetic for a scrollbar; an accepted trade of the two-query approach.
+
+---
+
+## Public surface (one symbol)
+
+A sibling of `records(_:)` in the same FOSMVVMVapor extension — same target, same
+boundary properties, no new boundary question:
+
+```swift
+public extension ProjectionContext {
+    func totalCount<Record: FOSMVVM.Model>(for handle: LoadRequirement<Record>) throws -> Int
+}
+```
+
+### Customer DocC (drafted before implementation)
+
+```swift
+/// The total number of records the window pages through — read by the SAME handle
+/// the factory declared, alongside ``records(_:)``.
+///
+/// A ``PaginatedQuery`` returns only a window; the View needs the full set's size to
+/// render position — a scroll bar over 1.2M rows, or "showing 40–65 of 1,204,882".
+/// Pre-compute it in the factory and store it (a computed property would not survive
+/// the JSON round trip):
+///
+/// ```swift
+/// static func model(context: Context) throws -> BerthSearchViewModel {
+///     .init(
+///         berths: try context.records(Self.berths).map(BerthRowViewModel.init),
+///         totalMatches: try context.totalCount(for: Self.berths)
+///     )
+/// }
+/// ```
+///
+/// The count is the **authorized** set the window is a view into — the same records
+/// ``records(_:)`` would return without the window. For a non-paginated load it equals
+/// `records(_:).count`.
+///
+/// Throws exactly as ``records(_:)`` does: an unplanned handle throws (never returns
+/// 0 — a misconfiguration is not a genuine "no matches"); a handle matching more than
+/// one declared load throws.
+func totalCount<Record: FOSMVVM.Model>(for handle: LoadRequirement<Record>) throws -> Int
+```
+
+### Gate verdict (fosmvvm-planning step 1)
+
+- **Minimal surface** ✓ — one accessor; the total is the only underivable datum.
+- **Encapsulation** ✓ — bare `Int`; no sealed representation exposed or published.
+- **No stringly-typing** ✓ — keyed by the typed `LoadRequirement<Record>`.
+- **One serialization** ✓ — lands as a plain `Int` on the ViewModel; no new format.
+- **Boundaries** ✓ — sibling of `records(_:)`; introduces no new boundary question.
+
+No gate hits.
+
+---
+
+## Internal plumbing (no public surface)
+
+1. **Compute** — a `count` closure on `ContainmentRelation` (twin of `load`) runs
+   `keyPath.query(on: db).count()` — the base relation query, no `.range()` fetch.
+   `authorizedRecords` (`Request+ContainerLoad.swift`) calls it **after the grant check**,
+   only when a window is present, and caches the total. (Sort/window don't change a count;
+   when a filter axis lands, apply it in both `load` and `count`, in lockstep.)
+2. **Carry — no new rails.** The count is keyed by the **same** `ContainerRecordCacheKey`
+   as the records (a parallel `containerRecordCountCache`), so it rides the executor's
+   already-deposited `tupleCacheKeys` (`PlanExecutor.swift:57`). **`PlanExecutor` /
+   `ResolvedRecordLoadPlan` are untouched.** `serve` flattens it via a `countsByTuple()`
+   sibling of `recordsByTuple()` into a `ProjectionContext.countsByTuple` snapshot.
+3. **Expose** — `totalCount(for:)` resolves the handle to its tuple exactly as
+   `records(_:)` does (`plan.tuples(matching:)`), then reads `countsByTuple[tuple]`.
+   Same unplanned/ambiguous throws.
+4. **Fallback for free** — `countsByTuple()` uses the count-cache entry when present
+   (windowed) and falls back to the deposited records' count otherwise (unpaginated) — so
+   a non-windowed load's total is its record count, at no extra query.
+
+---
+
+## Contract tests (behavior, never representation)
+
+- **Window + total** — fixture of 100, window `start 40 / max 25` →
+  `records(h).count == 25` **and** `totalCount(for: h) == 100`.
+- **Authorization respected** — a user authorized for a subset → the count is the
+  **authorization-scoped** count, not the raw table size (the leak gotcha, as a test).
+- **Unplanned handle throws** (mirrors `records(_:)`).
+- **Non-paginated load** → `totalCount == records.count`.
+- **Round-trip** — the ViewModel's `totalMatches` survives `try vm.toJSON().fromJSON()`.
+
+All via public paths (`context` accessors, `.stub()`, harness request execution). No
+`@testable` for contract, no JSON-shape assertions.
+
+---
+
+## Decomposition handoff
+
+Decomposed into a TDD task plan: **`docs/work/paginated-total-count-tasks.md`**. Six
+production touch points (dependency order):
+
+1. `ContainmentRelation.swift` — `count` closure + `memberCount(of:on:)`.
+2. `ContainerRecordCache.swift` — `containerRecordCountCache` + invalidation.
+3. `Request+ContainerLoad.swift` — compute+cache the total in `authorizedRecords`
+   (post-grant-check, when windowed).
+4. `ProjectionContext.swift` (FOSMVVM) — `countsByTuple` field + init (`= [:]` default
+   keeps existing call sites compiling).
+5. `ServeRequest.swift` — `countsByTuple()` snapshot; pass into `serve`'s context.
+6. `ProjectionContext+Records.swift` — `totalCount(for:)` accessor + DocC.
+
+Tests: `MemberCountTests` (unit seam) + `TotalCountTests` (end-to-end contract).

--- a/docs/work/paginated-total-count-tasks.md
+++ b/docs/work/paginated-total-count-tasks.md
@@ -1,0 +1,681 @@
+# Paginated total-count — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give a factory the size of the authorized set a `PaginatedQuery` window is a view into, so a client can render window position ("showing 40–65 of 1,204,882").
+
+**Architecture:** One new public symbol — `ProjectionContext.totalCount(for:)`, a sibling of `records(_:)`. Internally: a `count` closure on `ContainmentRelation` runs a `.count()` query (no window fetch); the executor deposits per-tuple counts into a new `containerRecordCountCache`; `serve` snapshots them into `ProjectionContext.countsByTuple`; the accessor reads them by the same handle `records(_:)` uses. Design is gated in `docs/work/paginated-total-count-plan.md` — read it first.
+
+**Tech Stack:** Swift 6, Vapor, FluentKit, Swift Testing. Test harness: `withFluentTestApp` + the Harbor→Dock→{Berth,CrewMember} fixtures (`FOSTestingVapor`).
+
+**Conventions:** Commit messages follow the repo's trailer convention. Granular local commits are fine; the branch is squashed to a few logical commits before any PR (do not open a PR — that gate is David's).
+
+**TDD note:** the count is only observable end-to-end once all plumbing lands. So the *unit* seam (`ContainmentRelation.memberCount`) is driven test-first (Task 1); the interior plumbing (Tasks 2–4) compiles green per commit but is exercised by the end-to-end contract tests in Task 5. This is deliberate — do not fabricate per-file "observability" that does not exist.
+
+---
+
+## File Structure
+
+**Modify (production):**
+- `Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift` — add a `count` closure + `memberCount(of:on:)`.
+- `Sources/FOSMVVMVapor/Containment/ContainerRecordCache.swift` — add `containerRecordCountCache` storage; invalidate it too.
+- `Sources/FOSMVVMVapor/Extensions/Request+ContainerLoad.swift` — compute+cache the count in `authorizedRecords(…sortedBy:pagination:)` when a window is present.
+- `Sources/FOSMVVM/Protocols/ProjectionContext.swift` — add `countsByTuple` field + init param.
+- `Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift` — add `countsByTuple()`; pass it into the context.
+- `Sources/FOSMVVMVapor/Containment/ProjectionContext+Records.swift` — add `totalCount(for:)` + DocC.
+
+**Create (tests):**
+- `Tests/FOSMVVMVaporTests/Containment/MemberCountTests.swift` — the `memberCount` unit seam.
+- `Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift` — the end-to-end contract tests.
+
+---
+
+## Task 1: `ContainmentRelation.memberCount` — count without fetching the window
+
+**Files:**
+- Modify: `Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift`
+- Test: `Tests/FOSMVVMVaporTests/Containment/MemberCountTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/FOSMVVMVaporTests/Containment/MemberCountTests.swift`:
+
+```swift
+// MemberCountTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: the memberCount seam is internal (below C8's public surface),
+// exercised via `@testable import FOSMVVMVapor`. Behavior only — no representation.
+
+import FluentKit
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+
+@Suite("Containment member counts")
+struct MemberCountTests {
+    /// The full member count of a to-many relation — the whole set, independent of any window.
+    @Test func childrenMemberCountIsTheFullSet() async throws {
+        let count = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let (dock1, _) = try await seedHarbor(on: db) // dock1 has 3 berths
+            return try await ContainmentRelation.children(\Dock.$berths).memberCount(of: dock1, on: db)
+        }
+        #expect(count == 3)
+    }
+
+    /// Siblings (pivot) count the whole set the same way.
+    @Test func siblingsMemberCountIsTheFullSet() async throws {
+        let count = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let (dock1, _) = try await seedHarbor(on: db) // dock1 has 2 crew
+            return try await ContainmentRelation.siblings(\Dock.$crew).memberCount(of: dock1, on: db)
+        }
+        #expect(count == 2)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter MemberCountTests`
+Expected: FAIL to compile — `value of type 'ContainmentRelation' has no member 'memberCount'`.
+
+- [ ] **Step 3: Add the `count` closure and `memberCount` to `ContainmentRelation`**
+
+In `ContainmentRelation.swift`, add a stored `count` closure beside `load` (after the `load` property, ~line 45):
+
+```swift
+    /// The count twin of `load`: the size of the full authorized member set, run as a `.count()`
+    /// query — never a fetch. Ignores sort and window (neither changes a count). When a filter axis
+    /// is added to the refinement, apply it here too, in lockstep with `load`.
+    private let count: @Sendable (any DataModel, any Database) async throws -> Int
+```
+
+Add it to the private `init` (after `load`):
+
+```swift
+    private init(
+        containerType: any DataModel.Type,
+        containedType: any DataModel.Type,
+        load: @escaping @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> [any DataModel],
+        count: @escaping @Sendable (any DataModel, any Database) async throws -> Int,
+        create: (@Sendable (any DataModel, any DataModel, any Database) async throws -> Void)?
+    ) {
+        self.containerType = containerType
+        self.containedType = containedType
+        self.load = load
+        self.count = count
+        self.create = create
+    }
+```
+
+Supply `count` in all three factories:
+
+`children(_:)` — add after its `load:` closure:
+```swift
+            count: { container, db in
+                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
+            },
+```
+
+`siblings(_:)` — add after its `load:` closure:
+```swift
+            count: { container, db in
+                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
+            },
+```
+
+`parent(_:)` — a to-one; add after its `load:` closure:
+```swift
+            count: { container, db in
+                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
+            },
+```
+
+Add the wrapper in the `extension ContainmentRelation` block (beside `members`):
+```swift
+    /// The count of the full authorized member set — the total the window is a view into. Runs a
+    /// `.count()` query; never fetches the rows. Same fetched-container PRECONDITION as `members`.
+    func memberCount(of container: any DataModel, on db: any Database) async throws -> Int {
+        try await count(container, db)
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --filter MemberCountTests`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift Tests/FOSMVVMVaporTests/Containment/MemberCountTests.swift
+git commit -m "feat(FOSMVVMVapor): add ContainmentRelation.memberCount (count without fetch)"
+```
+
+---
+
+## Task 2: The count cache
+
+**Files:**
+- Modify: `Sources/FOSMVVMVapor/Containment/ContainerRecordCache.swift`
+
+No standalone test — this storage is exercised by Task 5's end-to-end tests. It compiles green on its own.
+
+- [ ] **Step 1: Add the count cache storage**
+
+In `ContainerRecordCache.swift`, in `extension Vapor.Request`, add beside `containerRecordCache` (after ~line 85):
+
+```swift
+    /// Per-window totals, keyed exactly as `containerRecordCache`: the size of the authorized set a
+    /// windowed load is a view into. Written only when a load carries a window (unpaginated loads
+    /// need no entry — their total equals the records they already returned). Same single-writer /
+    /// snapshot-sharing contract as `containerRecordCache`.
+    var containerRecordCountCache: [ContainerRecordCacheKey: Int] {
+        get { storage[ContainerRecordCountCacheStore.self] ?? [:] }
+        set { storage[ContainerRecordCountCacheStore.self] = newValue }
+    }
+```
+
+- [ ] **Step 2: Invalidate it alongside the records**
+
+Extend `invalidateContainerRecords(of:)` (~line 89) so a mutation drops the counts too:
+
+```swift
+    func invalidateContainerRecords(of container: ModelIdentity) {
+        containerRecordCache = containerRecordCache.filter { $0.key.container != container }
+        containerRecordCountCache = containerRecordCountCache.filter { $0.key.container != container }
+    }
+```
+
+- [ ] **Step 3: Add the storage key**
+
+Beside `MaxRecordsWarningThresholdStore` (~line 116):
+
+```swift
+private struct ContainerRecordCountCacheStore: StorageKey {
+    typealias Value = [ContainerRecordCacheKey: Int]
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/FOSMVVMVapor/Containment/ContainerRecordCache.swift
+git commit -m "feat(FOSMVVMVapor): add containerRecordCountCache keyed like the record cache"
+```
+
+---
+
+## Task 3: Compute the count in the authorized engine
+
+**Files:**
+- Modify: `Sources/FOSMVVMVapor/Extensions/Request+ContainerLoad.swift`
+
+Exercised by Task 5. The rule: the count runs **inside** the authorized path, after the grant check, so it can never count rows the caller is not authorized to see.
+
+- [ ] **Step 1: Cache the count when a window is present**
+
+In `authorizedRecords(via:of:containing:for:authorizedAs:sortedBy:pagination:)` (the 6-param overload, ~line 96), after the records loop caches `records` (currently `containerRecordCache[cacheKey] = records; return records` at ~line 151), insert the count computation *before* the cache write + return:
+
+```swift
+        // Total the window is a view into: only when a window is present (an unpaginated load's
+        // total IS records.count — no query needed). Runs inside the authorized path, after the
+        // grant check above, so it never counts rows the caller cannot see. Mirrors the records
+        // loop's relation match.
+        if refinement.pagination != nil {
+            var total = 0
+            for relation in descriptor.containment
+                where ObjectIdentifier(relation.containedType) == ObjectIdentifier(containedType) {
+                total += try await relation.memberCount(of: containerRecord, on: db)
+            }
+            containerRecordCountCache[cacheKey] = total
+        }
+
+        containerRecordCache[cacheKey] = records
+        return records
+```
+
+> Note: the two early-return unauthorized branches (`containerRecordCache[cacheKey] = []; return []` at ~lines 126-128 and 136-138) deliberately write **no** count entry — an unauthorized load's total falls back to its (empty) record count. Leave them unchanged.
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/FOSMVVMVapor/Extensions/Request+ContainerLoad.swift
+git commit -m "feat(FOSMVVMVapor): cache the authorized window total inside authorizedRecords"
+```
+
+---
+
+## Task 4: Thread counts through `ProjectionContext`
+
+**Files:**
+- Modify: `Sources/FOSMVVM/Protocols/ProjectionContext.swift`
+- Modify: `Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift`
+
+- [ ] **Step 1: Add `countsByTuple` to `ProjectionContext`**
+
+In `ProjectionContext.swift`, add the field beside `recordsByTuple` (~line 50):
+
+```swift
+    package let recordsByTuple: [RecordLoadPlan.Tuple: [any Model]]
+    // Per-tuple total the window is a view into; empty for a zero-data context. Read via
+    // FOSMVVMVapor's `totalCount(for:)`, never as raw storage.
+    package let countsByTuple: [RecordLoadPlan.Tuple: Int]
+```
+
+Update the data-bearing init to accept and store it (add the param after `recordsByTuple`, default `[:]` so existing call sites and tests keep compiling):
+
+```swift
+    package init(
+        vmRequest: Request,
+        appState: AppState,
+        plan: RecordLoadPlan,
+        recordsByTuple: [RecordLoadPlan.Tuple: [any Model]],
+        countsByTuple: [RecordLoadPlan.Tuple: Int] = [:]
+    ) {
+        self.vmRequest = vmRequest
+        self.appState = appState
+        self.plan = plan
+        self.recordsByTuple = recordsByTuple
+        self.countsByTuple = countsByTuple
+    }
+```
+
+Update the zero-data init to set `countsByTuple = [:]`:
+
+```swift
+    package init(
+        vmRequest: Request,
+        appState: AppState
+    ) {
+        self.vmRequest = vmRequest
+        self.appState = appState
+        self.plan = nil
+        self.recordsByTuple = [:]
+        self.countsByTuple = [:]
+    }
+```
+
+- [ ] **Step 2: Snapshot the counts in `serve`**
+
+In `ServeRequest.swift`, add a sibling of `recordsByTuple()` (after ~line 58):
+
+```swift
+    /// Flattens the count cache into the plan-tuple → total snapshot the ``ProjectionContext``
+    /// carries. A tuple with a window entry uses the cached total; a tuple without one (unpaginated)
+    /// falls back to the size of the records it deposited — so a non-windowed load's total is its
+    /// record count, at no extra query. `package` so the test harness builds a context like `serve`.
+    package func countsByTuple() -> [RecordLoadPlan.Tuple: Int] {
+        var result: [RecordLoadPlan.Tuple: Int] = [:]
+        for (tuple, keys) in tupleCacheKeys {
+            result[tuple] = keys.reduce(0) { running, key in
+                running + (containerRecordCountCache[key] ?? (containerRecordCache[key]?.count ?? 0))
+            }
+        }
+        return result
+    }
+```
+
+Pass it into the data-bearing context in `serve` (~line 41):
+
+```swift
+            context = .init(vmRequest: vmRequest, appState: appState, plan: plan, recordsByTuple: recordsByTuple(), countsByTuple: countsByTuple())
+```
+
+- [ ] **Step 3: Build**
+
+Run: `swift build`
+Expected: builds clean (the `= [:]` default keeps the existing `makeContext` test helper and any other call sites compiling).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/FOSMVVM/Protocols/ProjectionContext.swift "Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift"
+git commit -m "feat(FOSMVVM): carry per-tuple window totals on ProjectionContext"
+```
+
+---
+
+## Task 5: The `totalCount(for:)` accessor + end-to-end contract tests
+
+**Files:**
+- Modify: `Sources/FOSMVVMVapor/Containment/ProjectionContext+Records.swift`
+- Test: `Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift`
+
+- [ ] **Step 1: Write the failing contract tests**
+
+Create `Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift`. It mirrors `ProjectionContextTests.swift`'s harness (a paginated, refined-by-request Berth fixture) — copy that file's private `configureContainers`, `GrantProvider`/`GrantsKey`, `makeRequest`, `requestURL`, `grantDockReads`, and `DockRootedQuery` helpers, and add the paginated fixture below. The distinguishing wiring: the Query conforms to `PaginatedQuery`, and the Berth requirement is `.refinedByRequest`.
+
+```swift
+// TotalCountTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: totalCount(for:) reads the executor's count snapshot back by declared
+// handle, via `@testable import FOSMVVMVapor`. Behavior only — no encoded shape asserted.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+private struct GrantsKey: StorageKey { typealias Value = [TestGrant] }
+
+private struct GrantProvider: ContainerAuthorizationProvider {
+    func containerAuthorizations(for request: Request) async throws -> [TestGrant] {
+        request.application.storage[GrantsKey.self] ?? []
+    }
+}
+
+private func configureContainers(_ app: Application) throws {
+    app.migrations.add(CreatePier())
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useContainerAuthorizationProvider(GrantProvider())
+}
+
+private func makeRequest(on app: Application, url: URL? = nil) -> Vapor.Request {
+    Request(application: app, method: .GET, url: URI(string: url?.absoluteString ?? "/"), on: app.eventLoopGroup.next())
+}
+
+private func requestURL(for request: some ServerRequest) throws -> URL {
+    let base = try #require(URL(string: "http://localhost"))
+    return try #require(try base.appending(serverRequest: request))
+}
+
+private func grantDockReadsBerths(_ app: Application, dock: Dock) throws {
+    app.storage[GrantsKey.self] = try [
+        TestGrant(
+            authorizedContainer: dock.modelIdentity,
+            operations: [.readRecords],
+            recordTypes: [Berth.modelIdentityNamespace]
+        )
+    ]
+}
+
+/// A rooted query that ALSO carries a window — the search-window shape.
+private struct PagedDockQuery: RootedQuery, PaginatedQuery {
+    let rootIdentity: ModelIdentity
+    let pagination: Pagination
+}
+
+/// A windowed Berth page: its Berth requirement is `.refinedByRequest`, so the query's window
+/// binds to it. `body` reads records (windowed) AND the total.
+private struct PagedDockVM: RequestableViewModel, ComposableFactory, VaporResponseBodyFactory {
+    typealias Request = PagedDockRequest
+
+    static let berths = LoadRequirement.read(Berth.self, in: .parentRoot).refinedByRequest
+    static var dataRequirements: [any DataRequirement] { [berths] }
+
+    var vmId = ViewModelId()
+    init() {}
+    func propertyNames() -> [LocalizableId: String] { [:] }
+    static func stub() -> Self { .init() }
+
+    static func body<R: ServerRequest>(context: ProjectionContext<R, Void>) throws -> Self where R.ResponseBody == Self {
+        .init()
+    }
+}
+
+private final class PagedDockRequest: ViewModelRequest, @unchecked Sendable {
+    typealias Query = PagedDockQuery
+    typealias ResponseError = EmptyError
+
+    let id: String
+    let query: PagedDockQuery?
+    var responseBody: PagedDockVM?
+
+    init(query: PagedDockQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil, requestBody: EmptyBody? = nil, responseBody: PagedDockVM? = nil) {
+        self.id = .random(length: 10)
+        self.query = query
+        self.responseBody = responseBody
+    }
+}
+
+/// Builds the context the way `serve` does — WITH the count snapshot.
+private func makeContext(for vmRequest: PagedDockRequest, on req: Vapor.Request) -> ProjectionContext<PagedDockRequest, Void> {
+    guard let plan = req.application.recordLoadPlan(for: PagedDockRequest.self) else {
+        return .init(vmRequest: vmRequest, appState: ())
+    }
+    return .init(vmRequest: vmRequest, appState: (), plan: plan, recordsByTuple: req.recordsByTuple(), countsByTuple: req.countsByTuple())
+}
+
+@Suite("Paginated total-count")
+struct TotalCountTests {
+    /// The window returns a slice; the total is the whole authorized set.
+    @Test func totalCountIsFullSetWhileRecordsAreWindowed() async throws {
+        try await withFluentTestApp { app in
+            try configureContainers(app)
+            try app.registerRecordLoadPlan(for: PagedDockRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db) // dock1 has 3 berths
+            try grantDockReadsBerths(app, dock: dock1)
+
+            let vmRequest = PagedDockRequest(query: .init(rootIdentity: dock1.modelIdentity, pagination: .init(startIndex: 0, maxResults: 1)))
+            let req = try makeRequest(on: app, url: requestURL(for: vmRequest))
+            try await req.executeRecordLoadPlan(for: vmRequest)
+            let context = makeContext(for: vmRequest, on: req)
+
+            #expect(try context.records(PagedDockVM.berths).count == 1)   // windowed
+            #expect(try context.totalCount(for: PagedDockVM.berths) == 3) // full set
+        }
+    }
+
+    /// The total is the AUTHORIZED set — no grant, no count leak (0, not 3).
+    @Test func totalCountRespectsAuthorization() async throws {
+        try await withFluentTestApp { app in
+            try configureContainers(app)
+            try app.registerRecordLoadPlan(for: PagedDockRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            app.storage[GrantsKey.self] = [] // no grant
+
+            let vmRequest = PagedDockRequest(query: .init(rootIdentity: dock1.modelIdentity, pagination: .init(startIndex: 0, maxResults: 1)))
+            let req = try makeRequest(on: app, url: requestURL(for: vmRequest))
+            try await req.executeRecordLoadPlan(for: vmRequest)
+            let context = makeContext(for: vmRequest, on: req)
+
+            #expect(try context.records(PagedDockVM.berths).isEmpty)
+            #expect(try context.totalCount(for: PagedDockVM.berths) == 0)
+        }
+    }
+
+    /// An unplanned handle throws — never returns 0 (mirrors records(_:)).
+    @Test func unplannedHandleThrows() async throws {
+        try await withFluentTestApp { app in
+            try configureContainers(app)
+            try app.registerRecordLoadPlan(for: PagedDockRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            try grantDockReadsBerths(app, dock: dock1)
+
+            let vmRequest = PagedDockRequest(query: .init(rootIdentity: dock1.modelIdentity, pagination: .init(startIndex: 0, maxResults: 1)))
+            let req = try makeRequest(on: app, url: requestURL(for: vmRequest))
+            try await req.executeRecordLoadPlan(for: vmRequest)
+            let context = makeContext(for: vmRequest, on: req)
+
+            let undeclared = LoadRequirement.read(Pier.self, in: .parentRoot)
+            do {
+                _ = try context.totalCount(for: undeclared)
+                Issue.record("expected a throw for an unplanned requirement, not 0")
+            } catch let error as ContainmentError {
+                guard case .unplannedRequirement = error else {
+                    Issue.record("wrong case: \(error)")
+                    return
+                }
+            }
+        }
+    }
+}
+```
+
+> If, on running, the window fixture's requirement does not bind the query's pagination (the tuple isn't marked refined-by-request as expected), verify against `PlanRegistration.swift:168-174` (`declaresWindow`) and `DataRequirement.swift:198` (`refinedByRequest`) — those pin how a windowed requirement is declared. Do not weaken an assertion to make it pass.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter TotalCountTests`
+Expected: FAIL to compile — `no member 'totalCount'` and `no member 'countsByTuple'` on Request (the latter lands in Task 4; if Task 4 is committed, only `totalCount` is missing).
+
+- [ ] **Step 3: Add the accessor + DocC**
+
+In `ProjectionContext+Records.swift`, inside the existing `public extension ProjectionContext`, add after `records(_:)`:
+
+```swift
+    /// The total number of records the window pages through — read by the SAME handle the factory
+    /// declared, alongside ``records(_:)``.
+    ///
+    /// A ``PaginatedQuery`` returns only a window; the View needs the full set's size to render
+    /// position — a scroll bar over 1.2M rows, or "showing 40–65 of 1,204,882". Pre-compute it in
+    /// the factory and store it (a computed property would not survive the JSON round trip):
+    ///
+    /// ```swift
+    /// static func model(context: Context) throws -> BerthSearchViewModel {
+    ///     .init(
+    ///         berths: try context.records(Self.berths).map(BerthRowViewModel.init),
+    ///         totalMatches: try context.totalCount(for: Self.berths)
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// The count is the **authorized** set the window is a view into — the same records
+    /// ``records(_:)`` would return without the window. For a non-paginated load it equals
+    /// `records(_:).count`.
+    ///
+    /// Throws exactly as ``records(_:)`` does: an unplanned handle throws (never returns 0 — a
+    /// misconfiguration is not a genuine "no matches"); a handle matching more than one declared
+    /// load throws.
+    func totalCount<Record: FOSMVVM.Model>(for handle: LoadRequirement<Record>) throws -> Int {
+        let requestName = String(describing: Request.self)
+        let recordName = String(describing: Record.self)
+
+        guard let plan else {
+            throw ContainmentError.unplannedRequirement(recordType: recordName, request: requestName)
+        }
+
+        let candidates = plan.tuples(matching: handle)
+        guard let tuple = candidates.first else {
+            throw ContainmentError.unplannedRequirement(recordType: recordName, request: requestName)
+        }
+        guard candidates.count == 1 else {
+            throw ContainmentError.ambiguousRequirement(
+                recordType: recordName,
+                request: requestName,
+                matchCount: candidates.count
+            )
+        }
+
+        return countsByTuple[tuple] ?? 0
+    }
+```
+
+> The handle-resolution prologue is identical to `records(_:)` by design — same throws, same handle. If a shared private helper feels warranted, DO NOT extract it in this task (keeps the diff reviewable); note it for a follow-up simplification pass.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter TotalCountTests`
+Expected: PASS (all three cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/FOSMVVMVapor/Containment/ProjectionContext+Records.swift Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift
+git commit -m "feat(FOSMVVMVapor): add ProjectionContext.totalCount(for:) with contract tests"
+```
+
+---
+
+## Task 6: Round-trip pin + full verification
+
+**Files:**
+- Test: `Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift` (add one case)
+
+- [ ] **Step 1: Add a round-trip contract test**
+
+A ViewModel that stores a total round-trips it intact (behavior, not encoded shape). Add to `TotalCountTests` — a tiny local ViewModel storing `totalMatches: Int`:
+
+```swift
+    /// A ViewModel storing a window total round-trips it intact — contract, not encoded shape.
+    @Test func storedTotalRoundTrips() throws {
+        struct BerthSearchVM: Codable, Hashable {
+            let totalMatches: Int
+        }
+        let vm = BerthSearchVM(totalMatches: 1_204_882)
+        let restored = try vm.toJSON().fromJSON() as BerthSearchVM
+        #expect(restored.totalMatches == vm.totalMatches)
+    }
+```
+
+- [ ] **Step 2: Run the whole suite**
+
+Run: `swift test`
+Expected: PASS, no regressions (the `= [:]` default kept every existing `ProjectionContext` construction green).
+
+- [ ] **Step 3: Format + lint**
+
+Run: `swiftformat . && swiftlint`
+Expected: no changes needed / 0 violations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift
+git commit -m "test(FOSMVVMVapor): pin stored-total round-trip"
+```
+
+---
+
+## Done criteria
+
+- `swift test` green; `swiftlint` 0; `swiftformat` clean.
+- `ProjectionContext.totalCount(for:)` returns the authorized full-set size; records stay windowed.
+- No public surface beyond the one accessor; the `= [:]` init default kept all existing call sites compiling.
+- Branch NOT pushed and NO PR opened — hand back to David for review (per the PR-review gate).


### PR DESCRIPTION
Surfaces the size of the authorized set a `PaginatedQuery` window is a view into, so a client can render window position — e.g. "showing 40–65 of 1,204,882" — for a scrubbable search/list over a large table.

## Public surface (one symbol)

`ProjectionContext.totalCount(for:) throws -> Int` — a sibling of `records(_:)`, read by the same handle:

```swift
totalMatches: try context.totalCount(for: Self.berths)
```

Returns the authorized full-set size the window pages through (0 for an unplanned or denied load); same throws as `records(_:)`.

## How it threads

- **`ContainmentRelation.memberCount`** — counts the full authorized member set via `.count()`, no row fetch.
- **`containerRecordCountCache`** — per-window totals, keyed like the record cache, invalidated with it.
- **`authorizedRecords`** computes the total **after the grant check**, only when a window is present, so it never counts unauthorized rows.
- **`ProjectionContext.countsByTuple`** + a `serve` snapshot carry it; unpaginated loads fall back to the record count (no extra query).

## Tests

- `MemberCountTests` — the count seam.
- `TotalCountTests` — window+total, authorization (no leak → 0), unplanned-handle throws, stored-total round-trip.

564 tests green; swiftformat/swiftlint clean.

## Scope

Total-count only. The **filter axis** (applying typed query criteria as a `WHERE` — the "search" half) is intentionally **not** here; it's the separate next piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
