### PR TITLE
Add query-driven filtering for windowed container loads

### DIFF
--- a/Sources/FOSMVVMVapor/Containment/ContainerRecordCache.swift
+++ b/Sources/FOSMVVMVapor/Containment/ContainerRecordCache.swift
@@ -57,14 +57,15 @@ struct ContainerRecordCacheKey: Hashable, Sendable {
         for operation: ContainerOperation,
         authorizedAs anchor: ModelIdentity?,
         sortedBy sortTerms: [AnySortTerm],
-        pagination: Pagination?
+        pagination: Pagination?,
+        filter: AnyFilter?
     ) -> ContainerRecordCacheKey {
         .init(
             container: container,
             containedType: containedType,
             operation: operation,
             authorizedAs: anchor,
-            refinement: .normalized(sortTerms: sortTerms, pagination: pagination)
+            refinement: .normalized(sortTerms: sortTerms, pagination: pagination, filter: filter)
         )
     }
 }
@@ -77,7 +78,7 @@ extension Vapor.Request {
     /// CONTRACT (snapshot sharing): cached elements are shared class references — readers
     /// (projections) must NOT mutate them; only the write path mutates records, and after commit
     /// it calls invalidateContainerRecords(of:).
-    /// The engine (authorizedRecords(via:of:containing:for:authorizedAs:sortedBy:pagination:))
+    /// The engine (authorizedRecords(via:of:containing:for:authorizedAs:sortedBy:pagination:filter:))
     /// is the cache's ONLY writer; everything else reads or invalidates.
     var containerRecordCache: [ContainerRecordCacheKey: [any DataModel]] {
         get { storage[ContainerRecordCacheStore.self]?.entries ?? [:] }

--- a/Sources/FOSMVVMVapor/Containment/ContainmentQueryRefinement.swift
+++ b/Sources/FOSMVVMVapor/Containment/ContainmentQueryRefinement.swift
@@ -51,19 +51,45 @@ extension SortCriteria {
     }
 }
 
+/// The erased request query — the load's filter — crossing the engine/refinement/cache seams. A
+/// query IS a filter (selecting records is what a query does), so this simply erases the request's
+/// `ServerRequestQuery`; there is no separate filter type. `Any` prefix per Swift's meaning-preserving
+/// erased-wrapper convention (AnyHashable/AnyView). The stored value keeps its dynamic type for the
+/// downcast to To.Filter inside the relation's closure.
+struct AnyFilter: Hashable, Sendable {
+    /// No `& Sendable` on the stored existential: ServerRequestQuery itself refines Sendable.
+    let value: any ServerRequestQuery // downcast to To.Filter inside the typed closure
+
+    init(_ query: some ServerRequestQuery) {
+        self.value = query
+    }
+
+    /// MANUAL Hashable: `any ServerRequestQuery` can't drive synthesis. AnyHashable carries both the
+    /// value and its dynamic type, so filters are equal iff query type and value match.
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        AnyHashable(lhs.value) == AnyHashable(rhs.value)
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(AnyHashable(value))
+    }
+}
+
 /// The erased load instructions the engine hands a ContainmentRelation (which alone knows `To`).
-/// Hashable so the CACHE KEYS ON THE WHOLE VALUE — additive future fields (filter, eager-loads) join
-/// the key automatically and can never resurrect the OQ-L1-4 collision.
+/// Hashable so the CACHE KEYS ON THE WHOLE VALUE — the filter (and any future eager-loads) join the
+/// key automatically and can never resurrect the OQ-L1-4 collision.
 struct ContainmentQueryRefinement: Hashable, Sendable {
     var sortTerms: [AnySortTerm]
     var pagination: Pagination?
+    var filter: AnyFilter?
 
     /// Empty — the unrefined path's value (C4's members(of:on:) forwards this).
     static let none = ContainmentQueryRefinement()
 
-    init(sortTerms: [AnySortTerm] = [], pagination: Pagination? = nil) {
+    init(sortTerms: [AnySortTerm] = [], pagination: Pagination? = nil, filter: AnyFilter? = nil) {
         self.sortTerms = sortTerms
         self.pagination = pagination
+        self.filter = filter
     }
 
     /// The refinement the engine actually applies (and keys the cache on) for raw request
@@ -73,7 +99,7 @@ struct ContainmentQueryRefinement: Hashable, Sendable {
     /// deliberately an empty page (not "absent") — a boundary guard, never silent truncation
     /// of valid input. The ONE normalization point: the engine's deposit and the executor's
     /// key reconstruction both go through it (via `ContainerRecordCacheKey.forLoad`).
-    static func normalized(sortTerms: [AnySortTerm], pagination: Pagination?) -> ContainmentQueryRefinement {
+    static func normalized(sortTerms: [AnySortTerm], pagination: Pagination?, filter: AnyFilter?) -> ContainmentQueryRefinement {
         .init(
             sortTerms: sortTerms,
             pagination: pagination.flatMap { window in
@@ -82,17 +108,20 @@ struct ContainmentQueryRefinement: Hashable, Sendable {
                 return startIndex == nil && maxResults == nil
                     ? nil
                     : Pagination(startIndex: startIndex, maxResults: maxResults)
-            }
+            },
+            filter: filter
         )
     }
 }
 
 extension ContainmentQueryRefinement {
-    /// Push-down application, called inside a relation's typed closure before `.all()`: sort via
-    /// To's SortableDataModel mappings (in term order), then the window via QueryBuilder.range.
-    /// Sort terms against a non-sortable To fail fast — NEVER a silently unsorted result.
+    /// Push-down application, called inside a relation's typed closure before `.all()`: filter
+    /// (`WHERE`) first, then sort via To's SortableDataModel mappings (in term order), then the
+    /// window via QueryBuilder.range. Filtering is opportunistic (a non-filterable To is simply not
+    /// narrowed); sort, by contrast, fails fast against a non-sortable To — a requested sort is
+    /// explicit intent and is NEVER silently dropped.
     func apply<To: DataModel>(to query: QueryBuilder<To>) throws -> QueryBuilder<To> {
-        var query = query
+        var query = try Self.applyFilter(filter, to: query)
         if let firstTerm = sortTerms.first {
             guard let sortableType = To.self as? any SortableDataModel.Type else {
                 throw ContainmentError.unsortableContainedType(
@@ -109,6 +138,49 @@ extension ContainmentQueryRefinement {
             query = query.range(lower: lower, upper: pagination.maxResults.map { lower + $0 - 1 })
         }
         return query
+    }
+
+    /// Filter-only push-down: the WHERE via To's FilterableDataModel translation. Shared by `apply`
+    /// (full load) and the relation's COUNT twin — the count honors the filter (it alone changes
+    /// cardinality) but not sort/window, so it applies this and nothing else. OPPORTUNISTIC: a To
+    /// that is not a FilterableDataModel, or a query that is not that model's declared `Filter` type,
+    /// simply isn't narrowed — there is no "filter" separate from the query to drop, so nothing throws
+    /// (a model you forgot to conform is unsearched, the same way an unsorted model is unordered).
+    static func applyFilter<To: DataModel>(_ filter: AnyFilter?, to query: QueryBuilder<To>) throws -> QueryBuilder<To> {
+        guard let filter, let filterableType = To.self as? any FilterableDataModel.Type else {
+            return query
+        }
+        return try filterableType.applyErasedFilter(filter, to: query)
+    }
+}
+
+private extension FilterableDataModel {
+    /// Opened-existential seam (mirror of applyErasedSortTerms): the caller opens
+    /// `To.self as? any FilterableDataModel.Type`, so Self IS M at runtime; QueryBuilder is invariant,
+    /// so the two conditional casts re-prove statically what the opening established dynamically —
+    /// backstops, not code paths. A filter value whose dynamic type is not Self.Filter is a DIFFERENT
+    /// request's query reaching this model — not narrowed (returned unchanged), never thrown.
+    static func applyErasedFilter<M: DataModel>(
+        _ filter: AnyFilter,
+        to query: QueryBuilder<M>
+    ) throws -> QueryBuilder<M> {
+        guard let opened = query as? QueryBuilder<Self> else {
+            throw ContainmentError.containerTypeMismatch(
+                expected: String(describing: Self.self),
+                actual: String(describing: M.self)
+            )
+        }
+        guard let typedFilter = filter.value as? Filter else {
+            return query
+        }
+        let filtered = apply(filter: typedFilter, to: opened)
+        guard let result = filtered as? QueryBuilder<M> else {
+            throw ContainmentError.containerTypeMismatch(
+                expected: String(describing: M.self),
+                actual: String(describing: Self.self)
+            )
+        }
+        return result
     }
 }
 

--- a/Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift
+++ b/Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift
@@ -44,10 +44,10 @@ public struct ContainmentRelation: Sendable {
     /// ONE refinement-aware code path with two internal entries (refined/unrefined) — no drift.
     private let load: @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> [any DataModel]
 
-    /// The count twin of `load`: the size of the full authorized member set, run as a `.count()`
-    /// query — never a fetch. Ignores sort and window (neither changes a count). When a filter axis
-    /// is added to the refinement, apply it here too, in lockstep with `load`.
-    private let count: @Sendable (any DataModel, any Database) async throws -> Int
+    /// The count twin of `load`: the size of the authorized member set, run as a `.count()` query —
+    /// never a fetch. Honors the refinement's FILTER (it alone changes cardinality) but ignores sort
+    /// and window (neither changes a count) — applied in lockstep with `load`.
+    private let count: @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> Int
 
     /// The additive twin of `load`, captured at factory time: persists a new contained record
     /// into a fetched container, setting the join (FK or pivot) the same way Fluent's relationship
@@ -59,7 +59,7 @@ public struct ContainmentRelation: Sendable {
         containerType: any DataModel.Type,
         containedType: any DataModel.Type,
         load: @escaping @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> [any DataModel],
-        count: @escaping @Sendable (any DataModel, any Database) async throws -> Int,
+        count: @escaping @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> Int,
         create: (@Sendable (any DataModel, any DataModel, any Database) async throws -> Void)?
     ) {
         self.containerType = containerType
@@ -81,8 +81,10 @@ public struct ContainmentRelation: Sendable {
                     .apply(to: container.cast(to: From.self)[keyPath: keyPath].query(on: db))
                     .all()
             },
-            count: { container, db in
-                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
+            count: { container, db, refinement in
+                try await ContainmentQueryRefinement
+                    .applyFilter(refinement.filter, to: container.cast(to: From.self)[keyPath: keyPath].query(on: db))
+                    .count()
             },
             create: { container, child, db in
                 // ChildrenProperty.create sets the child's FK back to the container and saves it.
@@ -103,8 +105,10 @@ public struct ContainmentRelation: Sendable {
                     .apply(to: container.cast(to: From.self)[keyPath: keyPath].query(on: db))
                     .all()
             },
-            count: { container, db in
-                try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
+            count: { container, db, refinement in
+                try await ContainmentQueryRefinement
+                    .applyFilter(refinement.filter, to: container.cast(to: From.self)[keyPath: keyPath].query(on: db))
+                    .count()
             },
             create: { container, child, db in
                 // A new sibling must be persisted before the pivot can reference it; then attach.
@@ -128,10 +132,10 @@ public struct ContainmentRelation: Sendable {
             containerType: From.self,
             containedType: To.self,
             load: { container, db, _ in
-                // `.parent` ignores the whole refinement — sort AND window are lossless for one row.
+                // `.parent` ignores the whole refinement — filter, sort AND window are lossless for one row.
                 try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).all()
             },
-            count: { container, db in
+            count: { container, db, _ in
                 try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
             },
             create: nil
@@ -163,10 +167,24 @@ extension ContainmentRelation {
         try await load(container, db, refinement)
     }
 
-    /// The count of the full authorized member set — the total the window is a view into. Runs a
-    /// `.count()` query; never fetches the rows. Same fetched-container PRECONDITION as `members`.
+    /// The count of the full authorized member set — the total an unfiltered window is a view into.
+    /// Runs a `.count()` query; never fetches the rows. Same fetched-container PRECONDITION as
+    /// `members`.
     func memberCount(of container: any DataModel, on db: any Database) async throws -> Int {
-        try await count(container, db)
+        try await count(container, db, .none)
+    }
+
+    /// The count of the authorized member set the FILTER selects — the total a filtered window is a
+    /// view into. Applies only the refinement's filter (sort/window never change a count), in
+    /// lockstep with the refined `members`. Same fetched-container PRECONDITION as `members`.
+    /// Filtering is opportunistic: a non-filterable To (or a non-matching query type) counts the
+    /// full set, never throws.
+    func memberCount(
+        of container: any DataModel,
+        on db: any Database,
+        applying refinement: ContainmentQueryRefinement
+    ) async throws -> Int {
+        try await count(container, db, refinement)
     }
 
     /// Persists `child` into `container` through this relation's join. Throws

--- a/Sources/FOSMVVMVapor/Containment/FilterableDataModel.swift
+++ b/Sources/FOSMVVMVapor/Containment/FilterableDataModel.swift
@@ -1,0 +1,48 @@
+// FilterableDataModel.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FluentKit
+import FOSMVVM
+import Foundation
+
+/// Declares how your model reads a request's query as a database `WHERE` — one hand-written
+/// translation, applied everywhere the framework loads this model for that request.
+///
+/// A query *is* a filter (selecting records is what a query does), so there is no separate filter
+/// type — you translate the request's own ``ServerRequestQuery`` to Fluent, by hand:
+///
+/// ```swift
+/// extension Berth: FilterableDataModel {
+///     static func apply(filter: BerthQuery, to query: QueryBuilder<Berth>) -> QueryBuilder<Berth> {
+///         guard let name = filter.dockName else { return query }
+///         return query.filter(\.$dockName == name)   // your Fluent, your columns
+///     }
+/// }
+/// ```
+///
+/// No filter vocabulary and no column names reach the wire. The framework rides the request's query
+/// into the one query it counts, paginates, and caches, so counts and windows reflect the narrowed
+/// set. `Filter` is the **one** query type this model narrows by — a request whose query is a
+/// different type simply doesn't narrow this model (its records load unfiltered).
+public protocol FilterableDataModel: DataModel {
+    /// The request query this model reads as a filter — the one ``ServerRequestQuery`` type whose
+    /// `WHERE` you translate below.
+    associatedtype Filter: ServerRequestQuery
+
+    /// Translate the request's query to this model's query as a `WHERE`, by hand. Return `query`
+    /// unchanged when the query carries nothing to narrow by — never a silent match-nothing.
+    static func apply(filter: Filter, to query: QueryBuilder<Self>) -> QueryBuilder<Self>
+}

--- a/Sources/FOSMVVMVapor/Containment/PlanExecutor.swift
+++ b/Sources/FOSMVVMVapor/Containment/PlanExecutor.swift
@@ -73,6 +73,7 @@ struct ResolvedRecordLoadPlan: Sendable {
     let rootIdentities: [RootSource: ModelIdentity]
     let sortTerms: [AnySortTerm]
     let pagination: Pagination?
+    let filter: AnyFilter?
 }
 
 extension ResolvedRecordLoadPlan {
@@ -132,13 +133,15 @@ private extension ResolvedRecordLoadPlan {
         for branch in branches {
             let sortedBy = tuple.isRefinedByRequest ? sortTerms : []
             let paginatedBy = tuple.isRefinedByRequest ? pagination : nil
+            let filteredBy = tuple.isRefinedByRequest ? filter : nil
             _ = try await request.authorizedRecords(
                 of: branch.container,
                 containing: recordType,
                 for: tuple.operation,
                 authorizedAs: branch.anchor,
                 sortedBy: sortedBy,
-                pagination: paginatedBy
+                pagination: paginatedBy,
+                filter: filteredBy
             )
             // Same inputs → the same key the engine just deposited (shared constructor —
             // ContainerRecordCacheKey.forLoad — is the no-drift guarantee).
@@ -148,7 +151,8 @@ private extension ResolvedRecordLoadPlan {
                 for: tuple.operation,
                 authorizedAs: branch.anchor,
                 sortedBy: sortedBy,
-                pagination: paginatedBy
+                pagination: paginatedBy,
+                filter: filteredBy
             ))
         }
         request.tupleCacheKeys[tuple] = depositedKeys
@@ -210,11 +214,14 @@ extension Vapor.Request {
         // The request's axes bind to the ONE marked tuple; without a mark they apply nowhere.
         var sortTerms = [AnySortTerm]()
         var pagination: Pagination?
+        var filter: AnyFilter?
         if plan.tuples.contains(where: \.isRefinedByRequest) {
             if let erasing = vmRequest.sort.flatMap({ $0 as? any ErasedSortTermsProviding }) {
                 sortTerms = erasing.erasedSortTerms
             }
             pagination = query.flatMap { $0 as? any PaginatedQuery }?.pagination
+            // The query IS the filter — a FilterableDataModel at the marked tuple reads it as a WHERE.
+            filter = query.map(AnyFilter.init)
         }
 
         return ResolvedRecordLoadPlan(
@@ -222,7 +229,8 @@ extension Vapor.Request {
             plan: plan,
             rootIdentities: rootIdentities,
             sortTerms: sortTerms,
-            pagination: pagination
+            pagination: pagination,
+            filter: filter
         )
     }
 

--- a/Sources/FOSMVVMVapor/Extensions/Request+ContainerLoad.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Request+ContainerLoad.swift
@@ -29,14 +29,15 @@ extension Vapor.Request {
         for operation: ContainerOperation,
         authorizedAs anchor: ModelIdentity? = nil,
         sortedBy sortTerms: [AnySortTerm] = [],
-        pagination: Pagination? = nil
+        pagination: Pagination? = nil,
+        filter: AnyFilter? = nil
     ) async throws -> [any DataModel] {
         guard let provider = application.containerAuthorizationProvider else {
             throw ContainmentError.noAuthorizationProvider
         }
         return try await authorizedRecords(
             via: provider, of: container, containing: containedType,
-            for: operation, authorizedAs: anchor, sortedBy: sortTerms, pagination: pagination
+            for: operation, authorizedAs: anchor, sortedBy: sortTerms, pagination: pagination, filter: filter
         )
     }
 
@@ -100,7 +101,8 @@ private extension Vapor.Request {
         for operation: ContainerOperation,
         authorizedAs anchor: ModelIdentity?,
         sortedBy sortTerms: [AnySortTerm],
-        pagination: Pagination?
+        pagination: Pagination?,
+        filter: AnyFilter?
     ) async throws -> [any DataModel] {
         let anchor = anchor ?? container
         // Anchor + pagination-boundary normalization live inside the shared key constructor —
@@ -111,7 +113,8 @@ private extension Vapor.Request {
             for: operation,
             authorizedAs: anchor,
             sortedBy: sortTerms,
-            pagination: pagination
+            pagination: pagination,
+            filter: filter
         )
         let refinement = cacheKey.refinement
         if let cached = containerRecordCache[cacheKey] {
@@ -149,14 +152,15 @@ private extension Vapor.Request {
         }
 
         // Total the window is a view into: only when a window is present (an unpaginated load's
-        // total IS records.count — no query needed). Runs inside the authorized path, after the
-        // grant check above, so it never counts rows the caller cannot see. Mirrors the records
-        // loop's relation match.
+        // total IS records.count — no query needed). Applies the refinement's FILTER (via the
+        // refined memberCount) so the total is the FILTERED set size the window slices, never the
+        // whole-set size. Runs inside the authorized path, after the grant check above, so it never
+        // counts rows the caller cannot see. Mirrors the records loop's relation match.
         if refinement.pagination != nil {
             var total = 0
             for relation in descriptor.containment
                 where ObjectIdentifier(relation.containedType) == ObjectIdentifier(containedType) {
-                total += try await relation.memberCount(of: containerRecord, on: db)
+                total += try await relation.memberCount(of: containerRecord, on: db, applying: refinement)
             }
             containerRecordCountCache[cacheKey] = total
         }

--- a/Tests/FOSMVVMVaporTests/Containment/ContainmentFixtures.swift
+++ b/Tests/FOSMVVMVaporTests/Containment/ContainmentFixtures.swift
@@ -178,6 +178,24 @@ extension Berth: SortableDataModel {
     }
 }
 
+/// The request query Berth reads as a filter (test-side stand-in for a shared-module type). A query
+/// IS a filter — the model translates it to Fluent below.
+struct BerthSearchQuery: ServerRequestQuery {
+    var dockName: String?
+}
+
+/// A query type Berth does NOT read — the wrong-query-type fixture (mirror of OtherSortKey).
+struct OtherQuery: ServerRequestQuery {
+    var value: Int
+}
+
+extension Berth: FilterableDataModel {
+    static func apply(filter: BerthSearchQuery, to query: QueryBuilder<Berth>) -> QueryBuilder<Berth> {
+        guard let dockName = filter.dockName else { return query }
+        return query.filter(\.$dockName == dockName)
+    }
+}
+
 final class CrewMember: DataModel, @unchecked Sendable {
     static let schema = "crew_members"
     @ID(key: .id) var id: UUID?

--- a/Tests/FOSMVVMVaporTests/Containment/FilteredMembersTests.swift
+++ b/Tests/FOSMVVMVaporTests/Containment/FilteredMembersTests.swift
@@ -1,0 +1,147 @@
+// FilteredMembersTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: coverage tests of the internal refined-members seam via `@testable
+// import FOSMVVMVapor` (sanctioned — below C8's public surface). No access level is widened for tests.
+
+import FluentKit
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+
+/// Seeds one dock with three berths whose dockNames DISCRIMINATE the filter: two "North"
+/// (numbers 3 and 1) and one "South" (number 2). A filter for "North" must return exactly the
+/// two North berths — never all three, never the wrong one.
+private func seedDockWithBerths(on db: any Database) async throws -> Dock {
+    let harbor = Harbor(name: "Filter Harbor")
+    try await harbor.save(on: db)
+    let pier = Pier(name: "Filter Pier")
+    try await pier.save(on: db)
+    let dock = try Dock(name: "Filter Dock", pierId: pier.requireId(), harborId: harbor.requireId())
+    try await dock.save(on: db)
+    try await Berth(number: 3, dockName: "North", dockId: dock.requireId()).save(on: db)
+    try await Berth(number: 2, dockName: "South", dockId: dock.requireId()).save(on: db)
+    try await Berth(number: 1, dockName: "North", dockId: dock.requireId()).save(on: db)
+    return dock
+}
+
+@Suite("Filtered containment member loads")
+struct FilteredMembersTests {
+    /// The request query pushes down into the children query as a WHERE — only the matching rows return.
+    @Test func refinedChildrenHonorsFilter() async throws {
+        let numbers = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let dock = try await seedDockWithBerths(on: db)
+            let refinement = ContainmentQueryRefinement(
+                filter: AnyFilter(BerthSearchQuery(dockName: "North"))
+            )
+            let members = try await ContainmentRelation.children(\Dock.$berths)
+                .members(of: dock, on: db, applying: refinement)
+            return try members.map { try #require($0 as? Berth).number }.sorted()
+        }
+        #expect(numbers == [1, 3]) // the two North berths; the South berth (2) is excluded
+    }
+
+    /// Filter, sort, and window compose: filter to North (numbers 3, 1), sort ascending, take the
+    /// first — proves the filter narrows BEFORE the sort/window slice.
+    @Test func filterComposesWithSortAndWindow() async throws {
+        let numbers = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let dock = try await seedDockWithBerths(on: db)
+            let refinement = ContainmentQueryRefinement(
+                sortTerms: SortCriteria([SortTerm(key: BerthSortKey.number, direction: .ascending)]).erasedTerms,
+                pagination: Pagination(startIndex: 0, maxResults: 1),
+                filter: AnyFilter(BerthSearchQuery(dockName: "North"))
+            )
+            let members = try await ContainmentRelation.children(\Dock.$berths)
+                .members(of: dock, on: db, applying: refinement)
+            return try members.map { try #require($0 as? Berth).number }
+        }
+        #expect(numbers == [1]) // North berths ascending = [1, 3]; window [0,1) = [1]
+    }
+
+    /// The critical new behavior: the COUNT twin honors the filter. Filter is the first axis that
+    /// changes cardinality, so a filtered memberCount must be the FILTERED size (2), while the
+    /// unfiltered memberCount stays the full size (3). This is what keeps totalCount honest.
+    @Test func memberCountHonorsFilter() async throws {
+        let counts = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let dock = try await seedDockWithBerths(on: db)
+            let relation = ContainmentRelation.children(\Dock.$berths)
+            let filtered = try await relation.memberCount(
+                of: dock, on: db,
+                applying: ContainmentQueryRefinement(filter: AnyFilter(BerthSearchQuery(dockName: "North")))
+            )
+            let unfiltered = try await relation.memberCount(of: dock, on: db)
+            return (filtered: filtered, unfiltered: unfiltered)
+        }
+        #expect(counts.filtered == 2)
+        #expect(counts.unfiltered == 3)
+    }
+
+    /// Opportunistic: a query against a relation whose To is not FilterableDataModel (CrewMember) is
+    /// simply not narrowed — the full set returns, nothing throws (a query is not a "filter demand").
+    @Test func filterAgainstUnfilterableModelIsSkipped() async throws {
+        let count = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let (dock1, _) = try await seedHarbor(on: db) // dock1 has 2 crew members
+            let refinement = ContainmentQueryRefinement(
+                filter: AnyFilter(BerthSearchQuery(dockName: "North"))
+            )
+            return try await ContainmentRelation.siblings(\Dock.$crew)
+                .members(of: dock1, on: db, applying: refinement).count
+        }
+        #expect(count == 2) // CrewMember is not filterable — unfiltered, all crew returned
+    }
+
+    /// Opportunistic: a filterable To (Berth) given a query of a type it does NOT read (its `Filter`
+    /// is BerthSearchQuery) is not narrowed — a different request's query reaching this model just
+    /// loads it unfiltered, never throws.
+    @Test func wrongQueryTypeIsSkipped() async throws {
+        let count = try await withFluentTestApp { app in
+            addHarborMigrations(app)
+        } _: { _, db in
+            let dock = try await seedDockWithBerths(on: db)
+            let refinement = ContainmentQueryRefinement(
+                filter: AnyFilter(OtherQuery(value: 1))
+            )
+            return try await ContainmentRelation.children(\Dock.$berths)
+                .members(of: dock, on: db, applying: refinement).count
+        }
+        #expect(count == 3) // OtherQuery is not Berth's Filter type — unfiltered, all berths returned
+    }
+
+    /// Cache-key behavior (the value IS the key): equal query meaning ⇒ equal refinements with
+    /// equal hashes; a differing query — or a different query TYPE — ⇒ unequal. Behavior only,
+    /// no representation.
+    @Test func refinementEqualityFollowsFilter() {
+        let north = ContainmentQueryRefinement(filter: AnyFilter(BerthSearchQuery(dockName: "North")))
+        let sameNorth = ContainmentQueryRefinement(filter: AnyFilter(BerthSearchQuery(dockName: "North")))
+        let south = ContainmentQueryRefinement(filter: AnyFilter(BerthSearchQuery(dockName: "South")))
+        let otherType = ContainmentQueryRefinement(filter: AnyFilter(OtherQuery(value: 1)))
+        #expect(north == sameNorth)
+        #expect(north.hashValue == sameNorth.hashValue)
+        #expect(north != south)
+        #expect(north != otherType)
+        #expect(north != .none)
+    }
+}


### PR DESCRIPTION
Completes the large-table search control: PR #111 added the total-count; this adds the filter that makes the count and window narrow to a search.

## Design: a query *is* a filter

Selecting records is what a `ServerRequestQuery` does, so there's **no query-side protocol and no separate filter type** (an earlier `FilterableQuery` / `ServerRequestFilter` pair was dropped as tautological). The request's query rides the containment refinement to the marked tuple, where the searched model translates it to Fluent by hand.

**Public FOSMVVM surface added: zero.** You write a query, as always.

## What's new

- **`FilterableDataModel`** (FOSMVVMVapor) — the one new public type, a sibling of `SortableDataModel`. A model declares the single `ServerRequestQuery` type it reads and hand-writes `apply(filter:to:)` as a `WHERE`. No filter vocabulary or column names reach the wire.
- **Cache-key participation** — the query rides `ContainmentQueryRefinement` as the erased `AnyFilter`, joining the cache key by value (two searches never collide) with no cache-layer change.
- **Count honors the filter** — filter is the first axis that changes cardinality, so `memberCount` and `totalCount(for:)` now reflect the narrowed set, not the whole set.
- **Opportunistic application** — a non-filterable model, or a query that isn't the model's declared `Filter` type, is simply not narrowed; nothing throws (a query isn't an explicit filter *demand*, unlike a sort).

## Known limitation / future

One query type per model for now (mirrors sort's one `RequestSortKey`). A `ServerRequestQuery.Type` → translator registry would later let one model be filtered by several request query types.

## Tests

`FilteredMembersTests` — push-down, filter+sort+window composition, the count honoring the filter, opportunistic skip for both unfilterable-model and wrong-query-type, and cache-key equality. Full suite: **570 passing**, swiftlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)