### PR TITLE
feat: ClientCredentialProvider / ClientCredentialMiddleware credential seam

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/skills/fosutilities-api-catalog/SKILL.md
+++ b/.claude/skills/fosutilities-api-catalog/SKILL.md
@@ -50,6 +50,7 @@ line via the `fosutilities-api-catalog-update` skill.
 - Identifying *which* entity a model is (opaque `ModelIdentity`) — keying refresh or authorization by it → `FOSMVVM.md § Protocols`
 - Container-scoped authorization — declaring containers, grant verbs, who may touch which records → `FOSMVVM.md § Protocols`
 - Client-chosen sort or pagination on a request → `FOSMVVM.md § Protocols`
+- Attaching auth headers (bearer token, API key) to every client request, rotation-safe → `FOSMVVM.md § Protocols`
 - Declaring the data a server-rendered body needs — composable factory, load requirements, rooted scopes → `FOSMVVM.md § Protocols`
 - Rendering a ViewModel in SwiftUI — app setup, view binding, previews, form views → `FOSMVVM.md § SwiftUI Support`
 - Versioning ViewModel properties, choosing deployment URLs, negotiating versions over HTTP → `FOSMVVM.md § Versioning`
@@ -61,6 +62,7 @@ line via the `fosutilities-api-catalog-update` skill.
 - The server-side write path — candidate set, field application, authorization provider → `FOSMVVMVapor.md § Protocols`
 - Projecting the database into ViewModels — resolvable requests, Fluent `DataModel` → `FOSMVVMVapor.md § Protocols`
 - Serving typed/localized errors, gating routes on client app version → `FOSMVVMVapor.md § Middleware`
+- Verifying a caller's bearer token / protecting route groups with app-owned credential rules → `FOSMVVMVapor.md § Middleware`
 - Testing ViewModels — Codable round-trip, version stability, translation coverage → `FOSTesting.md § FOSTesting`
 - UI-testing SwiftUI ViewModel views (XCUITest hosting, operations, identifiers) → `FOSTesting.md § FOSTestingUI`, `FOSMVVM.md § SwiftUI Support`
 - Testing Vapor ServerRequests end to end, or Fluent-backed code against a fresh in-memory database → `FOSTesting.md § FOSTestingVapor`

--- a/.claude/skills/shared/api-catalog/FOSMVVM.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVM.md
@@ -419,6 +419,24 @@ public struct ResponseError: ValidatableViewModelRequestError {
 }
 ```
 
+### Attach a credential to every request — `ClientCredentialProvider` / `BearerCredentialProvider`
+Reach for this when: the app must authenticate its ServerRequests (a bearer
+token, an API key) without per-call header plumbing — set a provider once on
+`MVVMEnvironment` and `processRequest(mvvmEnv:)` consults it on every request,
+so a credential that rotates mid-session is picked up on the next call. A `nil`
+token sends no header (the request proceeds unauthenticated). The server-side
+complement is `ClientCredentialMiddleware` (see `FOSMVVMVapor.md § Middleware`).
+Don't bake a token into the static `requestHeaders` — a rotating credential
+goes stale there; the provider is the dynamic sibling.
+
+```swift
+let env = MVVMEnvironment(
+    appBundle: .main,
+    clientCredentialProvider: BearerCredentialProvider { await tokens.current },
+    deploymentURLs: deploymentURLs
+)
+```
+
 ### Cap upload sizes — `ServerRequestBodySize`
 Reach for this when: a request body can be large (file uploads) — set
 `maxBodySize` on the `ServerRequestBody` so the server collects the whole

--- a/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
@@ -185,8 +185,8 @@ routes.on(.POST, body: .collect(maxSize: FileUploadBody.maxBodySize?.vaporByteCo
 
 ## Middleware
 
-Two middlewares that belong on every FOSMVVM route group: typed, localized
-error responses and client-version gating.
+Three middlewares for FOSMVVM route groups: typed, localized error
+responses, client-version gating, and client-credential verification.
 
 ### Serve errors typed and localized — `ErrorMiddleware`
 Reach for this when: configuring the application's error handling — use
@@ -211,6 +211,25 @@ applications are rejected before any handler runs.
 ```swift
 let versionedGroup = app.grouped(RequireVersionedAppMiddleware())
 try versionedGroup.register(collection: ReplaceBerthController())
+```
+
+### Verify the caller's credential — `ClientCredentialMiddleware` / `ServerCredentialVerifier` / `BearerCredentialVerifier`
+Reach for this when: a route group must reject unauthenticated callers and the
+app owns the validity rule — the server complement of FOSMVVM's
+`ClientCredentialProvider` (the client attaches the credential, this verifies
+it). Supply the rule as a `ServerCredentialVerifier` (throw to reject, return
+to admit); the stock `BearerCredentialVerifier` extracts `Authorization:
+Bearer` and asks your `isValid` closure (compare digests or constant-time —
+never `==` on raw secrets). Missing or invalid → 401 with `WWW-Authenticate`.
+Limitation: a rejection reaches a FOSMVVM client as a transport-level
+bad-status error (401), not the request's typed `ResponseError` — and a
+`ResponseError` that decodes from any JSON body (e.g. `EmptyError`) swallows
+the 401 entirely; give protected requests an error type with a required field
+absent from rejection bodies.
+
+```swift
+let protected = app.grouped(ClientCredentialMiddleware(
+    verifier: BearerCredentialVerifier { token in await tokens.isCurrent(token) }))
 ```
 
 ## Containment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ClientCredentialProvider`** (FOSMVVM) — supplies the authentication headers that
+  accompany every `ServerRequest`; consulted per request, so a rotating credential is
+  picked up on the next call. The dynamic sibling of the static
+  `MVVMEnvironment.requestHeaders`. Ships with the stock **`BearerCredentialProvider`**
+  (`Authorization: Bearer <token>`; a `nil` token sends the request unauthenticated).
+- **`MVVMEnvironment.clientCredentialProvider`** — register a `ClientCredentialProvider`
+  once (defaulted parameter on every initializer; additive) and
+  `processRequest(mvvmEnv:)` attaches its headers to every request, after the static
+  `requestHeaders` so the per-request credential wins on a duplicate field.
+- **`ClientCredentialMiddleware` + `ServerCredentialVerifier`** (FOSMVVMVapor) — the
+  server half of the credential pair: route groups run an app-supplied
+  `ServerCredentialVerifier` before each route; throw to reject, return to admit.
+  Consulted per request, so a credential revoked server-side takes effect on the next
+  call. Ships with the stock **`BearerCredentialVerifier`** — the matched pair of
+  `BearerCredentialProvider` — which extracts `Authorization: Bearer` and asks the
+  app whether that token is currently valid (missing or invalid → `401` with
+  `WWW-Authenticate: Bearer`, never echoing the presented token). On a FOSMVVM client
+  a rejection surfaces as `DataFetchError.badStatus(httpStatusCode: 401)` — this
+  requires an error serializer that forwards the `Abort`'s status and headers (FOS
+  `ErrorMiddleware.default` does). Known limitation: a request whose `ResponseError`
+  decodes from the rejection body swallows the `401` into a typed error instead —
+  `EmptyError` always does (its synthesized decode is a no-op, accepting any
+  valid-JSON body); pre-existing `DataFetch` behavior.
+
 ## [0.5.0] - 2026-07-08
 
 ### Added

--- a/Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift
+++ b/Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift
@@ -1,0 +1,100 @@
+// ClientCredentialProvider.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Supplies the authentication headers that accompany every ``ServerRequest``
+///
+/// Register a ``ClientCredentialProvider`` on ``MVVMEnvironment`` and every
+/// `processRequest(mvvmEnv:)` call attaches the provider's headers automatically —
+/// no per-request plumbing in application code.
+///
+/// The provider is consulted **per request**, so a credential that rotates (a
+/// refreshed access token, a re-issued session) is picked up on the very next
+/// call. When the client is unauthenticated, return an empty array and the
+/// request proceeds without authentication headers.
+///
+/// ``ClientCredentialProvider`` is the *dynamic* sibling of the static
+/// ``MVVMEnvironment/requestHeaders``: use `requestHeaders` for values fixed for
+/// the life of the application, and a credential provider for values that must be
+/// resolved at request time. On a duplicate header field, the provider's value wins.
+///
+/// Use the stock ``BearerCredentialProvider`` for standard `Authorization: Bearer`
+/// authentication, or conform your own type for any other credential scheme.
+///
+/// ## Example
+///
+/// ```swift
+/// let environment = MVVMEnvironment(
+///     appBundle: Bundle.main,
+///     clientCredentialProvider: BearerCredentialProvider {
+///         await SessionStore.shared.accessToken
+///     },
+///     deploymentURLs: [
+///         .production: URL(string: "https://api.mywebserver.com")!,
+///         .debug: URL(string: "http://localhost:8080")!
+///     ]
+/// )
+/// ```
+public protocol ClientCredentialProvider: Sendable {
+    /// The authentication headers for the next request; empty when unauthenticated
+    ///
+    /// Called once per ``ServerRequest`` immediately before the request is sent,
+    /// so the returned headers always reflect the current credential.
+    ///
+    /// - Returns: HTTP header fields to attach to the request; an empty array
+    ///     sends the request unauthenticated
+    /// - Throws: When the credential cannot be resolved; no request is sent and the
+    ///     error propagates from `processRequest` to the caller —
+    ///     ``MVVMEnvironment/requestErrorHandler`` handles only typed
+    ///     `ServerRequestError`s
+    func credentialHeaders() async throws -> [(field: String, value: String)]
+}
+
+/// The stock ``ClientCredentialProvider`` for `Authorization: Bearer` authentication
+///
+/// Supply a closure that yields the current token; the provider formats the
+/// `Authorization` header for you. The closure is consulted on **every** request,
+/// so return the token from wherever your application keeps it current (a session
+/// store, a keychain, a refresh flow) and rotation is handled automatically.
+///
+/// When the closure yields `nil` — the user is signed out, no token has been
+/// issued yet — no headers are produced and the request proceeds unauthenticated.
+///
+/// ## Example
+///
+/// ```swift
+/// let provider = BearerCredentialProvider {
+///     await SessionStore.shared.accessToken
+/// }
+/// ```
+public struct BearerCredentialProvider: ClientCredentialProvider {
+    private let token: @Sendable () async -> String?
+
+    /// Initializes the ``BearerCredentialProvider``
+    ///
+    /// - Parameter token: Yields the current bearer token, or `nil` when
+    ///     unauthenticated; called once per request
+    public init(token: @Sendable @escaping () async -> String?) {
+        self.token = token
+    }
+
+    public func credentialHeaders() async throws -> [(field: String, value: String)] {
+        guard let token = await token() else {
+            return []
+        }
+
+        return [(field: "Authorization", value: "Bearer \(token)")]
+    }
+}

--- a/Sources/FOSMVVM/Protocols/DestroyRequest.swift
+++ b/Sources/FOSMVVM/Protocols/DestroyRequest.swift
@@ -21,7 +21,7 @@ import FOSFoundation
 /// > **destroy** indicates **permanent destruction** of the resource as
 /// > opposed to *delete* that performs a "soft deletion" of the resource
 public protocol DestroyRequest: ServerRequest, Stubbable where
-ResponseBody: DestroyResponseBody  {}
+    ResponseBody: DestroyResponseBody {}
 
 public extension DestroyRequest {
     static var baseTypeName: String {

--- a/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
+++ b/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
@@ -146,6 +146,13 @@ public extension ServerRequest {
                 headers.append((field: key, value: value))
             }
 
+            // Credential headers append AFTER the static requestHeaders: headers apply to the
+            // URLRequest in order (setValue), so on a duplicate field the per-request
+            // credential wins.
+            if let credentialProvider = mvvmEnv.clientCredentialProvider {
+                headers += try await credentialProvider.credentialHeaders()
+            }
+
             try await processRequest(
                 baseURL: mvvmEnv.serverBaseURL,
                 headers: headers,

--- a/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
@@ -94,6 +94,17 @@ public final class MVVMEnvironment: @unchecked Sendable {
     /// A dictionary of values to populate the *URLRequest*'s HTTPHeaderFields
     public let requestHeaders: [String: String]
 
+    /// Supplies the authentication headers that accompany every ``ServerRequest``
+    ///
+    /// The provider is consulted per request, so a rotating credential (a refreshed
+    /// access token) is picked up on the next call — the dynamic sibling of the static
+    /// ``requestHeaders``. On a duplicate header field the provider's value wins.
+    /// `nil` (the default) sends requests without authentication headers.
+    ///
+    /// Use the stock ``BearerCredentialProvider`` for `Authorization: Bearer`
+    /// authentication, or conform your own ``ClientCredentialProvider``.
+    public let clientCredentialProvider: (any ClientCredentialProvider)?
+
     /// A function that is called when there is an error processing a ``ServerRequest``
     public let requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)?
 
@@ -194,6 +205,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - resourceDirectoryName: The directory name that contains the resources (default: nil).  Only needed
     ///          if the client application is hosting the YAML files.
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
+    ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
+    ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
     ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
@@ -206,6 +219,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceBundles: [Bundle]? = nil,
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
+        clientCredentialProvider: (any ClientCredentialProvider)? = nil,
         deploymentURLs: [Deployment: URLPackage],
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil,
         session: URLSession? = nil,
@@ -215,6 +229,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         self.resourceBundles = resourceBundles ?? [appBundle]
         self.resourceDirectoryName = resourceDirectoryName
         self.requestHeaders = requestHeaders
+        self.clientCredentialProvider = clientCredentialProvider
         self.deploymentURLs = deploymentURLs
         self.requestErrorHandler = requestErrorHandler
         self.session = session
@@ -240,6 +255,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - resourceDirectoryName: The directory name that contains the resources (default: nil).  Only needed
     ///          if the client application is hosting the YAML files.
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
+    ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
+    ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
     ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
@@ -252,6 +269,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceBundles: [Bundle]? = nil,
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
+        clientCredentialProvider: (any ClientCredentialProvider)? = nil,
         deploymentURLs: [Deployment: URL],
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil,
         session: URLSession? = nil,
@@ -263,6 +281,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
             resourceBundles: resourceBundles,
             resourceDirectoryName: resourceDirectoryName,
             requestHeaders: requestHeaders,
+            clientCredentialProvider: clientCredentialProvider,
             deploymentURLs: deploymentURLs.reduce([Deployment: URLPackage]()) { result, pair in
                 var result = result
                 let (deployment, url) = pair
@@ -291,6 +310,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         self.resourceBundles = []
         self.resourceDirectoryName = nil
         self.requestHeaders = [:]
+        self.clientCredentialProvider = nil
         self.deploymentURLs = deploymentURLs
         self.requestErrorHandler = nil
         self.session = session
@@ -312,6 +332,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - resourceDirectoryName: The directory name that contains the resources (default: nil).  Only needed
     ///          if the client application is hosting the YAML files.
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
+    ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
+    ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
@@ -322,6 +344,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceBundles: [Bundle]? = nil,
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
+        clientCredentialProvider: (any ClientCredentialProvider)? = nil,
         deploymentURLs: [Deployment: URLPackage],
         session: URLSession? = nil,
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil
@@ -333,6 +356,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         self.resourceBundles = resourceBundles ?? [appBundle]
         self.resourceDirectoryName = resourceDirectoryName
         self.requestHeaders = requestHeaders
+        self.clientCredentialProvider = clientCredentialProvider
         self.deploymentURLs = deploymentURLs
         self.requestErrorHandler = requestErrorHandler
         self.session = session
@@ -370,6 +394,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - resourceDirectoryName: The directory name that contains the resources (default: nil).  Only needed
     ///          if the client application is hosting the YAML files.
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
+    ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
+    ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
@@ -380,6 +406,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceBundles: [Bundle]? = nil,
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
+        clientCredentialProvider: (any ClientCredentialProvider)? = nil,
         deploymentURLs: [Deployment: URL],
         session: URLSession? = nil,
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil
@@ -393,6 +420,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
             resourceBundles: resourceBundles,
             resourceDirectoryName: resourceDirectoryName,
             requestHeaders: requestHeaders,
+            clientCredentialProvider: clientCredentialProvider,
             deploymentURLs: deploymentURLs.reduce([Deployment: URLPackage]()) { result, pair in
                 var result = result
                 let (deployment, url) = pair

--- a/Sources/FOSMVVMVapor/Middleware/ClientCredentialMiddleware.swift
+++ b/Sources/FOSMVVMVapor/Middleware/ClientCredentialMiddleware.swift
@@ -1,0 +1,161 @@
+// ClientCredentialMiddleware.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Vapor
+
+/// Decides whether a request's presented credential admits it
+///
+/// A ``ServerCredentialVerifier`` is the validity rule that ``ClientCredentialMiddleware``
+/// runs before each route in a protected group: return to admit the request, throw to
+/// reject it — typically `Abort(.unauthorized)`. Rejection reasons must **never** echo
+/// the presented credential back to the caller.
+///
+/// The verifier is consulted **per request**, so a credential revoked or rotated on the
+/// server side takes effect on the very next call — mirroring how the client's
+/// `ClientCredentialProvider` resolves its credential per request.
+///
+/// Use the stock ``BearerCredentialVerifier`` for standard `Authorization: Bearer`
+/// authentication, or conform your own type for any other credential scheme.
+public protocol ServerCredentialVerifier: Sendable {
+    /// Admits or rejects the request presenting these headers
+    ///
+    /// Called once per request before the route runs.
+    ///
+    /// - Parameter headers: The HTTP headers the request presented
+    /// - Throws: To reject the request — typically `Abort(.unauthorized)`; the
+    ///     rejection reason must not contain the presented credential
+    func verify(headers: HTTPHeaders) async throws
+}
+
+/// A Vapor *Middleware* implementation that runs a ``ServerCredentialVerifier``
+/// before the route
+///
+/// ``ClientCredentialMiddleware`` is the server half of the credential pair: the client
+/// attaches its credential to every *ServerRequest* through a `ClientCredentialProvider`
+/// registered on `MVVMEnvironment`, and this middleware verifies that credential before
+/// any route in the protected group runs. The validity rule itself — which credentials
+/// are currently good — is supplied by the application through the verifier.
+///
+/// ## Client-Side Contract
+///
+/// On a FOSMVVM client, a rejection surfaces from `processRequest(mvvmEnv:)` as
+/// FOSFoundation's `DataFetchError.badStatus(httpStatusCode: 401)` — not as the
+/// request's typed `ResponseError` — so `MVVMEnvironment.requestErrorHandler` is
+/// bypassed and the error propagates directly to the caller. This contract requires
+/// an installed error serializer that forwards the `Abort`'s status and headers;
+/// FOS ``ErrorMiddleware`` (`.default(environment:)`) does.
+///
+/// Known limitation: a request whose `ResponseError` decodes from the rejection body
+/// swallows the 401 into a typed error instead. `EmptyError` **always** does — an
+/// empty struct's synthesized decode is a no-op, so it decodes from ANY valid-JSON
+/// rejection body (FOS ``ErrorMiddleware``'s JSON string and Vapor's stock JSON
+/// object alike). A pre-existing `DataFetch` property, noted here because this
+/// middleware is the first consumer depending on 401 visibility: a request that must
+/// observe the 401 needs a `ResponseError` with at least one required field absent
+/// from rejection bodies.
+///
+/// ## Example
+///
+/// ```swift
+/// func routes(_ app: Application) throws {
+///     // MARK: Credentialed Routes
+///
+///     let protectedGroup = app.grouped(
+///         ClientCredentialMiddleware(verifier: BearerCredentialVerifier { token in
+///             await tokens.isCurrent(token)
+///         })
+///     )
+///     try protectedGroup.register(collection: MyController())
+/// }
+/// ```
+public struct ClientCredentialMiddleware: AsyncMiddleware {
+    private let verifier: any ServerCredentialVerifier
+
+    // MARK: Middleware Protocol
+
+    public func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        // Ensure that the presented credential admits the request
+        try await verifier.verify(headers: request.headers)
+
+        return try await next.respond(to: request)
+    }
+
+    // MARK: Initialization Methods
+
+    /// Create a new ``ClientCredentialMiddleware``
+    ///
+    /// - Parameter verifier: The validity rule run against each request's
+    ///     presented credential
+    public init(verifier: any ServerCredentialVerifier) {
+        self.verifier = verifier
+    }
+}
+
+/// The stock ``ServerCredentialVerifier`` for `Authorization: Bearer` authentication
+///
+/// ``BearerCredentialVerifier`` is the matched pair of the client's
+/// `BearerCredentialProvider`: the provider attaches `Authorization: Bearer <token>`
+/// to every request; this verifier extracts that token and asks the application
+/// whether it is currently valid. A missing `Authorization` header or an invalid
+/// token rejects the request with `401 Unauthorized` carrying
+/// `WWW-Authenticate: Bearer` (RFC 7235) — never echoing the presented token.
+///
+/// The `isValid` closure is consulted on **every** request, so answer from wherever
+/// the application keeps its live token set (a session store, a database, a
+/// revocation list) and rotation is handled automatically.
+///
+/// ## Example
+///
+/// ```swift
+/// let verifier = BearerCredentialVerifier { token in
+///     await tokens.isCurrent(token)
+/// }
+/// ```
+public struct BearerCredentialVerifier: ServerCredentialVerifier {
+    private let isValid: @Sendable (String) async -> Bool
+
+    // MARK: ServerCredentialVerifier Protocol
+
+    public func verify(headers: HTTPHeaders) async throws {
+        guard let token = headers.bearerAuthorization?.token else {
+            throw Abort(
+                .unauthorized,
+                headers: ["WWW-Authenticate": "Bearer"],
+                reason: "Missing bearer credential"
+            )
+        }
+
+        guard await isValid(token) else {
+            throw Abort(
+                .unauthorized,
+                headers: ["WWW-Authenticate": "Bearer"],
+                reason: "Invalid bearer credential"
+            )
+        }
+    }
+
+    // MARK: Initialization Methods
+
+    /// Initializes the ``BearerCredentialVerifier``
+    ///
+    /// - Parameter isValid: Answers whether the presented bearer token is currently
+    ///     valid; called once per request. When comparing against stored secret
+    ///     material, compare in constant time or compare digests — a plain `==`
+    ///     on secrets leaks timing
+    public init(isValid: @Sendable @escaping (String) async -> Bool) {
+        self.isValid = isValid
+    }
+}

--- a/Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift
+++ b/Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift
@@ -1,0 +1,70 @@
+// ClientCredentialProviderTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+import Testing
+
+@Suite("ClientCredentialProvider")
+struct ClientCredentialProviderTests {
+    @Test("BearerCredentialProvider yields exactly one Authorization: Bearer header")
+    func bearerHeader() async throws {
+        let provider = BearerCredentialProvider { "abc" }
+
+        let headers = try await provider.credentialHeaders()
+
+        #expect(headers.count == 1)
+        #expect(headers.first?.field == "Authorization")
+        #expect(headers.first?.value == "Bearer abc")
+    }
+
+    @Test("A nil token yields no headers — the request proceeds unauthenticated")
+    func nilToken() async throws {
+        let provider = BearerCredentialProvider { nil }
+
+        let headers = try await provider.credentialHeaders()
+
+        #expect(headers.isEmpty)
+    }
+
+    @Test("A rotated token is reflected on the next credentialHeaders() call")
+    func rotation() async throws {
+        let vault = TokenVault(token: "first")
+        let provider = BearerCredentialProvider { await vault.token }
+
+        let first = try await provider.credentialHeaders()
+        #expect(first.first?.value == "Bearer first")
+
+        await vault.rotate(to: "second")
+
+        let second = try await provider.credentialHeaders()
+        #expect(second.first?.value == "Bearer second")
+    }
+}
+
+/// A mutable token source — models an app session whose credential rotates between requests.
+private actor TokenVault {
+    var token: String?
+
+    init(token: String?) {
+        self.token = token
+    }
+
+    func rotate(to newToken: String?) {
+        token = newToken
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift
+++ b/Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift
@@ -1,0 +1,400 @@
+// ClientCredentialMiddlewareTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Behavior contract of `ClientCredentialMiddleware` — the server half of the credential
+// pair (`ClientCredentialProvider` attaches; this verifies) — against a REAL running
+// server so the observed status codes are exactly what a client sees on the wire:
+//   • a valid bearer credential admits the request — the route runs,
+//   • a missing or invalid credential is rejected 401, WITHOUT echoing the
+//     presented token back to the caller,
+//   • any custom `ServerCredentialVerifier` conformance is honored (the protocol
+//     seam, not just the stock bearer verifier),
+//   • the verifier is consulted PER REQUEST, so a credential revoked between two
+//     requests admits the first and rejects the second (rotation semantics,
+//     mirroring the client side),
+//   • rejections carry `WWW-Authenticate: Bearer` (RFC 7235) on the wire,
+//   • the Authorization parse edges are pinned: a lowercase `bearer` scheme admits;
+//     an empty token (`Bearer `) rejects,
+//   • the CLIENT-SIDE contract: through the REAL client (`processRequest(mvvmEnv:)`)
+//     with FOS `ErrorMiddleware.default` installed, a rejection surfaces as
+//     `DataFetchError.badStatus(httpStatusCode: 401)` — requestErrorHandler bypassed —
+//     PROVIDED the request's `ResponseError` does not decode from the rejection body;
+//     `EmptyError` always decodes (no-op synthesized decode), swallowing the 401 into
+//     a contentless typed error — the known limitation, pinned by its own test.
+
+import FOSFoundation
+import FOSMVVM
+import FOSMVVMVapor
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+import Vapor
+
+@Suite("ClientCredentialMiddleware (verifier ↔ running server)", .serialized)
+struct ClientCredentialMiddlewareTests {
+    @Test("A valid bearer credential admits the request — the route runs")
+    func validBearerAdmits() async throws {
+        try await withRunningServer { app in
+            Self.registerProtectedRoute(app, isValid: { $0 == "current-token" })
+        } _: { base in
+            let reply = try await Self.send(
+                to: base,
+                headers: ["Authorization": "Bearer current-token"]
+            )
+
+            #expect(reply.status == 200)
+            #expect(reply.body == "granted")
+        }
+    }
+
+    @Test("A missing Authorization header is rejected 401 — the route never runs")
+    func missingAuthorizationRejects() async throws {
+        try await withRunningServer { app in
+            Self.registerProtectedRoute(app, isValid: { _ in true })
+        } _: { base in
+            let reply = try await Self.send(to: base, headers: [:])
+
+            #expect(reply.status == 401)
+            #expect(reply.body != "granted")
+            // RFC 7235: the challenge header reaches the wire
+            #expect(reply.wwwAuthenticate == "Bearer")
+        }
+    }
+
+    @Test("An invalid token is rejected 401 and the response never echoes the token")
+    func invalidTokenRejectsWithoutEchoingToken() async throws {
+        let presentedToken = "stolen-or-expired-token"
+
+        try await withRunningServer { app in
+            Self.registerProtectedRoute(app, isValid: { _ in false })
+        } _: { base in
+            let reply = try await Self.send(
+                to: base,
+                headers: ["Authorization": "Bearer \(presentedToken)"]
+            )
+
+            #expect(reply.status == 401)
+            #expect(!reply.body.contains(presentedToken))
+            // RFC 7235: the challenge header reaches the wire
+            #expect(reply.wwwAuthenticate == "Bearer")
+        }
+    }
+
+    @Test("A lowercase bearer scheme admits — the Authorization parse is scheme-case-insensitive")
+    func lowercaseBearerSchemeAdmits() async throws {
+        try await withRunningServer { app in
+            Self.registerProtectedRoute(app, isValid: { $0 == "current-token" })
+        } _: { base in
+            let reply = try await Self.send(
+                to: base,
+                headers: ["Authorization": "bearer current-token"]
+            )
+
+            #expect(reply.status == 200)
+            #expect(reply.body == "granted")
+        }
+    }
+
+    @Test("An empty bearer token is rejected 401 — even against an always-true validity rule")
+    func emptyBearerTokenRejects() async throws {
+        try await withRunningServer { app in
+            Self.registerProtectedRoute(app, isValid: { _ in true })
+        } _: { base in
+            let reply = try await Self.send(
+                to: base,
+                headers: ["Authorization": "Bearer "]
+            )
+
+            #expect(reply.status == 401)
+            #expect(reply.body != "granted")
+        }
+    }
+
+    @Test("On a FOSMVVM client, a rejection surfaces as DataFetchError.badStatus(401)")
+    func rejectionSurfacesAsBadStatus401ToTheClient() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app)
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            let request = ShowStrictErrorReplyRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected DataFetchError.badStatus(401), but the request succeeded")
+            } catch DataFetchError.badStatus(httpStatusCode: let code) {
+                // NOT a ServerRequestError — requestErrorHandler is bypassed; this is
+                // the error downstream consumers branch on.
+                #expect(code == 401)
+            } catch {
+                Issue.record("Expected DataFetchError.badStatus(401), got \(error)")
+            }
+
+            #expect(request.responseBody == nil)
+        }
+    }
+
+    @Test("Known limitation: an EmptyError ResponseError swallows the 401 into a contentless typed error")
+    func emptyErrorResponseSwallowsThe401() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app)
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            // EmptyError's synthesized decode is a no-op, so it decodes from ANY
+            // valid-JSON rejection body — the 401 never reaches the caller. Pinned
+            // here so a DataFetch behavior change surfaces as a test delta.
+            let request = ShowGrantedReplyRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected EmptyError, but the request succeeded")
+            } catch is EmptyError {
+                // The documented swallow — a contentless typed error, no status visible
+            } catch {
+                Issue.record("Expected EmptyError, got \(error)")
+            }
+
+            #expect(request.responseBody == nil)
+        }
+    }
+
+    @Test("A custom ServerCredentialVerifier conformance is honored — the protocol seam")
+    func customVerifierIsHonored() async throws {
+        try await withRunningServer { app in
+            let protected = app.grouped(
+                ClientCredentialMiddleware(verifier: ApiKeyVerifier(expectedKey: "the-key"))
+            )
+            protected.get("protected") { _ in "granted" }
+        } _: { base in
+            let admitted = try await Self.send(
+                to: base,
+                headers: ["X-Api-Key": "the-key"]
+            )
+            #expect(admitted.status == 200)
+            #expect(admitted.body == "granted")
+
+            let rejected = try await Self.send(
+                to: base,
+                headers: ["X-Api-Key": "the-wrong-key"]
+            )
+            #expect(rejected.status == 401)
+        }
+    }
+
+    @Test("The verifier is consulted per request — a revoked token admits, then rejects")
+    func verifierConsultedPerRequest() async throws {
+        let registry = TokenRegistry(currentToken: "rotating-token")
+
+        try await withRunningServer { app in
+            Self.registerProtectedRoute(app, isValid: { token in
+                await registry.isCurrent(token)
+            })
+        } _: { base in
+            let headers = ["Authorization": "Bearer rotating-token"]
+
+            let beforeRevocation = try await Self.send(to: base, headers: headers)
+            #expect(beforeRevocation.status == 200)
+
+            await registry.revoke()
+
+            let afterRevocation = try await Self.send(to: base, headers: headers)
+            #expect(afterRevocation.status == 401)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Registers `GET /protected` behind a ``ClientCredentialMiddleware`` running the stock
+    /// bearer verifier over `isValid`.
+    private static func registerProtectedRoute(
+        _ app: Application,
+        isValid: @Sendable @escaping (String) async -> Bool
+    ) {
+        let protected = app.grouped(
+            ClientCredentialMiddleware(verifier: BearerCredentialVerifier(isValid: isValid))
+        )
+        protected.get("protected") { _ in "granted" }
+    }
+
+    /// Registers both client-contract fixtures behind an always-rejecting bearer verifier,
+    /// with FOS `ErrorMiddleware.default` replacing Vapor's stock error serializer — the
+    /// configuration the DocC's Client-Side Contract describes.
+    private static func registerRejectingClientContractRoutes(_ app: Application) throws {
+        app.middleware = .init()
+        app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+        let protected = app.grouped(
+            ClientCredentialMiddleware(verifier: BearerCredentialVerifier { _ in false })
+        )
+        try protected.register(collection: RoundTripController<ShowStrictErrorReplyRequest>(actions: [
+            .show: { _, _ in GrantedReply(message: "granted") }
+        ]))
+        try protected.register(collection: RoundTripController<ShowGrantedReplyRequest>(actions: [
+            .show: { _, _ in GrantedReply(message: "granted") }
+        ]))
+    }
+
+    /// Performs `GET <base>/protected` with the given headers and yields the raw
+    /// status + body + challenge header the server sent — no client-side error
+    /// mapping in the way.
+    private static func send(
+        to base: URL,
+        headers: [String: String]
+    ) async throws -> (status: Int, body: String, wwwAuthenticate: String?) {
+        var urlRequest = URLRequest(url: base.appendingPathComponent("protected"))
+        for (field, value) in headers {
+            urlRequest.setValue(value, forHTTPHeaderField: field)
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let http = response as? HTTPURLResponse else {
+                    continuation.resume(throwing: NonHTTPResponseFailure())
+                    return
+                }
+
+                continuation.resume(returning: (
+                    status: http.statusCode,
+                    body: String(data: data ?? Data(), encoding: .utf8) ?? "",
+                    wwwAuthenticate: http.value(forHTTPHeaderField: "WWW-Authenticate")
+                ))
+            }.resume()
+        }
+    }
+
+    /// An `MVVMEnvironment` pointed at the live server for every `Deployment`, so the test
+    /// holds regardless of how the test process resolves `Deployment.current`. The explicit
+    /// `session:`-before-`requestErrorHandler:` label order selects the non-SwiftUI
+    /// initializer (no bundle-version compatibility gate).
+    private static func environment(
+        base: URL,
+        provider: any ClientCredentialProvider
+    ) -> MVVMEnvironment {
+        MVVMEnvironment(
+            currentVersion: SystemVersion.current,
+            appBundle: Bundle.main,
+            clientCredentialProvider: provider,
+            deploymentURLs: [
+                .production: base,
+                .staging: base,
+                .debug: base,
+                .test: base
+            ],
+            session: nil,
+            requestErrorHandler: nil
+        )
+    }
+}
+
+/// The server replied with something other than HTTP — never expected against the harness.
+private struct NonHTTPResponseFailure: Error {}
+
+/// A custom verifier over a different credential scheme entirely (`X-Api-Key`) —
+/// proves the middleware honors any ``ServerCredentialVerifier`` conformance.
+private struct ApiKeyVerifier: ServerCredentialVerifier {
+    let expectedKey: String
+
+    func verify(headers: HTTPHeaders) async throws {
+        guard headers.first(name: "X-Api-Key") == expectedKey else {
+            throw Abort(.unauthorized, reason: "Invalid API key")
+        }
+    }
+}
+
+/// A revocable token source — models a server-side session store whose set of
+/// currently-valid tokens changes between requests.
+private actor TokenRegistry {
+    private var currentToken: String?
+
+    init(currentToken: String?) {
+        self.currentToken = currentToken
+    }
+
+    func isCurrent(_ token: String) -> Bool {
+        token == currentToken
+    }
+
+    func revoke() {
+        currentToken = nil
+    }
+}
+
+/// The response body a protected route grants — the client-contract test never
+/// receives one (the middleware rejects first).
+private struct GrantedReply: ServerRequestBody {
+    let message: String
+}
+
+/// A typed error with a required field — it does NOT decode from a rejection body,
+/// so the middleware's 401 stays visible to the caller as `DataFetchError.badStatus`.
+private struct StrictContractError: ServerRequestError {
+    let errorCode: Int
+}
+
+/// `.show` fixture behind the protected group — drives the REAL client
+/// (`processRequest(mvvmEnv:)`) against the middleware. Its `EmptyError`
+/// `ResponseError` is the known-limitation fixture: it decodes from any
+/// valid-JSON rejection body, swallowing the 401.
+private final class ShowGrantedReplyRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = GrantedReply
+    typealias ResponseError = EmptyError
+
+    var action: ServerRequestAction {
+        .show
+    }
+
+    var responseBody: GrantedReply?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: GrantedReply? = nil) {
+        self.responseBody = responseBody
+    }
+}
+
+/// The 401-visibility fixture: same `.show` shape, but its `ResponseError` cannot
+/// decode from a rejection body, so `DataFetchError.badStatus(401)` surfaces.
+private final class ShowStrictErrorReplyRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = GrantedReply
+    typealias ResponseError = StrictContractError
+
+    var action: ServerRequestAction {
+        .show
+    }
+
+    var responseBody: GrantedReply?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: GrantedReply? = nil) {
+        self.responseBody = responseBody
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift
@@ -1,0 +1,212 @@
+// ClientCredentialRoundTripTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end proof that a `ClientCredentialProvider` registered on `MVVMEnvironment` puts its
+// headers ON THE WIRE: the REAL client (`processRequest(mvvmEnv:)`) against a REAL server that
+// echoes back the header values it observed. The contract under test:
+//   • the provider's headers ARRIVE at the server,
+//   • the provider is consulted PER CALL (a rotated credential rides the next request),
+//   • provider headers append AFTER the static `requestHeaders`, so the per-request
+//     credential wins on a duplicate field while other static headers still flow,
+//   • a THROWING provider propagates to the caller and no request reaches the server.
+
+import FOSFoundation
+import FOSMVVM
+import FOSMVVMVapor
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+import Vapor
+
+@Suite("ClientCredentialProvider round-trip (processRequest(mvvmEnv:) ↔ running server)", .serialized)
+struct ClientCredentialRoundTripTests {
+    @Test("Provider headers arrive at the server, and rotation is reflected per call")
+    func providerHeaderArrivesAndRotates() async throws {
+        try await withRunningServer { app in
+            try app.routes.register(collection: Self.headerEchoController())
+        } _: { base in
+            let vault = TokenVault(token: "first")
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { await vault.token }
+            )
+
+            let firstRequest = ShowObservedHeadersRequest()
+            try await firstRequest.processRequest(mvvmEnv: env)
+            #expect(firstRequest.responseBody?.authorization == "Bearer first")
+
+            await vault.rotate(to: "second")
+
+            let secondRequest = ShowObservedHeadersRequest()
+            try await secondRequest.processRequest(mvvmEnv: env)
+            #expect(secondRequest.responseBody?.authorization == "Bearer second")
+        }
+    }
+
+    @Test("Provider headers append after static requestHeaders — provider wins on a duplicate field")
+    func providerHeadersWinOverStaticRequestHeaders() async throws {
+        try await withRunningServer { app in
+            try app.routes.register(collection: Self.headerEchoController())
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                requestHeaders: [
+                    "Authorization": "Bearer stale-static",
+                    "X-Client-Marker": "static-value"
+                ],
+                provider: BearerCredentialProvider { "fresh" }
+            )
+
+            let request = ShowObservedHeadersRequest()
+            try await request.processRequest(mvvmEnv: env)
+
+            // The duplicate field: the provider's per-request credential wins
+            #expect(request.responseBody?.authorization == "Bearer fresh")
+            // The non-duplicate static header still arrives
+            #expect(request.responseBody?.clientMarker == "static-value")
+        }
+    }
+
+    @Test("A throwing provider surfaces to the caller and no request reaches the server")
+    func throwingProviderSurfacesAndSendsNothing() async throws {
+        let tally = RequestTally()
+
+        try await withRunningServer { app in
+            let controller = RoundTripController<ShowObservedHeadersRequest>(actions: [
+                .show: { req, _ in
+                    await tally.increment()
+                    return ObservedHeaders(
+                        authorization: req.headers.first(name: "Authorization") ?? "<none>",
+                        clientMarker: req.headers.first(name: "X-Client-Marker") ?? "<none>"
+                    )
+                }
+            ])
+            try app.routes.register(collection: controller)
+        } _: { base in
+            let env = Self.environment(base: base, provider: FailingCredentialProvider())
+
+            let request = ShowObservedHeadersRequest()
+            await #expect(throws: CredentialResolutionFailure.self) {
+                try await request.processRequest(mvvmEnv: env)
+            }
+
+            // The failure pre-empted the request — the server served nothing
+            #expect(await tally.count == 0)
+            #expect(request.responseBody == nil)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Echoes the request headers the server observed back over the wire.
+    private static func headerEchoController() -> RoundTripController<ShowObservedHeadersRequest> {
+        RoundTripController(actions: [
+            .show: { req, _ in
+                ObservedHeaders(
+                    authorization: req.headers.first(name: "Authorization") ?? "<none>",
+                    clientMarker: req.headers.first(name: "X-Client-Marker") ?? "<none>"
+                )
+            }
+        ])
+    }
+
+    /// An `MVVMEnvironment` pointed at the live server for every `Deployment`, so the test
+    /// holds regardless of how the test process resolves `Deployment.current`. The explicit
+    /// `session:`-before-`requestErrorHandler:` label order selects the non-SwiftUI initializer
+    /// (no bundle-version compatibility gate).
+    private static func environment(
+        base: URL,
+        requestHeaders: [String: String] = [:],
+        provider: any ClientCredentialProvider
+    ) -> MVVMEnvironment {
+        MVVMEnvironment(
+            currentVersion: SystemVersion.current,
+            appBundle: Bundle.main,
+            requestHeaders: requestHeaders,
+            clientCredentialProvider: provider,
+            deploymentURLs: [
+                .production: base,
+                .staging: base,
+                .debug: base,
+                .test: base
+            ],
+            session: nil,
+            requestErrorHandler: nil
+        )
+    }
+}
+
+/// A mutable token source — models an app session whose credential rotates between requests.
+/// (Mirrors the helper in `ClientCredentialProviderTests` — separate test targets, same shape.)
+private actor TokenVault {
+    var token: String?
+
+    init(token: String?) {
+        self.token = token
+    }
+
+    func rotate(to newToken: String?) {
+        token = newToken
+    }
+}
+
+/// The failure a credential provider raises when its credential cannot be resolved.
+private struct CredentialResolutionFailure: Error {}
+
+/// A provider whose credential resolution always fails — drives the propagation contract.
+private struct FailingCredentialProvider: ClientCredentialProvider {
+    func credentialHeaders() async throws -> [(field: String, value: String)] {
+        throw CredentialResolutionFailure()
+    }
+}
+
+/// Counts the requests the server actually served.
+private actor RequestTally {
+    private(set) var count = 0
+
+    func increment() {
+        count += 1
+    }
+}
+
+/// The header values the server observed — the processor writes them; the client decodes them
+/// off the wire.
+private struct ObservedHeaders: ServerRequestBody {
+    let authorization: String
+    let clientMarker: String
+}
+
+/// `.show` fixture whose response body carries the observed headers.
+private final class ShowObservedHeadersRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = ObservedHeaders
+    typealias ResponseError = EmptyError
+
+    var action: ServerRequestAction {
+        .show
+    }
+
+    var responseBody: ObservedHeaders?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: ObservedHeaders? = nil) {
+        self.responseBody = responseBody
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Protocols/RoundTripHarness.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/RoundTripHarness.swift
@@ -1,0 +1,80 @@
+// RoundTripHarness.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The live-server round-trip harness, shared by the suites that exercise the REAL client
+// (`ServerRequest.processRequest` → `DataFetch` → a live `URLSession`) against a REAL server
+// bound to an OS-assigned port (see `ServerRequestRoundTripTests` for why that gap matters).
+
+import FOSFoundation
+import FOSMVVM
+import FOSMVVMVapor
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+import Vapor
+
+/// Boots a real listening `Application` on an OS-assigned port (`127.0.0.1:0`), registers routes
+/// via `register`, yields the base URL (`http://127.0.0.1:<port>`) to `body`, then tears the
+/// server down. Localization is initialized so `buildResponse`'s `localizingEncoder` resolves.
+func withRunningServer(
+    register: (Application) throws -> Void,
+    _ body: (URL) async throws -> Void
+) async throws {
+    let app = try await Application.make(.testing)
+    do {
+        // A stub store so `buildResponse`'s `localizingEncoder` resolves (keys fall back to
+        // default). The live server needs this; the round-trip asserts transport, not localization.
+        app.localizationStore = RoundTripLocalizationStore()
+        try register(app)
+
+        try await app.server.start(address: .hostname("127.0.0.1", port: 0))
+        let port = try #require(
+            app.http.server.shared.localAddress?.port,
+            "Failed to read OS-assigned port after server.start"
+        )
+        let base = try #require(URL(string: "http://127.0.0.1:\(port)"))
+
+        try await body(base)
+
+        await app.server.shutdown()
+        try await app.asyncShutdown()
+    } catch {
+        await app.server.shutdown()
+        try await app.asyncShutdown()
+        throw error
+    }
+}
+
+/// A no-op `LocalizationStore` so `req.localizingEncoder` resolves on the live server; every key
+/// falls back to its `default`.
+private struct RoundTripLocalizationStore: LocalizationStore {
+    func value(_ key: String, locale: Locale, default defaultValue: Any?, index: Int?) -> Any? {
+        defaultValue
+    }
+}
+
+/// A hand-written controller: one processor per action, over any `ServerRequest`.
+final class RoundTripController<R: ServerRequest>: ServerRequestController, @unchecked Sendable {
+    typealias TRequest = R
+
+    let actions: [ServerRequestAction: ActionProcessor]
+
+    init(actions: [ServerRequestAction: ActionProcessor]) {
+        self.actions = actions
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Protocols/ServerRequestRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/ServerRequestRoundTripTests.swift
@@ -52,14 +52,13 @@ struct ServerRequestRoundTripTests {
 
     /// An `EmptyBody` response must round-trip through the real client too. This drives the exact
     /// header `processRequest(mvvmEnv:)` injects for an `EmptyBody` response — `Accept: text/plain`
-    /// (`ServerRequest+Fetch.swift:122`) — which is what a real consumer sends.
+    /// (the `EmptyBody` branch of `processRequest` in `ServerRequest+Fetch.swift`) — which is what
+    /// a real consumer sends.
     ///
-    /// It currently FAILS (`DataFetchError.badResponseMimeType`): `buildResponse` answers
-    /// `application/json` (`EmptyBody` → `{}`) regardless of `Accept`, and `DataFetch.checkMimeType`
-    /// rejects `application/json` against the expected `text/plain`. That is the content-negotiation
-    /// gap (PL-8): one fixed `Accept` for `EmptyBody` cannot satisfy both a `text/plain` (plain REST)
-    /// server and an `application/json` (`buildResponse`) server. The fix should make an `EmptyBody`
-    /// response content-agnostic (on 2xx, decode to `EmptyBody()` without a MIME gate).
+    /// This locks the resolution of the content-negotiation gap (PL-8): an `EmptyBody` response is
+    /// content-agnostic on the client (any 2xx body is accepted and discarded, no MIME gate), so one
+    /// request satisfies both an `application/json` (`buildResponse` answers `{}`) server and a
+    /// `text/plain` (plain REST) server.
     @Test func emptyBodyResponseRoundTrips() async throws {
         try await withRunningServer { app in
             let controller = RoundTripController<EmptyAckRequest>(actions: [
@@ -112,50 +111,11 @@ struct ServerRequestRoundTripTests {
         }
     }
 
-    // MARK: - Harness
-
-    /// Boots a real listening `Application` on an OS-assigned port (`127.0.0.1:0`), registers routes
-    /// via `register`, yields the base URL (`http://127.0.0.1:<port>`) to `body`, then tears the
-    /// server down. Localization is initialized so `buildResponse`'s `localizingEncoder` resolves.
-    private func withRunningServer(
-        register: (Application) throws -> Void,
-        _ body: (URL) async throws -> Void
-    ) async throws {
-        let app = try await Application.make(.testing)
-        do {
-            // A stub store so `buildResponse`'s `localizingEncoder` resolves (keys fall back to
-            // default). The live server needs this; the round-trip asserts transport, not localization.
-            app.localizationStore = RoundTripLocalizationStore()
-            try register(app)
-
-            try await app.server.start(address: .hostname("127.0.0.1", port: 0))
-            let port = try #require(
-                app.http.server.shared.localAddress?.port,
-                "Failed to read OS-assigned port after server.start"
-            )
-            let base = try #require(URL(string: "http://127.0.0.1:\(port)"))
-
-            try await body(base)
-
-            await app.server.shutdown()
-            try await app.asyncShutdown()
-        } catch {
-            await app.server.shutdown()
-            try await app.asyncShutdown()
-            throw error
-        }
-    }
+    // The harness (`withRunningServer`) and the generic `RoundTripController` live in
+    // `RoundTripHarness.swift`, shared with the other live-server round-trip suites.
 }
 
 // MARK: - Fixtures
-
-/// A no-op `LocalizationStore` so `req.localizingEncoder` resolves on the live server; every key
-/// falls back to its `default`.
-private struct RoundTripLocalizationStore: LocalizationStore {
-    func value(_ key: String, locale: Locale, default defaultValue: Any?, index: Int?) -> Any? {
-        defaultValue
-    }
-}
 
 /// A query carrying a single string, so a `.show` processor can echo it back over the wire.
 private struct RoundTripQuery: ServerRequestQuery {
@@ -165,17 +125,6 @@ private struct RoundTripQuery: ServerRequestQuery {
 /// A marker response body — the processor writes what it observed; the client decodes it off the wire.
 private struct RoundTripMarker: ServerRequestBody {
     let marker: String
-}
-
-/// A hand-written controller: one processor per action, over any `ServerRequest`.
-private final class RoundTripController<R: ServerRequest>: ServerRequestController, @unchecked Sendable {
-    typealias TRequest = R
-
-    let actions: [ServerRequestAction: ActionProcessor]
-
-    init(actions: [ServerRequestAction: ActionProcessor]) {
-        self.actions = actions
-    }
 }
 
 /// `.show` fixture with a real (`RoundTripMarker`) response body — the control case.

--- a/docs/superpowers/plans/2026-07-09-localizable-overload-sweep.md
+++ b/docs/superpowers/plans/2026-07-09-localizable-overload-sweep.md
@@ -1,0 +1,529 @@
+# SwiftUI Localizable Overload Sweep — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A maintainer-run Swift script that sweeps the SwiftUI/SwiftUICore
+symbol graphs and generates FOSMVVM's complete `Localizable` overload
+surface, replacing the seven hand-written mirror locations.
+
+**Architecture:** Six-stage pipeline (Extract → Select → Union →
+Transform → Emit → Verify) in one sectioned script,
+`Scripts/localizable-overload-sweep.swift`, zero dependencies, decoding
+`swift-symbolgraph-extract` JSON with `Codable`. Generated sources are
+checked in under `Sources/FOSMVVM/SwiftUI Support/Generated/`; skipped
+candidates are logged in a checked-in `SweepCoverage.md`. Version
+identity is per-platform SDK versions, never Xcode's.
+
+**Tech Stack:** Swift 6, Foundation only (script); Swift Testing
+(behavioral tests); GitHub Actions (staleness gate).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-swiftui-localizable-overload-generator-design.md`
+— read it first; it is the source of truth for every rule referenced
+below. This plan resequences the spec's migration (relocate → generate
+→ swap-delete) so the build stays green at every commit; the spec's
+constraint (relocate before delete) is preserved.
+
+---
+
+## File structure
+
+| Path | Role |
+|---|---|
+| `Scripts/localizable-overload-sweep.swift` | The generator (new; sectioned by pipeline stage) |
+| `Sources/FOSMVVM/SwiftUI Support/Generated/*.swift` | Generated overloads, one file per extended type (new; machine-owned) |
+| `Sources/FOSMVVM/SwiftUI Support/SweepCoverage.md` | Coverage manifest (new; machine-owned) |
+| `Sources/FOSMVVM/SwiftUI Support/LocalizableViews.swift` | Relocated hand-written survivors (new) |
+| `Sources/FOSMVVM/SwiftUI Support/Text.swift` | DELETED after relocation + swap |
+| `Sources/FOSMVVM/SwiftUI Support/{Label,LabeledContent,Tab,ContentUnavailableView,TextField}.swift` | DELETED at swap |
+| `Sources/FOSMVVM/SwiftUI Support/View.swift` | `navigationTitle` mirror removed; everything else untouched |
+| `Package.swift` | `exclude` entry for `SweepCoverage.md` in the FOSMVVM target |
+| `Tests/FOSMVVMTests/SwiftUI Support/GeneratedOverloadTests.swift` | Behavioral contract tests (new) |
+| `.github/workflows/ci.yml` | Staleness-gate job (new job appended) |
+| `.claude/skills/shared/api-catalog/FOSMVVM.md` | One family entry, § SwiftUI Support |
+| `CHANGELOG.md` | Unreleased entry (breaking: `defaultTitle:` → `defaultValue:`, `any` → `some`) |
+
+**Branch:** all work on `spec/localizable-overload-sweep` (repo
+convention), PR to `main` only after David's review gate.
+
+---
+
+## Rationale notes for the implementer (not DocC material)
+
+- **Why the script never emits on doubt:** a wrong overload is public
+  API shipped to every FOSMVVM consumer. Skip + manifest beats guess.
+- **Why delegate-by-name works without pinpointing the exact sibling:**
+  the emitted body calls `self.init(...)`/`method(...)` with a `String`
+  argument; the compiler's overload resolution picks Apple's
+  `StringProtocol` variant. Sibling matching is only a *gate* to avoid
+  emitting calls with no target; the CI compile is the real verifier.
+  Recursion is impossible: our overloads take `some Localizable`, and
+  `String` is not `Localizable`.
+- **Why variadic-parameter candidates are skipped:** Swift cannot
+  forward a variadic argument list to another variadic parameter.
+  Closed-set reason: `unrecognized-shape`.
+- **swiftformat interaction:** the repo's swiftformat config inserts
+  the Apache header as the *first* comment block. The script must emit
+  that header itself (byte-identical to what swiftformat would insert)
+  and place the DO-NOT-EDIT stamp as a *second* comment block, so a
+  swiftformat pass is a no-op. Acceptance for Task 7 includes
+  swiftformat idempotence.
+- **`defaultedLocalizedString` stays `internal`**
+  (`Sources/FOSMVVM/Localization/Localizable.swift:65`) — generated
+  files are in the same module. Do not widen access.
+- **Memory strategy:** decode one platform×module graph at a time;
+  run Select during decode; discard everything else before loading the
+  next graph (multi-GB working set otherwise).
+
+---
+
+### Task 0: Branch
+
+**Files:** none
+
+- [ ] **Step 1:** `git checkout -b spec/localizable-overload-sweep`
+- [ ] **Step 2:** Confirm clean: `git status` → nothing to commit
+
+---
+
+### Task 1: Relocate hand-written survivors (build stays green)
+
+**Files:**
+- Create: `Sources/FOSMVVM/SwiftUI Support/LocalizableViews.swift`
+- Modify: `Sources/FOSMVVM/SwiftUI Support/Text.swift`
+
+Move — verbatim, no edits beyond the move — from `Text.swift` into the
+new `LocalizableViews.swift`:
+
+1. `public extension Localizable { var text: some View ... }` (Text.swift:50-54)
+2. `private struct LocalizableResolverView<L: Localizable>: View { ... }` (Text.swift:56-104)
+3. The optional-Localizable init `init(_ localizable: (some Localizable)?, defaultValue: String? = nil)` (Text.swift:45-47) — it mirrors nothing in SwiftUI (no optional-key inits exist) and stays hand-written per spec.
+
+`Text.swift` keeps (for now) only the non-optional mirror init; it is
+deleted in Task 8. `LocalizableViews.swift` needs the same imports as
+`Text.swift` (`FOSFoundation`, `#if canImport(SwiftUI) import SwiftUI`)
+and the Apache header (run `swiftformat .`).
+
+- [ ] **Step 1:** Create the file, move the three items, leave `Text.swift` compiling with just the plain mirror init.
+- [ ] **Step 2:** `swift build --target FOSMVVM` → succeeds
+- [ ] **Step 3:** `swift test --filter FOSMVVMTests` → green
+- [ ] **Step 4:** Commit: `refactor(FOSMVVM): relocate Localizable resolution machinery to LocalizableViews.swift`
+
+---
+
+### Task 2: Script skeleton + Extract stage
+
+**Files:**
+- Create: `Scripts/localizable-overload-sweep.swift`
+
+Follow `Scripts/api-catalog-audit.swift` conventions (top-of-file
+usage comment, Apache header, `import Foundation`, runs via
+`swift Scripts/localizable-overload-sweep.swift`). No shebang.
+
+CLI surface (parse from `CommandLine.arguments` by hand, as the audit
+script does):
+
+```
+swift Scripts/localizable-overload-sweep.swift [flags]
+  --check           regenerate to a temp dir and diff against checked-in
+                    output; exit 1 on drift (used by CI)
+  --filter <Type>   process only symbols whose extended type == <Type>
+                    (debugging affordance)
+  --keep-graphs     leave extracted JSON in the temp dir and print its path
+```
+
+Extract stage:
+
+```swift
+// MARK: - Stage 1: Extract
+
+struct PlatformSDK {
+    let platform: String       // "macosx", "iphoneos", "appletvos", "watchos", "xros"
+    let target: String         // "arm64-apple-macos15.0", "arm64-apple-ios17.0", ...
+    let version: String        // from `xcrun --sdk <p> --show-sdk-version`
+    let path: String           // from `xcrun --sdk <p> --show-sdk-path`
+}
+
+let requiredSDKs = ["macosx", "iphoneos", "appletvos", "watchos", "xros"]
+let modules = ["SwiftUI", "SwiftUICore"]
+```
+
+- Resolve all five SDKs first. **Any missing → print exactly which and
+  `exit(1)`** (spec: no partial-platform generation).
+- For each SDK × module: run
+  `xcrun swift-symbolgraph-extract -module-name <m> -target <t> -sdk <path> -output-dir <tmp>/<platform>/`
+  via `Process`. Collect main graphs *and* `<m>@*.symbols.json`
+  extension graphs.
+- Record each SDK's version string — this is the run's identity stamp.
+- Print a one-line summary per graph: platform, module, byte size.
+
+- [ ] **Step 1:** Write the section with CLI parsing + Extract.
+- [ ] **Step 2:** Run: `swift Scripts/localizable-overload-sweep.swift --keep-graphs` → summary lists ≥ 10 graphs across 5 platforms; SDK versions printed.
+- [ ] **Step 3:** Temporarily rename one SDK dir? — do NOT; instead verify the missing-SDK path with `xcrun --sdk madeupos --show-sdk-version` behavior stubbed in a code path review. (Manual verification; the hard-exit is trivially inspectable.)
+- [ ] **Step 4:** Commit: `feat(scripts): overload sweep — extract stage`
+
+---
+
+### Task 3: Codable models + Select stage
+
+**Files:**
+- Modify: `Scripts/localizable-overload-sweep.swift`
+
+```swift
+// MARK: - Symbol graph model (subset we consume)
+
+struct SymbolGraph: Decodable {
+    let symbols: [Symbol]
+    let relationships: [Relationship]
+}
+
+struct Symbol: Decodable {
+    struct Identifier: Decodable { let precise: String }
+    struct Kind: Decodable { let identifier: String }   // "swift.init" | "swift.method" | "swift.func" | ...
+    struct Fragment: Decodable {
+        let kind: String            // "typeIdentifier" | "externalParam" | "text" | ...
+        let spelling: String
+        let preciseIdentifier: String?
+    }
+    struct Availability: Decodable {
+        struct Version: Decodable { let major: Int; let minor: Int?; let patch: Int? }
+        let domain: String?
+        let introduced: Version?
+        let deprecated: Version?
+        let obsoleted: Version?
+        let isUnconditionallyDeprecated: Bool?
+        let isUnconditionallyUnavailable: Bool?
+    }
+    struct SwiftExtension: Decodable {
+        struct Constraint: Decodable { let kind: String; let lhs: String; let rhs: String }
+        let extendedModule: String?
+        let constraints: [Constraint]?
+    }
+    let identifier: Identifier
+    let kind: Kind
+    let pathComponents: [String]        // ["Text", "init(_:tableName:bundle:comment:)"]
+    let declarationFragments: [Fragment]?
+    let availability: [Availability]?
+    let swiftExtension: SwiftExtension?
+    let accessLevel: String?
+}
+
+struct Relationship: Decodable {
+    let kind: String                    // "memberOf" | "extensionTo" | ...
+    let source: String
+    let target: String
+    let targetFallback: String?         // "SwiftUICore.Text"
+}
+```
+
+Selection rule (spec Stage 2), applied per graph during decode:
+
+```swift
+let localizedStringKeyUSR = "s:7SwiftUI18LocalizedStringKeyV"
+
+func isCandidate(_ s: Symbol) -> Bool {
+    guard ["swift.init", "swift.method", "swift.func"].contains(s.kind.identifier),
+          s.accessLevel == "public",
+          let frags = s.declarationFragments,
+          // parameter position: a typeIdentifier fragment for LocalizedStringKey
+          frags.contains(where: { $0.preciseIdentifier == localizedStringKeyUSR }),
+          !s.pathComponents.contains(where: { $0.hasPrefix("_") }),
+          !isDeprecatedOrObsoleted(s.availability)
+    else { return false }
+    return true
+}
+```
+
+`isDeprecatedOrObsoleted`: true if any availability entry has
+`isUnconditionallyDeprecated`, `deprecated`, or `obsoleted` set.
+Every rejected candidate that matched the LocalizedStringKey test but
+failed a later clause is retained (USR + reason) for the manifest.
+
+**Caution (verify while implementing):** `LocalizedStringKey`'s USR may
+differ now that it lives in SwiftUICore (`s:11SwiftUICore…`). Do not
+hardcode blindly — locate the `LocalizedStringKey` type symbol in the
+graphs first and take its USR from there; fail loudly if not found.
+
+- [ ] **Step 1:** Write models + Select; wire per-graph streaming (decode → select → discard).
+- [ ] **Step 2:** Run with `--filter Text` → prints candidate list including `init(_:tableName:bundle:comment:)`-style inits.
+- [ ] **Step 3:** Run unfiltered → total candidate count printed; expect same order of magnitude as the probe (thousands pre-dedup across platforms) and post-filter counts per kind.
+- [ ] **Step 4:** Commit: `feat(scripts): overload sweep — symbol models + select stage`
+
+---
+
+### Task 4: Union + availability merge + floor clamp
+
+**Files:**
+- Modify: `Scripts/localizable-overload-sweep.swift`
+
+- Merge candidates across platforms by USR into one record with a
+  per-domain availability map (`iOS`, `macOS`, `macCatalyst`, `tvOS`,
+  `watchOS`, `visionOS`).
+- A domain seen in a platform's graph without an `introduced` version =
+  available since forever → treated as at-floor.
+- Floors (from Package.swift): iOS 17, macOS 14, macCatalyst 17,
+  tvOS 17, watchOS 10, visionOS 1. Clamp: `introduced <= floor` ⇒ drop
+  from the emitted annotation; all domains dropped ⇒ no annotation.
+- `isUnconditionallyUnavailable` domains ⇒ `@available(<domain>, unavailable)` lines.
+- Flag `beta-tier` when a domain's `introduced` equals that platform's
+  SDK version *and* the SDK version string marks a beta/major ahead of
+  the current release train (implementable as: introduced == SDK
+  version; the flag is informational only).
+
+- [ ] **Step 1:** Implement union + merge + clamp.
+- [ ] **Step 2:** Run `--filter TextField` → the `selection:` init shows `@available(iOS 18.0, macOS 15.0, visionOS 2.0, *)` + tvOS/watchOS unavailable (cross-check against `TextField.swift:130-132` before it is deleted).
+- [ ] **Step 3:** Run `--filter Text` → the basic init shows NO annotation (pre-floor).
+- [ ] **Step 4:** Commit: `feat(scripts): overload sweep — union and availability clamping`
+
+---
+
+### Task 5: Extended-type resolution + sibling index + delegate policy
+
+**Files:**
+- Modify: `Scripts/localizable-overload-sweep.swift`
+
+**Extended type:** `pathComponents.dropLast()` names the extended type
+(`["Text", "init(...)"]` → `Text`; `["View", "navigationTitle(_:)"]` →
+`View`). Extension constraints come from the `swiftExtension` mixin
+(e.g. `Label` members carry `Title == Text, Icon == Image`). Nested
+types (`dropLast()` count > 1) → join with `.`.
+
+**Sibling index:** while decoding each graph, also index NON-candidate
+public inits/methods by `(extendedType, pathComponents.last!)` — i.e.
+same name, same arity-labels. For a candidate, a **String sibling**
+exists when an indexed sibling's fragments have, at the
+LocalizedStringKey parameter position(s), `some StringProtocol` (or a
+generic constrained to `StringProtocol`); a **Text sibling** when the
+position holds `Text`. Position comparison is by external parameter
+labels, not fragment offsets.
+
+**Delegate policy (spec Stage 4):**
+1. String sibling → direct delegation.
+2. Else Text sibling → wrap: `Text(verbatim: <resolved>)`.
+3. Else → skip, manifest reason `no-delegate-target`.
+
+Variadic parameter anywhere in the candidate → skip,
+`unrecognized-shape` (cannot forward variadics in Swift).
+
+- [ ] **Step 1:** Implement type resolution, sibling index, policy classification.
+- [ ] **Step 2:** Run summary: counts per policy path printed; `navigationTitle` classifies as policy 1. Spot-check one policy-2 and one skipped candidate and record them for Task 6's golden checks.
+- [ ] **Step 3:** Commit: `feat(scripts): overload sweep — sibling matching and delegate policy`
+
+---
+
+### Task 6: Transform stage
+
+**Files:**
+- Modify: `Scripts/localizable-overload-sweep.swift`
+
+Signature rewrite over `declarationFragments` (work on the fragment
+array, not regex over joined text):
+
+- Fragment run for each LocalizedStringKey **parameter type** →
+  replace with `some Localizable`.
+- After each replaced parameter, insert
+  `, defaultValue: String? = nil` (unnamed slot) or
+  `, default<CapitalizedLabel>: String? = nil` (labeled slot).
+- Copy verbatim: `nonisolated`, generic parameter lists, `where`
+  clauses, default arguments, attributes (`@ViewBuilder`, `@escaping`),
+  return types.
+- Body:
+  - init-shaped: `self.init(<resolved>, <passthrough args>)`
+  - method-shaped: `<name>(<resolved>, <passthrough args>)`
+  - `<resolved>` = `localizable.defaultedLocalizedString(defaultValue: defaultValue)`
+    (or the `default<Label>`-named parameter for labeled slots), wrapped
+    in `Text(verbatim: ...)` on policy path 2.
+  - passthrough: every other parameter forwarded by label
+    (`prompt: prompt`), including defaulted ones.
+- Any fragment shape the rewriter does not recognize → skip the
+  candidate, `unrecognized-shape`, with the raw declaration in the
+  manifest. **Never emit a guess.**
+
+- [ ] **Step 1:** Implement transform.
+- [ ] **Step 2 (golden check):** `--filter Label` printed output matches the hand-written `Label.swift:26-46` shape (modulo DocC + `defaultValue` position); diff by eye.
+- [ ] **Step 3 (golden check):** `--filter View` output contains a `navigationTitle(_ localizable: some Localizable, defaultValue: String? = nil) -> some View` delegating by method call.
+- [ ] **Step 4:** Commit: `feat(scripts): overload sweep — transform stage`
+
+---
+
+### Task 7: Emit stage + manifest + Package.swift exclude
+
+**Files:**
+- Modify: `Scripts/localizable-overload-sweep.swift`
+- Modify: `Package.swift` (FOSMVVM target: add `exclude` for `SwiftUI Support/SweepCoverage.md`)
+- Create (generated): `Sources/FOSMVVM/SwiftUI Support/Generated/*.swift`, `Sources/FOSMVVM/SwiftUI Support/SweepCoverage.md`
+
+File layout per generated file:
+
+```swift
+// <TypeName>.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+// <exact Apache header block the repo's swiftformat config emits>
+
+// GENERATED FILE — DO NOT EDIT
+// Generated by Scripts/localizable-overload-sweep.swift
+// SDKs: macosx <v> | iphoneos <v> | appletvos <v> | watchos <v> | xros <v>
+// Xcode <v> (informational)
+// Regenerate: swift Scripts/localizable-overload-sweep.swift
+
+#if canImport(SwiftUI)
+import SwiftUI
+
+public extension <TypeName> <constraints> {
+    /// Localizable-accepting form of SwiftUI's `<TypeName>.<title>`.
+    ///
+    /// ## Example
+    /// ```swift
+    /// <one concrete example — full example on the file's first overload,
+    ///  one-liner on the rest>
+    /// ```
+    /// - Parameters:
+    ///   - localizable: The ``Localizable`` to display.
+    ///   - defaultValue: Fallback text used if localization did not complete.
+    <overload>
+}
+#endif
+```
+
+- Group overloads by extended type; one file per type; members sorted
+  by USR (determinism). Multiple constraint-sets on one type → multiple
+  `extension` blocks in the same file.
+- Availability annotation (from Task 4) directly above each overload.
+- `SweepCoverage.md`: header with the same SDK stamp, then sections per
+  closed-set reason (`deprecated`, `no-delegate-target`,
+  `unrecognized-shape`), one line per skipped USR with its declaration
+  title; `beta-tier` flags listed in their own section. Sorted. Nothing
+  silently dropped.
+- `--check` mode: emit to temp dir; byte-compare against checked-in
+  `Generated/` + `SweepCoverage.md`; nonzero exit + file list on drift.
+
+- [ ] **Step 1:** Implement emit + manifest + `--check`.
+- [ ] **Step 2:** Run the script for real. `Generated/` populates; skim `Text.swift`, `View.swift` outputs.
+- [ ] **Step 3:** `swiftformat .` → **zero changes in `Generated/`** (idempotence acceptance). If it rewrites anything, fix the emitter, not the config.
+- [ ] **Step 4:** `swift Scripts/localizable-overload-sweep.swift --check` → exit 0. Touch one generated file, re-run → exit 1 naming it; revert.
+- [ ] **Step 5:** Commit (script + Package.swift only — generated output lands with the swap): `feat(scripts): overload sweep — emit, manifest, --check`
+
+---
+
+### Task 8: The swap (delete mirrors, build green)
+
+**Files:**
+- Delete: `Label.swift`, `LabeledContent.swift`, `Tab.swift`, `ContentUnavailableView.swift`, `TextField.swift`, `Text.swift` (all in `SwiftUI Support/`)
+- Modify: `View.swift` — remove ONLY the `navigationTitle` overload, DocC + func (View.swift:38-57). Line 37 (`public extension View {`) MUST stay — `invalidateBinding` and `refreshedViewModel` live in that same extension block. `withValidations` and the `EnvironmentValues` entry also stay.
+- Add: everything under `Generated/` + `SweepCoverage.md`
+
+- [ ] **Step 1:** Delete/trim per the file list. **Do not touch `LocalizableViews.swift`.**
+- [ ] **Step 2:** `swift build` → fix any in-repo call sites that used retired spellings. No `defaultTitle:` callers exist in `Sources/`; the realistic risk is `any` → `some` inference at the ~13 `TextField(` call sites in `FormFieldView.swift`.
+- [ ] **Step 3:** `swift test` → full suite green on macOS.
+- [ ] **Step 4:** `xcrun xcodebuild` iOS-simulator build (mirror the ci.yml invocation) → compiles. This is the first proof the availability matrices are coherent on a non-macOS platform.
+- [ ] **Step 5:** Commit: `feat(FOSMVVM)!: generated Localizable overload surface replaces hand-written mirrors`
+
+---
+
+### Task 9: Behavioral contract tests
+
+**Files:**
+- Create: `Tests/FOSMVVMTests/SwiftUI Support/GeneratedOverloadTests.swift`
+
+Contract-only (no `@testable` for these; construct via public API;
+`Text` is `Equatable` — assert behavior, never generated text):
+
+```swift
+// Policy path 1 (String sibling): a localized Localizable renders its value
+@Test func textOverloadUsesLocalizedValue() throws {
+    let localizable = /* localized LocalizableString via existing test YAML store —
+                         follow the construction pattern in existing FOSMVVMTests
+                         localization tests */
+    #expect(Text(localizable) == Text(verbatim: try localizable.localizedString))
+}
+
+// defaultValue contract: pending (un-localized) value falls back
+@Test func textOverloadFallsBackToDefaultValue() {
+    let pending = LocalizedString(/* pending, not encoded */)
+    #expect(Text(pending, defaultValue: "fallback") == Text(verbatim: "fallback"))
+}
+
+// Policy path 2 (Text sibling): pick one generated policy-2 overload
+// (recorded in Task 5 Step 2) and assert its observable contract the
+// same way if the type is Equatable; otherwise compile-exercise it in
+// a @ViewBuilder body and assert the view builds.
+
+// Modifier path: compile-exercise
+@Test @MainActor func navigationTitleOverloadBuilds() {
+    let localizable: LocalizedString = /* localized */
+    _ = EmptyView().navigationTitle(localizable) // compiles + returns some View
+}
+```
+
+- [ ] **Step 1:** Write the four tests following existing FOSMVVMTests localization-store setup.
+- [ ] **Step 2:** `swift test --filter GeneratedOverloadTests` → green.
+- [ ] **Step 3:** Commit: `test(FOSMVVM): behavioral contract tests for generated overloads`
+
+---
+
+### Task 10: CI staleness gate
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (append job)
+
+```yaml
+  overload_sweep_staleness:
+    name: Generated overloads staleness gate
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Compare SDK stamp and regenerate
+        run: |
+          # The script's --check mode compares per-platform SDK versions
+          # against the stamp in SweepCoverage.md. Platforms whose SDK
+          # version differs are reported and skipped (exit 0 + notice);
+          # matching platforms must be diff-clean (exit 1 on drift).
+          swift Scripts/localizable-overload-sweep.swift --check
+```
+
+Requires `--check` to implement the per-platform skip semantics (spec
+Stage 6): version mismatch ⇒ informational skip, never failure —
+regeneration is a deliberate act, and a runner with a missing SDK
+(e.g. no visionOS image) reports-and-skips that platform rather than
+hard-exiting in `--check` mode. (Full generation keeps the hard-exit.)
+
+- [ ] **Step 1:** Adjust `--check` for per-platform skip semantics; add the job.
+- [ ] **Step 2:** Local rehearsal: `swift Scripts/localizable-overload-sweep.swift --check` → exit 0 with per-platform verdict lines.
+- [ ] **Step 3:** Commit: `ci: staleness gate for generated Localizable overloads`
+
+---
+
+### Task 11: Catalog, CHANGELOG, docs
+
+**Files:**
+- Modify: `.claude/skills/shared/api-catalog/FOSMVVM.md` — one *family* entry under § SwiftUI Support describing the generated overload surface (how to call: `Text(viewModel.title)`, `Button(vm.action) {...}`, etc.; contract: mirrors SwiftUI's LocalizedStringKey surface with `some Localizable` + `defaultValue:`), marked `<!-- apple-only -->` if the audit requires it.
+- Modify: `CHANGELOG.md` — Unreleased: feature (full generated overload surface) + breaking (`defaultTitle:` → `defaultValue:`, `any` → `some`, removed optional-init relocation notes).
+
+- [ ] **Step 1:** Write both entries.
+- [ ] **Step 2:** `swift Scripts/api-catalog-audit.swift` → no stale-entry errors introduced (gap warnings about generated members should be satisfied by the family entry; if the audit floods, extend `scripts/api-catalog-ignore.txt` per its documented mechanism and note it in the PR).
+- [ ] **Step 3:** Commit: `docs: catalog family entry + CHANGELOG for generated overloads`
+
+---
+
+### Task 12: Final verification + review gate
+
+- [ ] **Step 1:** `swiftformat .` → no diff; `swiftlint` → clean.
+- [ ] **Step 2:** `swift test` full suite → green; record counts.
+- [ ] **Step 3:** `swift Scripts/localizable-overload-sweep.swift --check` → exit 0.
+- [ ] **Step 4:** Squash granular commits into logical commits (script / migration / tests / ci+docs). **Do NOT open a PR** — push the branch and stop: David reviews first (repo review gate), then says go.
+
+---
+
+## Deviations that require stopping
+
+- The real graphs surface a candidate class the transform rules don't
+  cover cleanly (beyond variadics) → stop and show David the class, do
+  not invent policy 4.
+- Generated output fails to compile on any platform after honest
+  sibling-matching → the delegate policy has a hole; stop, bring the
+  failing declarations.
+- The candidate count after filtering is wildly off the probe's order
+  of magnitude (e.g. 10 or 50,000) → selection rule is wrong; stop.

--- a/docs/superpowers/specs/2026-07-09-swiftui-localizable-overload-generator-design.md
+++ b/docs/superpowers/specs/2026-07-09-swiftui-localizable-overload-generator-design.md
@@ -1,0 +1,284 @@
+# SwiftUI Localizable Overload Generator — Design
+
+**Date:** 2026-07-09
+**Status:** Approved design, pre-implementation
+**Owner:** David Hunt
+
+## Problem
+
+FOSMVVM ships `Localizable`-accepting overloads that mirror SwiftUI's
+`LocalizedStringKey`/`String` APIs (`Text`, `Label`, `TextField`,
+`LabeledContent`, `Tab`, `ContentUnavailableView`, `View.navigationTitle`).
+
+Today those overloads are hand-written:
+
+- Coverage is incidental (seven files; Button, Toggle, Picker, alerts,
+  and hundreds of others have no overload).
+- Conventions drifted (`defaultValue:` vs `defaultTitle:`,
+  `some Localizable` vs `any Localizable`).
+- Every new SwiftUI release silently widens the gap.
+
+## Goal
+
+A mechanism that sweeps the SwiftUI API surface as it evolves each OS
+release and generates the full set of `Localizable` overloads
+automatically, deterministically, and verifiably.
+
+## Decisions (settled during design review)
+
+1. **Fully automatic selection** — a deterministic rule decides which
+   APIs get overloads. No per-API human allowlist.
+   The rule leans on Apple's own curation: a `LocalizedStringKey`
+   parameter is Apple's signal that the parameter is display text.
+2. **Sweep scope: the SwiftUI module surface** — initializers *and*
+   modifiers/methods. Because `Text`, `LocalizedStringKey`, and much of
+   the surface migrated to `SwiftUICore` (2024 SDKs), the sweep covers
+   both binary modules (`SwiftUI`, `SwiftUICore`) and their
+   cross-module extension graphs. Sibling frameworks (Charts,
+   WidgetKit, TipKit) are out of scope.
+3. **Checked-in, maintainer-run** — the generator is a tool the
+   maintainer runs when new SDKs ship. Generated sources are committed.
+   FOSMVVM's public API is deterministic and reviewable in PRs.
+4. **Generated replaces hand-written** — the seven hand-written mirror
+   files are deleted. Non-mirror machinery is relocated (see
+   "Not generated"). Source-breaking unification is accepted now,
+   pre-1.0 (`defaultTitle:` → `defaultValue:`,
+   `any Localizable` → `some Localizable`).
+5. **`defaultValue:` kept everywhere** — every generated overload takes
+   a `String? = nil` fallback after each Localizable slot.
+6. **Extraction mechanism: symbol graphs** (Approach A) —
+   `xcrun swift-symbolgraph-extract` JSON, decoded with plain
+   `Codable`. Zero new dependencies; prior art in
+   `Scripts/api-catalog-audit.swift`. The rejected alternative
+   (parsing `.swiftinterface` with swift-syntax) bought only verbatim
+   extension contexts at the cost of a high-churn dependency.
+7. **Version identity is the SDK/OS version, never Xcode's version.**
+   SwiftUI's surface is tied to the OS SDK. All stamps, comparisons,
+   and gates key on per-platform SDK versions
+   (`xcrun --sdk <name> --show-sdk-version`).
+8. **Availability spans old-through-beta from one generated set** —
+   generation runs against the newest installed SDKs, betas included
+   (today: the OS 27 betas), and every overload carries the
+   per-platform `@available` matrix from symbol-graph data, so one
+   checked-in set serves clients back through OS 26 (and the package
+   floors below that) while exposing 27-beta API behind guards.
+
+## Empirical grounding (probed 2026-07-08, OS 26-era macOS SDK)
+
+- `swift-symbolgraph-extract -module-name SwiftUI` succeeds;
+  output ~456 MB JSON, 83,378 symbols.
+- 5,124 symbols are inits/methods with a `LocalizedStringKey`
+  parameter (184 inits, 4,940 methods) *before* filtering
+  deprecated/obsoleted/underscored — filtering will cut this
+  substantially; expect a shipped surface in the hundreds.
+- `declarationFragments` reproduce exact signatures, including
+  default arguments, `nonisolated`, generic params, and `where`
+  clauses. Example, verbatim from the graph:
+
+  ```swift
+  nonisolated init<F>(_ titleKey: LocalizedStringKey,
+      value: Binding<F.FormatInput?>, format: F, prompt: Text? = nil)
+      where F : ParseableFormatStyle, F.FormatOutput == String
+  ```
+
+## Architecture — six-stage pipeline
+
+The tool is a standalone SPM executable package under `Tools/`,
+independent of the root package (consumers never see it).
+Not a single-file script: it has real parsing and transformation
+rules and deserves unit tests.
+
+### 1. Extract
+
+For each platform — macOS, iOS, tvOS, watchOS, visionOS — run
+`xcrun swift-symbolgraph-extract` against that platform's SDK for both
+modules (`SwiftUI`, `SwiftUICore`), collecting main graphs and
+extension graphs (e.g. `SwiftUI@SwiftUICore.symbols.json`).
+Record each SDK's version at extract time; these versions become the
+run's identity stamp.
+
+### 2. Select
+
+Keep a symbol when all of:
+
+- kind ∈ { `swift.init`, `swift.method`, `swift.func` }
+- at least one *parameter* is `LocalizedStringKey`, matched by the
+  fragment's `preciseIdentifier` (`s:7SwiftUI18LocalizedStringKeyV`),
+  never by spelling
+- not deprecated, not obsoleted, not underscored, not SPI
+
+### 3. Union
+
+Merge platform graphs by USR (Apple's stable symbol ID).
+One API seen on several platforms becomes one record with a merged
+per-platform availability matrix.
+
+Availability clamping against the Package.swift floors
+(iOS 17 / macOS 14 / macCatalyst 17 / tvOS 17 / watchOS 10 /
+visionOS 1): introduced-at-or-below-floor ⇒ no annotation;
+otherwise emit the full `@available(...)` line from graph data.
+`unavailable` domains are emitted as Apple declares them.
+
+iPadOS has no separate availability domain in symbol graphs — it rides
+`iOS`. macCatalyst is its own domain.
+
+### 4. Transform
+
+For each record, produce one overload:
+Apple's signature with these edits, everything else copied verbatim
+(generic parameters, `where` clauses, default arguments,
+`nonisolated`, extension context and its constraints —
+e.g. `extension TextField where Label == Text`):
+
+- Each `LocalizedStringKey` parameter type becomes `some Localizable`.
+  Never `any` (existentials are a code smell, per governance).
+- After each replaced slot, insert a fallback parameter:
+  - unnamed leading slot (`_ titleKey:`) → `defaultValue: String? = nil`
+  - labeled slot → `default<Label>: String? = nil`
+    (a two-slot API reads `defaultValue:` + `defaultMessage:`)
+- Multi-slot APIs produce **one** overload with all key slots
+  replaced — no mixed String/Localizable combinatorics.
+
+**Body — delegate-target policy.** The body must hand SwiftUI an
+*already-localized* `String`, never a `LocalizedStringKey` (that would
+re-enter bundle lookup). Deterministic, in order:
+
+1. A `some StringProtocol` sibling with an otherwise-identical
+   signature exists in the graphs → delegate directly:
+   `self.init(localizable.defaultedLocalizedString(defaultValue: defaultValue), ...)`
+2. Else a `Text`-taking sibling exists → delegate wrapping
+   `Text(verbatim: resolved)`.
+3. Else → skip; record in the coverage manifest.
+   The tool never emits a call it cannot prove has a target.
+
+### 5. Emit
+
+- One generated file per extended type (`Text.swift`,
+  `TextField.swift`, `View.swift`, …) under a generated-sources
+  directory inside `Sources/FOSMVVM/SwiftUI Support/`
+  (directory name: naming table).
+- Files wrapped in `#if canImport(SwiftUI)`.
+- Every file gets a DO-NOT-EDIT header stamped with the per-platform
+  SDK versions the run saw (Xcode version recorded only as an
+  informational footnote).
+- Output sorted by USR: same SDKs in ⇒ byte-identical files out.
+- `swiftformat` runs on output (also inserts the Apache header).
+- Alongside the code: a checked-in **coverage manifest** listing every
+  candidate the run skipped, with a reason from a closed set
+  (`deprecated` / `no-delegate-target` / `unrecognized-shape` /
+  duplicates folded by union). Silent truncation is banned; coverage
+  changes must be visible in the PR diff.
+- **Beta hygiene:** any API whose `introduced:` equals a beta SDK's own
+  version is flagged `beta-tier` in the manifest — informational, so
+  the RC-time regeneration diff shows exactly which beta-era
+  signatures Apple renamed or dropped.
+
+### 6. Verify
+
+- Generated code is checked in ⇒ the existing CI matrix compiling
+  FOSMVVM on all Apple platforms is the primary integration test.
+- **CI staleness gate:** per platform, if the runner's SDK version
+  equals the stamped one, that platform's regeneration slice must be
+  `git diff --exit-code` clean. Platforms whose SDK differs are
+  skipped with an informational note — a new-SDK rollout never breaks
+  unrelated PRs; regeneration is a deliberate, reviewed act.
+
+### Maintainer workflow (new SDKs ship)
+
+Run the tool → review the diff (new APIs appear as new overloads;
+manifest diff shows coverage changes) → commit.
+
+## Not generated (relocated, stays hand-written)
+
+- `LocalizableResolverView` + the `Localizable.text` property —
+  client-side resolution machinery; mirrors nothing.
+- The optional-Localizable `Text` init — SwiftUI has no optional-key
+  inits to mirror.
+
+Both move to one hand-written file (name: naming table).
+
+## Documentation
+
+- Every generated overload gets a template-driven, customer-framed
+  DocC comment: one sentence
+  ("Localizable-accepting form of SwiftUI's `Label.init(_:systemImage:)`")
+  plus one usage example per extended type.
+- The API catalog gets one curated *family* entry
+  (`FOSMVVM.md § SwiftUI Support`) so the catalog audit sees the
+  surface without flooding gap warnings.
+
+## Error handling
+
+- **Missing SDK** → hard exit, nonzero, naming exactly which SDKs are
+  missing. No partial-platform generation — it would silently emit
+  wrong availability annotations.
+- **Un-transformable symbol** (unrecognized declaration shape) →
+  never guess, never emit: skip + manifest entry with reason and raw
+  declaration. The run still succeeds.
+- **Nothing is silently dropped** — every non-generated candidate is a
+  manifest line with a closed-set reason.
+
+## Testing
+
+1. **Unit tests on the tool** (Swift Testing, in the tool package):
+   selection filter, availability merge + floor clamping, signature
+   transformation, delegate-target policy, multi-slot naming.
+   Driven by small checked-in symbol-graph fixtures (hand-trimmed JSON
+   records, a few KB — never the real graphs).
+   Golden tests: fixture record in → expected Swift source out,
+   verbatim.
+2. **The package build is the integration test** — checked-in output
+   compiling on the full CI matrix proves delegate targets resolve and
+   availability is coherent.
+3. **Behavioral tests stay behavioral** — a small hand-written test
+   file exercises one representative overload per delegate-policy path
+   (String-sibling, Text-verbatim), asserting the localized value
+   lands in the view. Test the contract, not the generated text.
+
+## Migration (one-time, in implementation)
+
+1. Delete the seven hand-written mirror files.
+2. Relocate resolver machinery + optional-Text init.
+3. Generate; run the full suite.
+4. Intended breakage surfaces in existing call sites
+   (`defaultTitle:` → `defaultValue:`, `any` → `some`).
+
+## Naming table — David arbitrates
+
+No name below is settled. Candidates carry the legibility axis
+(distinct leading characters, no confusable shapes).
+
+**1. Tool package directory (under `Tools/`)**
+
+- `LocalizableOverloads` — plain, states the output
+- `OverloadSweep` — states the mechanism (sweep), distinct shape
+- `SwiftUIMirror` — states the relationship, risks vagueness
+
+**2. Generated-sources directory (inside `SwiftUI Support/`)**
+
+- `Generated` — conventional, instantly legible
+- `Swept` — distinct from everything, but cryptic
+
+**3. Relocated hand-written file**
+
+- `LocalizableViews.swift`
+- `LocalizableResolution.swift` — names the machinery's job
+
+**4. Coverage manifest filename**
+
+- `SweepCoverage.md` — ⚠ flagged: `Generated/` + `GenerationManifest.md`
+  would share a `Genera-` prefix (confusable shapes); a `Sweep-` name
+  avoids the collision
+- `GenerationManifest.md`
+
+**5. Multi-slot fallback parameter convention**
+
+- `defaultValue:` (unnamed slot) + `default<Label>:` (labeled slots) —
+  proposed
+- alternative: `default<Label>:` everywhere, no bare `defaultValue:`
+  (uniform but breaks the shipped convention)
+
+## Open questions
+
+- None blocking. Naming table awaits arbitration; can be settled at
+  implementation-plan time.

--- a/docs/superpowers/specs/2026-07-09-swiftui-localizable-overload-generator-design.md
+++ b/docs/superpowers/specs/2026-07-09-swiftui-localizable-overload-generator-design.md
@@ -10,9 +10,10 @@ FOSMVVM ships `Localizable`-accepting overloads that mirror SwiftUI's
 `LocalizedStringKey`/`String` APIs (`Text`, `Label`, `TextField`,
 `LabeledContent`, `Tab`, `ContentUnavailableView`, `View.navigationTitle`).
 
-Today those overloads are hand-written:
+Today those overloads are hand-written — six dedicated files, plus
+`navigationTitle` living inside the shared `View.swift`:
 
-- Coverage is incidental (seven files; Button, Toggle, Picker, alerts,
+- Coverage is incidental (Button, Toggle, Picker, alerts,
   and hundreds of others have no overload).
 - Conventions drifted (`defaultValue:` vs `defaultTitle:`,
   `some Localizable` vs `any Localizable`).
@@ -39,8 +40,9 @@ automatically, deterministically, and verifiably.
 3. **Checked-in, maintainer-run** — the generator is a tool the
    maintainer runs when new SDKs ship. Generated sources are committed.
    FOSMVVM's public API is deterministic and reviewable in PRs.
-4. **Generated replaces hand-written** — the seven hand-written mirror
-   files are deleted. Non-mirror machinery is relocated (see
+4. **Generated replaces hand-written** — the hand-written mirror
+   overloads are deleted (six files plus the `View.swift` overload).
+   Non-mirror machinery is relocated or stays put (see
    "Not generated"). Source-breaking unification is accepted now,
    pre-1.0 (`defaultTitle:` → `defaultValue:`,
    `any Localizable` → `some Localizable`).
@@ -66,7 +68,10 @@ automatically, deterministically, and verifiably.
 ## Empirical grounding (probed 2026-07-08, OS 26-era macOS SDK)
 
 - `swift-symbolgraph-extract -module-name SwiftUI` succeeds;
-  output ~456 MB JSON, 83,378 symbols.
+  output ~456 MB JSON, 83,378 symbols. Across 5 platforms × 2 modules
+  (+ extension graphs) the working set is multi-GB — the Extract/Select
+  stages must process graphs one at a time (select while decoding,
+  discard the rest) rather than holding all graphs in memory.
 - 5,124 symbols are inits/methods with a `LocalizedStringKey`
   parameter (184 inits, 4,940 methods) *before* filtering
   deprecated/obsoleted/underscored — filtering will cut this
@@ -144,8 +149,12 @@ e.g. `extension TextField where Label == Text`):
 re-enter bundle lookup). Deterministic, in order:
 
 1. A `some StringProtocol` sibling with an otherwise-identical
-   signature exists in the graphs → delegate directly:
+   signature exists in the graphs → delegate directly.
+   Init-shaped:
    `self.init(localizable.defaultedLocalizedString(defaultValue: defaultValue), ...)`
+   Method/modifier-shaped (the dominant case, ~96% of candidates):
+   `navigationTitle(localizable.defaultedLocalizedString(defaultValue: defaultValue))`
+   — call the sibling method and return its result.
 2. Else a `Text`-taking sibling exists → delegate wrapping
    `Text(verbatim: resolved)`.
 3. Else → skip; record in the coverage manifest.
@@ -188,14 +197,22 @@ re-enter bundle lookup). Deterministic, in order:
 Run the tool → review the diff (new APIs appear as new overloads;
 manifest diff shows coverage changes) → commit.
 
-## Not generated (relocated, stays hand-written)
+## Not generated (stays hand-written)
+
+Relocated to one hand-written file (name: naming table):
 
 - `LocalizableResolverView` + the `Localizable.text` property —
   client-side resolution machinery; mirrors nothing.
 - The optional-Localizable `Text` init — SwiftUI has no optional-key
   inits to mirror.
 
-Both move to one hand-written file (name: naming table).
+Stays exactly where it is (`View.swift` is a shared file — only its
+`navigationTitle` overload is a mirror):
+
+- `withValidations(for:)` (3 overloads), `invalidateBinding(_:)`,
+  `refreshedViewModel(_:)`, and the `EnvironmentValues` `@Entry`
+  extension. None of these mirror SwiftUI API; they are load-bearing
+  for `FormFieldView` and ViewModel binding.
 
 ## Documentation
 
@@ -237,8 +254,16 @@ Both move to one hand-written file (name: naming table).
 
 ## Migration (one-time, in implementation)
 
-1. Delete the seven hand-written mirror files.
-2. Relocate resolver machinery + optional-Text init.
+Order matters: relocate first, delete second — and deletion is
+**per-overload** in shared files, never wholesale.
+
+1. Relocate resolver machinery + optional-Text init out of
+   `Text.swift` into the hand-written survivor file.
+2. Delete the four pure-mirror files wholesale
+   (`Label.swift`, `LabeledContent.swift`, `Tab.swift`,
+   `ContentUnavailableView.swift`); delete `Text.swift` once emptied
+   of relocated content; remove **only** the `navigationTitle`
+   mirror overload from `View.swift` (its other members stay put).
 3. Generate; run the full suite.
 4. Intended breakage surfaces in existing call sites
    (`defaultTitle:` → `defaultValue:`, `any` → `some`).

--- a/docs/superpowers/specs/2026-07-09-swiftui-localizable-overload-generator-design.md
+++ b/docs/superpowers/specs/2026-07-09-swiftui-localizable-overload-generator-design.md
@@ -58,7 +58,16 @@ automatically, deterministically, and verifiably.
    SwiftUI's surface is tied to the OS SDK. All stamps, comparisons,
    and gates key on per-platform SDK versions
    (`xcrun --sdk <name> --show-sdk-version`).
-8. **Availability spans old-through-beta from one generated set** —
+8. **Script first, package only if warranted** — the tool is a plain
+   single-file Swift script in `Scripts/` (run as
+   `swift Scripts/<name>.swift`, same convention as
+   `api-catalog-audit.swift`). Zero dependencies, so swift-sh is not
+   needed. The rejected-for-now alternative (SPM package under
+   `Tools/`) bought exactly one thing — a unit-test target for the
+   transformer; if a regeneration-debugging session ever makes that
+   pain real, promotion to a tested package is mechanical and done
+   then, with evidence.
+9. **Availability spans old-through-beta from one generated set** —
    generation runs against the newest installed SDKs, betas included
    (today: the OS 27 betas), and every overload carries the
    per-platform `@available` matrix from symbol-graph data, so one
@@ -88,10 +97,11 @@ automatically, deterministically, and verifiably.
 
 ## Architecture — six-stage pipeline
 
-The tool is a standalone SPM executable package under `Tools/`,
-independent of the root package (consumers never see it).
-Not a single-file script: it has real parsing and transformation
-rules and deserves unit tests.
+The tool is a single-file Swift script in `Scripts/`
+(decision 8) — outside the root package; consumers never see it.
+The file is organized in clearly-marked sections mirroring the six
+stages below, so a future promotion to a package is a mechanical
+split.
 
 ### 1. Extract
 
@@ -237,13 +247,16 @@ Stays exactly where it is (`View.swift` is a shared file — only its
 
 ## Testing
 
-1. **Unit tests on the tool** (Swift Testing, in the tool package):
-   selection filter, availability merge + floor clamping, signature
-   transformation, delegate-target policy, multi-slot naming.
-   Driven by small checked-in symbol-graph fixtures (hand-trimmed JSON
-   records, a few KB — never the real graphs).
-   Golden tests: fixture record in → expected Swift source out,
-   verbatim.
+1. **Unit tests on the tool — DEFERRED** (decision 8). A script has
+   no test target. What ships is verified by layers 2–3 regardless;
+   what the deferred tests would protect is maintainer debugging of a
+   future regeneration. If that pain materializes, promote the script
+   to an SPM package under `Tools/` and add the deferred layer:
+   Swift Testing over small checked-in symbol-graph fixtures
+   (hand-trimmed JSON, a few KB — never the real graphs), golden
+   tests fixture-record-in → exact-Swift-out, covering the selection
+   filter, availability merge + floor clamping, signature
+   transformation, delegate-target policy, and multi-slot naming.
 2. **The package build is the integration test** — checked-in output
    compiling on the full CI matrix proves delegate targets resolve and
    availability is coherent.
@@ -268,42 +281,22 @@ Order matters: relocate first, delete second — and deletion is
 4. Intended breakage surfaces in existing call sites
    (`defaultTitle:` → `defaultValue:`, `any` → `some`).
 
-## Naming table — David arbitrates
+## Naming table — arbitrated 2026-07-09
 
-No name below is settled. Candidates carry the legibility axis
-(distinct leading characters, no confusable shapes).
-
-**1. Tool package directory (under `Tools/`)**
-
-- `LocalizableOverloads` — plain, states the output
-- `OverloadSweep` — states the mechanism (sweep), distinct shape
-- `SwiftUIMirror` — states the relationship, risks vagueness
-
-**2. Generated-sources directory (inside `SwiftUI Support/`)**
-
-- `Generated` — conventional, instantly legible
-- `Swept` — distinct from everything, but cryptic
-
-**3. Relocated hand-written file**
-
-- `LocalizableViews.swift`
-- `LocalizableResolution.swift` — names the machinery's job
-
-**4. Coverage manifest filename**
-
-- `SweepCoverage.md` — ⚠ flagged: `Generated/` + `GenerationManifest.md`
-  would share a `Genera-` prefix (confusable shapes); a `Sweep-` name
-  avoids the collision
-- `GenerationManifest.md`
-
-**5. Multi-slot fallback parameter convention**
-
-- `defaultValue:` (unnamed slot) + `default<Label>:` (labeled slots) —
-  proposed
-- alternative: `default<Label>:` everywhere, no bare `defaultValue:`
-  (uniform but breaks the shipped convention)
+- **Tool** — single-file script (decision 8); no `Tools/` package
+  directory exists. Script filename proposal:
+  `Scripts/localizable-overload-sweep.swift`
+  (kebab-case like `api-catalog-audit.swift`; pairs with
+  `SweepCoverage.md`). Awaiting David's veto only.
+- **Generated-sources directory** —
+  `Sources/FOSMVVM/SwiftUI Support/Generated/` ✓ settled
+- **Relocated hand-written file** — `LocalizableViews.swift` ✓ settled
+- **Coverage manifest** — `SweepCoverage.md` ✓ settled
+  (distinct leading word; avoids `Genera-` prefix collision with
+  `Generated/`)
+- **Multi-slot fallback convention** — `defaultValue:` (unnamed slot)
+  + `default<Label>:` (labeled slots) ✓ settled at design Section 2
 
 ## Open questions
 
-- None blocking. Naming table awaits arbitration; can be settled at
-  implementation-plan time.
+- None blocking. Script filename awaits a veto-or-nod.


### PR DESCRIPTION
## Summary

Adds a **client/server credential seam** to FOSMVVM so apps can attach and verify
per-request authentication without per-call plumbing.

- **`ClientCredentialProvider` (FOSMVVM)** — supplies auth headers for every
  `ServerRequest`. Consulted per request, so a rotating credential is picked up on
  the next call; a nil bearer token sends the request unauthenticated. Wired into
  `MVVMEnvironment` (nil-defaulted on all four inits — additive, no call-site
  breaks) and applied in `processRequest(mvvmEnv:)` after the static
  `requestHeaders` (per-request credential wins on a duplicate field). Ships the
  stock `BearerCredentialProvider`.

- **`ClientCredentialMiddleware` + `ServerCredentialVerifier` (FOSMVVMVapor)** —
  the server half. Route groups run an app-supplied verifier before each route
  (throw to reject, return to admit), consulted per request so a server-side
  revocation takes effect on the next call. Ships the stock
  `BearerCredentialVerifier`; missing/invalid → 401 with `WWW-Authenticate: Bearer`,
  never echoing the presented token.

- **Docs** — api-catalog entries for both halves + reach-for index; plugin 2.11.0.

## Contract pinned by tests

- Live-server round-trip harness verifies on-the-wire header arrival, per-call
  rotation, provider-wins-over-static, and that a throwing provider sends no
  request and propagates to the caller.
- Client-side 401 surfaces as `DataFetchError.badStatus(401)` (bypasses
  `requestErrorHandler`) — **provided** the request's `ResponseError` doesn't
  decode from the rejection body. The `EmptyError`-swallow limitation is pinned by
  its own test and documented.

## Test Plan

- [x] `swift test` — 585 tests, 104 suites, all passing (exit 0)
- [ ] Reviewer: confirm the additive `MVVMEnvironment` inits don't break downstream call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
