### PR TITLE
feat(FOSMVVM): live ViewModel invalidation — @ViewModel(options: [.live]) (L2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live ViewModel invalidation — `@ViewModel(options: [.live])`** (FOSMVVM / FOSMVVMVapor).
+  Opt a screen in with the one macro option and any view bound with `.bind()` re-fetches
+  automatically whenever another actor commits a change to the data that ViewModel was served
+  from — no polling, no manual invalidation, nothing else to write. Where no live connection is
+  configured the ViewModel behaves exactly like a non-live one (fetch once on appear), so adding
+  `.live` to a shipped screen is purely additive. The macro synthesizes a **`LiveViewModel`**
+  marker; `.live` combined with `.clientHostedFactory` is a macro diagnostic (a client-hosted VM
+  has no server response to derive registrations from).
+- **`Application.useLiveInvalidation(on:)`** (FOSMVVMVapor) — the server boot switch. Call once,
+  passing the route group your clients authenticate against; every registered container model then
+  nudges connected clients after each committed change. Registrations made before or after the
+  call are both honored.
+- **`Request.liveTransaction` / `Application.liveTransaction`** (FOSMVVMVapor) — the sanctioned
+  replacement for a bare `database.transaction { }` in a live application: every write inside the
+  closure nudges live clients if — and only if — the transaction commits (a throw/rollback nudges
+  nothing). Inside a bare `transaction { }` the framework cannot know whether your writes commit,
+  so it stays silent and logs a warning.
+- **`InvalidationChannel` / `InvalidationEvent` + `MVVMEnvironment.invalidationChannel`** (FOSMVVM)
+  — the transport seam. Most apps configure nothing (leave `invalidationChannel` `nil` and the
+  standard channel is synthesized over your deployment URLs, with `invalidationBaseURL` defaulting
+  to `serverBaseURL`); conform your own `InvalidationChannel` only to replace the transport
+  wholesale. The invalidation nudge carries opaque `ModelIdentity` values only — **never** any
+  ViewModel data. Contract: the client authenticates the stream through your
+  `ClientCredentialProvider` at connect, and a reconnect refreshes every live screen.
+- **`withServedFluentTestApp`** (FOSTestingVapor) — a Fluent test harness that serves the app on
+  an ephemeral local port and hands the test a base URL, for exercising long-lived streaming
+  endpoints that outlast the in-process `app.test(...)` responder.
+- Served responses now carry an **`X-FOS-Registrations`** response header alongside `X-FOS-Version`
+  (the data a live client registers to watch). Treat it as opaque — do not parse or hand-construct
+  it; only the live resolver reads it.
+
+### Fixed
+
+- **`X-FOS-Version` attaches exactly once** to a served response (FOSMVVMVapor). The version header
+  was being appended twice on the served response; `addSystemVersion()` now replaces-or-adds, so
+  exactly one value is present. Clients reading the first value were unaffected — this removes a
+  latent duplicate on the wire.
+
 - **`ClientCredentialProvider`** (FOSMVVM) — supplies the authentication headers that
   accompany every `ServerRequest`; consulted per request, so a rotating credential is
   picked up on the next call. The dynamic sibling of the static

--- a/Sources/FOSFoundation/Networking/DataFetch.swift
+++ b/Sources/FOSFoundation/Networking/DataFetch.swift
@@ -346,6 +346,25 @@ public final class DataFetch<Session: URLSessionProtocol>: Sendable {
 
     /// - Throws: ``DataFetchError`` or **errorType**
     public func send<ResultValue: Decodable & Sendable>(data: Data? = nil, to url: URL, httpMethod: String, headers: [(field: String, value: String)]?, locale: Locale?, checkReceivedMimeType: Bool = true, errorType: (some Decodable & Error).Type) async throws -> ResultValue {
+        try await send(
+            data: data,
+            to: url,
+            httpMethod: httpMethod,
+            headers: headers,
+            locale: locale,
+            checkReceivedMimeType: checkReceivedMimeType,
+            errorType: errorType,
+            capturingResponseHeader: nil
+        ).value
+    }
+
+    /// Identical to `send(…errorType:)` but also returns the value of a single named response
+    /// header (`nil` when absent). `package`, not public: FOSMVVM's live-invalidation resolver reads
+    /// `X-FOS-Registrations` off the very fetch that produced the ViewModel, and there is no other
+    /// way for a sibling module to reach a response header the public API deliberately discards. Kept
+    /// `package` (not public) so the wire concern never leaks onto FOSFoundation's public surface.
+    /// - Throws: ``DataFetchError`` or **errorType**
+    package func send<ResultValue: Decodable & Sendable>(data: Data? = nil, to url: URL, httpMethod: String, headers: [(field: String, value: String)]?, locale: Locale?, checkReceivedMimeType: Bool = true, errorType: (some Decodable & Error).Type, capturingResponseHeader field: String?) async throws -> (value: ResultValue, headerValue: String?) {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = httpMethod
 
@@ -406,7 +425,10 @@ public final class DataFetch<Session: URLSessionProtocol>: Sendable {
                             errorType: errorType
                         )
 
-                        continuation.resume(returning: result)
+                        let headerValue = field.flatMap {
+                            (response as? HTTPURLResponse)?.value(forHTTPHeaderField: $0)
+                        }
+                        continuation.resume(returning: (value: result, headerValue: headerValue))
                     } catch let e {
                         continuation.resume(throwing: e)
                     }

--- a/Sources/FOSMVVM/Macros/Macros.swift
+++ b/Sources/FOSMVVM/Macros/Macros.swift
@@ -19,6 +19,9 @@ import FOSFoundation
 public enum ViewModelOptions {
     /// Generate ``ClientHostedViewModelFactory`` support
     case clientHostedFactory
+
+    /// Refresh bound views automatically when server data changes — see ``LiveViewModel``
+    case live
 }
 
 @attached(extension, conformances: RetrievablePropertyNames, FieldValidationModel)
@@ -28,7 +31,7 @@ public macro FieldValidationModel() = #externalMacro(
     type: "FieldValidationModelMacro"
 )
 
-@attached(extension, conformances: RetrievablePropertyNames, ViewModel, ClientHostedViewModelFactory, RequestableViewModel)
+@attached(extension, conformances: RetrievablePropertyNames, ViewModel, ClientHostedViewModelFactory, RequestableViewModel, LiveViewModel)
 @attached(member, names: named(propertyNames), named(Request), named(AppState), named(model), named(modelSync), named(ClientHostedRequest), named(stub))
 public macro ViewModel(options: Set<ViewModelOptions> = []) = #externalMacro(
     module: "FOSMacros",

--- a/Sources/FOSMVVM/Protocols/InvalidationChannel.swift
+++ b/Sources/FOSMVVM/Protocols/InvalidationChannel.swift
@@ -1,0 +1,48 @@
+// InvalidationChannel.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// One event from the server's live-invalidation stream
+///
+/// You only meet this type when supplying a custom ``InvalidationChannel``;
+/// the default channel produces it for you. Yield `.connected` whenever your
+/// transport (re)establishes its connection — FOSMVVM responds by refreshing
+/// every live screen — and `.invalidated` with each identity set the server
+/// pushes.
+public enum InvalidationEvent: Sendable {
+    case connected
+    case invalidated(Set<ModelIdentity>)
+}
+
+/// The transport that delivers server invalidation nudges to this client
+///
+/// Most apps never touch this: leave ``MVVMEnvironment/invalidationChannel``
+/// `nil` and FOSMVVM synthesizes the standard channel over your deployment
+/// URLs. Conform your own type only to replace the transport wholesale:
+///
+/// ```swift
+/// struct MyChannel: InvalidationChannel {
+///     func events() -> AsyncStream<InvalidationEvent> { ... }
+/// }
+///
+/// let environment = MVVMEnvironment(
+///     appBundle: Bundle.main,
+///     invalidationChannel: MyChannel(),
+///     deploymentURLs: ...
+/// )
+/// ```
+public protocol InvalidationChannel: Sendable {
+    func events() -> AsyncStream<InvalidationEvent>
+}

--- a/Sources/FOSMVVM/Protocols/LiveViewModel.swift
+++ b/Sources/FOSMVVM/Protocols/LiveViewModel.swift
@@ -1,0 +1,31 @@
+// LiveViewModel.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A ``ViewModel`` that refreshes automatically when its server data changes
+///
+/// Don't conform directly — opt in with the macro:
+///
+/// ```swift
+/// @ViewModel(options: [.live])
+/// public struct DocksViewModel: RequestableViewModel { ... }
+/// ```
+///
+/// Any view bound with `.bind()` then re-fetches whenever another actor mutates
+/// the data this ViewModel was served from — no polling, no manual invalidation,
+/// and nothing else to write. Where no live connection is configured the
+/// ViewModel behaves exactly like a non-live one (fetch once on appear), so
+/// adding `.live` to a shipped screen is purely additive.
+public protocol LiveViewModel: RequestableViewModel {}

--- a/Sources/FOSMVVM/Protocols/ModelIdentity.swift
+++ b/Sources/FOSMVVM/Protocols/ModelIdentity.swift
@@ -58,6 +58,16 @@ public struct ModelIdentity: Hashable, Codable, Sendable {
 }
 
 public extension ModelIdentity {
+    /// The HTTP response header FOSMVVM uses to keep ``LiveViewModel`` screens current
+    ///
+    /// The framework attaches it to served responses and the live bind resolver consumes
+    /// it — application code never reads, parses, or constructs its value. The constant
+    /// exists so infrastructure (proxies, logging filters, tests) can reference the header
+    /// **by name**; its value is an opaque framework contract that may evolve.
+    static let registrationsHeader = "X-FOS-Registrations"
+}
+
+public extension ModelIdentity {
     /// Whether this identity is the one rooted in `model` — sugar for `models.filter { changed == $0 }`.
     ///
     /// An unpersisted `model` (`id == nil`) compares `false`; it never throws.

--- a/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
+++ b/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
@@ -79,6 +79,19 @@ public extension ServerRequest {
     /// - Returns: ``ServerRequest/ResponseBody``
     @discardableResult
     func processRequest(baseURL: URL, headers: [(field: String, value: String)]? = nil, session: URLSession? = nil) async throws -> ResponseBody? {
+        try await processRequestCapturingRegistrations(baseURL: baseURL, headers: headers, session: session).body
+    }
+
+    /// Internal live-delivery seam: the same fetch as `processRequest(baseURL:headers:session:)`, also
+    /// returning the ViewModel's server-derived live registration set decoded from the
+    /// `X-FOS-Registrations` response header (spec §3.4). The public overload delegates here and drops
+    /// the registrations, so its observable behavior is byte-identical. Absent header ⇒ empty set; a
+    /// malformed value ⇒ empty set (decided: a broken registration header must never fail the fetch —
+    /// the screen simply degrades to fetch-once).
+    ///
+    /// Explicitly `internal` — this sits in a `public extension`, whose default would silently
+    /// publish the wire seam onto ``ServerRequest``'s public surface.
+    internal func processRequestCapturingRegistrations(baseURL: URL, headers: [(field: String, value: String)]? = nil, session: URLSession? = nil) async throws -> (body: ResponseBody?, registrations: [ModelIdentity]) {
         let dataFetch: DataFetch<URLSession> = if let session {
             DataFetch(urlSession: session)
         } else {
@@ -96,6 +109,7 @@ public extension ServerRequest {
             try requestBody?.toJSONData() ?? Data()
         }
 
+        let headerValue: String?
         if ResponseBody.self == EmptyBody.self {
             // An `EmptyBody` response carries no meaningful content, so its media type is irrelevant.
             // Fetch it as `String` (the one decode path that accepts ANY 2xx body) with the
@@ -104,28 +118,33 @@ public extension ServerRequest {
             // one that answers `text/plain`/empty (a plain REST API) — neither type is
             // enforced, because there is nothing to type. A non-2xx still decodes the typed
             // `ResponseError` via `errorType`, unchanged.
-            let _: String = try await dataFetch.send(
+            let (_, captured): (String, String?) = try await dataFetch.send(
                 data: requestData,
                 to: requestURL(baseURL: baseURL),
                 httpMethod: action.httpMethod,
                 headers: requestHeaders,
                 locale: Locale.current,
                 checkReceivedMimeType: false,
-                errorType: Self.ResponseError.self
+                errorType: Self.ResponseError.self,
+                capturingResponseHeader: ModelIdentity.registrationsHeader
             )
             responseBody = EmptyBody() as? ResponseBody
+            headerValue = captured
         } else {
-            responseBody = try await dataFetch.send(
+            let (body, captured): (ResponseBody, String?) = try await dataFetch.send(
                 data: requestData,
                 to: requestURL(baseURL: baseURL),
                 httpMethod: action.httpMethod,
                 headers: requestHeaders,
                 locale: Locale.current,
-                errorType: Self.ResponseError.self
+                errorType: Self.ResponseError.self,
+                capturingResponseHeader: ModelIdentity.registrationsHeader
             )
+            responseBody = body
+            headerValue = captured
         }
 
-        return responseBody
+        return (responseBody, LiveRegistrations.decode(headerValue))
     }
 
     /// Send the ``ServerRequest`` to the web service and wait for a response
@@ -137,6 +156,18 @@ public extension ServerRequest {
     ///   - mvvmEnv: The current ``MVVMEnvironment`` for the client application
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     func processRequest(mvvmEnv: MVVMEnvironment) async throws {
+        _ = try await processRequestCapturingRegistrations(mvvmEnv: mvvmEnv)
+    }
+
+    /// Internal live-delivery seam: the `mvvmEnv` fetch, additionally returning the response's live
+    /// registration set (spec §3.4). Error handling matches `processRequest(mvvmEnv:)`; the bind
+    /// resolver drives every server-hosted request through it — a non-live ViewModel simply ignores
+    /// the returned set.
+    ///
+    /// Explicitly `internal` — this sits in a `public extension`, whose default would silently
+    /// publish the wire seam onto ``ServerRequest``'s public surface.
+    @discardableResult
+    internal func processRequestCapturingRegistrations(mvvmEnv: MVVMEnvironment) async throws -> [ModelIdentity] {
         do {
             var headers = [(field: String, value: String)]()
             if ResponseBody.self == EmptyBody.self {
@@ -153,18 +184,30 @@ public extension ServerRequest {
                 headers += try await credentialProvider.credentialHeaders()
             }
 
-            try await processRequest(
+            return try await processRequestCapturingRegistrations(
                 baseURL: mvvmEnv.serverBaseURL,
                 headers: headers,
                 session: mvvmEnv.session
-            )
+            ).registrations
         } catch let error as ServerRequestError {
             if let errorHandler = mvvmEnv.requestErrorHandler {
                 errorHandler(self, error)
+                return []
             } else {
                 throw error
             }
         }
+    }
+}
+
+/// Decodes the `X-FOS-Registrations` response header into a live-invalidation registration set.
+enum LiveRegistrations {
+    /// An absent or empty header ⇒ empty set. A malformed value also ⇒ empty set: a broken
+    /// registration header must never fail the fetch (spec §3.4) — the screen degrades to
+    /// fetch-once rather than surfacing an error the user cannot act on.
+    static func decode(_ headerValue: String?) -> [ModelIdentity] {
+        guard let headerValue, !headerValue.isEmpty else { return [] }
+        return (try? headerValue.fromJSON()) ?? []
     }
 }
 

--- a/Sources/FOSMVVM/SwiftUI Support/FreshnessGate.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/FreshnessGate.swift
@@ -1,0 +1,29 @@
+// FreshnessGate.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The monotonic gate that guards a same-request refresh swap (spec §3.3): a newer response
+/// replaces the current one, an older one racing in is dropped. Keyed on ``ViewModelId/freshness``
+/// (L0's version clock), it applies only where the two ViewModels answer the *same* request —
+/// a `query`/`fragment` change is navigation to different data, incomparable, and bypasses it.
+enum FreshnessGate {
+    /// Whether `incoming` should replace `current`. `nil` current is always accepted (first arrival);
+    /// otherwise only a strictly-fresher `incoming` wins — an equal-or-older one (the redundant
+    /// self-nudge a client's own write races back to it) is dropped.
+    static func shouldReplace<V: ViewModel>(current: V?, with incoming: V) -> Bool {
+        guard let current else { return true }
+        return incoming.vmId.freshness > current.vmId.freshness
+    }
+}

--- a/Sources/FOSMVVM/SwiftUI Support/InvalidationDispatcher.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/InvalidationDispatcher.swift
@@ -1,0 +1,250 @@
+// InvalidationDispatcher.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import Foundation
+
+/// Routes server invalidation nudges to the live screens that depend on the affected identities
+/// (spec §3.3). One instance is owned by ``MVVMEnvironment``; the bind resolver registers a
+/// re-fetch trigger per live screen and re-registers each response's derived identity set.
+///
+/// Not `Sendable`, `@MainActor`: every registration and every fired trigger touches SwiftUI state.
+/// The consumption task inherits this isolation, so incoming events are handled on the main actor.
+@MainActor
+final class InvalidationDispatcher {
+    /// A live registration handle. The registrant holds it for as long as its screen is bound;
+    /// when it deallocates the dispatcher's weak reference clears and the registration stops firing.
+    final class Token {
+        fileprivate let trigger: @MainActor () -> Void
+
+        fileprivate init(trigger: @escaping @MainActor () -> Void) {
+            self.trigger = trigger
+        }
+    }
+
+    /// The dispatcher-side record. `token` is weak — the registrant's release IS the unregister, so a
+    /// vanished screen never fires (deref → nil → pruned). `identities`/`namespaces` are kept here (not
+    /// read off the token) so pruning a dead token still knows which index buckets to clean.
+    private final class Entry {
+        weak var token: Token?
+        var identities: Set<ModelIdentity>
+        var namespaces: Set<ModelNamespace>
+
+        init(token: Token, identities: Set<ModelIdentity>, namespaces: Set<ModelNamespace>) {
+            self.token = token
+            self.identities = identities
+            self.namespaces = namespaces
+        }
+    }
+
+    private let channel: (any InvalidationChannel)?
+    private var consumeTask: Task<Void, Never>?
+
+    private var entries: [ObjectIdentifier: Entry] = [:]
+    private var exactIndex: [ModelIdentity: Set<ObjectIdentifier>] = [:]
+    private var namespaceIndex: [ModelNamespace: Set<ObjectIdentifier>] = [:]
+
+    init(channel: (any InvalidationChannel)?) {
+        self.channel = channel
+    }
+
+    deinit {
+        // `Task` is `Sendable`, so a nonisolated deinit may read this isolated stored property.
+        consumeTask?.cancel()
+    }
+
+    /// Registers `trigger` to fire when the server nudges any of `identities`, or any identity whose
+    /// namespace is in `namespaces`. The returned ``Token`` must be retained for the registration to
+    /// live. The first registration opens the channel (an app with no live screens never connects).
+    ///
+    /// - Warning: `trigger` must not strongly capture the token's owner — the dispatcher holds the
+    ///   token weakly, so a token → trigger → owner → token cycle is immortal.
+    @discardableResult
+    func register(
+        identities: Set<ModelIdentity>,
+        namespaces: Set<ModelNamespace>,
+        trigger: @escaping @MainActor () -> Void
+    ) -> Token {
+        let token = Token(trigger: trigger)
+        let id = ObjectIdentifier(token)
+        // A brand-new token can share an address only with a dead one whose entry lingers — evict
+        // that stale entry first so its old identities don't stay indexed against this id.
+        remove(id)
+        pruneDead(inBucketsFor: identities, namespaces: namespaces)
+        entries[id] = Entry(token: token, identities: identities, namespaces: namespaces)
+        addToIndices(id, identities: identities, namespaces: namespaces)
+        startConsumingIfNeeded()
+        return token
+    }
+
+    /// Replaces `token`'s identity/namespace set, keeping its trigger — the seam the resolver drives
+    /// on every refresh so a screen whose plan touched new containers starts listening to them
+    /// (spec §3.4). A no-op if `token` is no longer registered.
+    func reregister(
+        _ token: Token,
+        identities: Set<ModelIdentity>,
+        namespaces: Set<ModelNamespace>
+    ) {
+        let id = ObjectIdentifier(token)
+        guard let entry = entries[id] else { return }
+
+        pruneDead(inBucketsFor: identities, namespaces: namespaces)
+        removeFromIndices(id, identities: entry.identities, namespaces: entry.namespaces)
+        entry.identities = identities
+        entry.namespaces = namespaces
+        addToIndices(id, identities: identities, namespaces: namespaces)
+    }
+
+    /// Drops `token`'s registration explicitly. Token deallocation does the same lazily.
+    func unregister(_ token: Token) {
+        remove(ObjectIdentifier(token))
+    }
+}
+
+private extension InvalidationDispatcher {
+    func startConsumingIfNeeded() {
+        // Opened once, on the first registration, and kept open for the app's foreground lifetime —
+        // reconnects live inside the channel's own stream (spec §3.2). `events()` is called
+        // synchronously here so "the socket opens at registration" holds without a scheduling hop.
+        guard consumeTask == nil, let channel else { return }
+
+        let stream = channel.events()
+        consumeTask = Task { [weak self] in
+            for await event in stream {
+                guard let self else { break }
+                handle(event)
+            }
+        }
+    }
+
+    func handle(_ event: InvalidationEvent) {
+        switch event {
+        case .connected:
+            // Reconnect sweep (spec §3.2): fire every registration, so whatever was missed while
+            // disconnected re-fetches. The freshness gate absorbs the redundancy.
+            fire(Set(entries.keys))
+        case .invalidated(let identities):
+            fire(matching: identities)
+        }
+    }
+
+    func fire(matching identities: Set<ModelIdentity>) {
+        var matched: Set<ObjectIdentifier> = []
+        for identity in identities {
+            if let hits = exactIndex[identity] {
+                matched.formUnion(hits)
+            }
+            if let hits = namespaceIndex[identity.namespace] {
+                matched.formUnion(hits)
+            }
+        }
+        fire(matched)
+    }
+
+    /// Deduped by construction: `matched` is a set of token ids, so a registration hit by several
+    /// identities in one event fires exactly once.
+    func fire(_ ids: Set<ObjectIdentifier>) {
+        for id in ids {
+            guard let entry = entries[id] else {
+                purgeOrphan(id) // a bucket id with no entry — self-heal instead of firing forever
+                continue
+            }
+            guard let token = entry.token else {
+                remove(id) // dead registrant — prune lazily on first touch
+                continue
+            }
+            token.trigger()
+        }
+    }
+
+    func remove(_ id: ObjectIdentifier) {
+        guard let entry = entries.removeValue(forKey: id) else { return }
+        removeFromIndices(id, identities: entry.identities, namespaces: entry.namespaces)
+    }
+
+    /// Incremental, not a full-table walk: sweeping only the buckets this (re)registration touches
+    /// keeps the cost proportional to the registration's own set while bounding index growth to
+    /// live entries + recent churn — dead never-firing namespaces can't accumulate unboundedly.
+    func pruneDead(inBucketsFor identities: Set<ModelIdentity>, namespaces: Set<ModelNamespace>) {
+        var dead: Set<ObjectIdentifier> = []
+        for identity in identities {
+            for id in exactIndex[identity] ?? [] where entries[id]?.token == nil {
+                dead.insert(id)
+            }
+        }
+        for namespace in namespaces {
+            for id in namespaceIndex[namespace] ?? [] where entries[id]?.token == nil {
+                dead.insert(id)
+            }
+        }
+        for id in dead {
+            if entries[id] != nil {
+                remove(id)
+            } else {
+                purgeOrphan(id)
+            }
+        }
+    }
+
+    /// Defensive only — register's evict-first makes orphaned bucket ids unreachable by
+    /// construction; if one ever appears, strip it from every bucket so it can't linger.
+    func purgeOrphan(_ id: ObjectIdentifier) {
+        for identity in Array(exactIndex.keys) {
+            exactIndex[identity]?.remove(id)
+            if exactIndex[identity]?.isEmpty == true {
+                exactIndex.removeValue(forKey: identity)
+            }
+        }
+        for namespace in Array(namespaceIndex.keys) {
+            namespaceIndex[namespace]?.remove(id)
+            if namespaceIndex[namespace]?.isEmpty == true {
+                namespaceIndex.removeValue(forKey: namespace)
+            }
+        }
+    }
+
+    func addToIndices(
+        _ id: ObjectIdentifier,
+        identities: Set<ModelIdentity>,
+        namespaces: Set<ModelNamespace>
+    ) {
+        for identity in identities {
+            exactIndex[identity, default: []].insert(id)
+        }
+        for namespace in namespaces {
+            namespaceIndex[namespace, default: []].insert(id)
+        }
+    }
+
+    func removeFromIndices(
+        _ id: ObjectIdentifier,
+        identities: Set<ModelIdentity>,
+        namespaces: Set<ModelNamespace>
+    ) {
+        for identity in identities {
+            exactIndex[identity]?.remove(id)
+            if exactIndex[identity]?.isEmpty == true {
+                exactIndex.removeValue(forKey: identity)
+            }
+        }
+        for namespace in namespaces {
+            namespaceIndex[namespace]?.remove(id)
+            if namespaceIndex[namespace]?.isEmpty == true {
+                namespaceIndex.removeValue(forKey: namespace)
+            }
+        }
+    }
+}

--- a/Sources/FOSMVVM/SwiftUI Support/LiveRegistrationCoordinator.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/LiveRegistrationCoordinator.swift
@@ -1,0 +1,64 @@
+// LiveRegistrationCoordinator.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(SwiftUI)
+import Foundation
+import SwiftUI
+
+/// Owns one live screen's dispatcher registration for the lifetime of its bind resolver (spec §3.4).
+///
+/// Held as `@State` by ``VMServerResolverView`` when its ViewModel is a ``LiveViewModel``: it holds
+/// the ``InvalidationDispatcher/Token`` strongly, re-registers the latest response's identity set on
+/// every refresh, and signals the resolver — via the observed ``refreshSignal`` — to re-fetch when a
+/// matching server nudge fires. When the resolver leaves the view hierarchy the coordinator
+/// deallocates, the token dies, and the registration stops (the dispatcher holds tokens weakly).
+@MainActor
+@Observable
+final class LiveRegistrationCoordinator {
+    /// Advances each time a matching nudge fires. The resolver observes it and re-fetches in place
+    /// through the freshness gate — it is the signal, not the fetch (the coordinator must never
+    /// capture the resolver's `View` value; see the trigger's weak capture below).
+    private(set) var refreshSignal = 0
+
+    @ObservationIgnored
+    private var token: InvalidationDispatcher.Token?
+
+    /// Whether a registration is currently held — a test/introspection seam.
+    var isRegistered: Bool {
+        token != nil
+    }
+
+    /// Registers (first call) or re-registers (each later call) `registrations` with `dispatcher`, so
+    /// a screen whose plan touched new containers starts listening to them automatically (spec §3.4).
+    func update(registrations: [ModelIdentity], dispatcher: InvalidationDispatcher) {
+        let identities = Set(registrations)
+        // v1: every shipped plan root resolves to an *exact* identity, so the namespace tier stays
+        // empty here — it ships dormant until a namespace-scoped plan kind exists (spec §3.3 note).
+        let namespaces = Set<ModelNamespace>()
+
+        if let token {
+            dispatcher.reregister(token, identities: identities, namespaces: namespaces)
+        } else {
+            token = dispatcher.register(identities: identities, namespaces: namespaces) { [weak self] in
+                // Weak by contract: the coordinator holds the token strongly and the dispatcher holds
+                // it weakly; a strong capture here would close a token → trigger → coordinator → token
+                // cycle that never deallocates (InvalidationDispatcher.register's warning).
+                self?.refreshSignal += 1
+            }
+        }
+    }
+}
+#endif

--- a/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
@@ -487,14 +487,15 @@ extension MVVMEnvironment {
 
     /// The channel the live-invalidation dispatcher consumes: the app-supplied
     /// ``invalidationChannel`` if set, otherwise the lazily-synthesized default SSE channel over
-    /// ``invalidationBaseURL`` and ``clientCredentialProvider``. `nil` only where no default
-    /// transport exists (e.g. WASI) — the app then degrades to fetch-once.
+    /// ``invalidationBaseURL`` and ``clientCredentialProvider``. The default channel is
+    /// Darwin-only (FoundationNetworking lacks `URLSession.bytes`); on Linux/WASI this is `nil`
+    /// and the app degrades to fetch-once.
     @MainActor
     var effectiveInvalidationChannel: (any InvalidationChannel)? {
         if let invalidationChannel {
             return invalidationChannel
         }
-        #if canImport(Darwin) || canImport(FoundationNetworking)
+        #if canImport(Darwin)
         if let cached = _defaultInvalidationChannel {
             return cached
         }

--- a/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
@@ -73,14 +73,19 @@ public final class MVVMEnvironment: @unchecked Sendable {
         /// The base  URL for images
         public let resourcesBaseURL: URL
 
+        /// The base URL of the live-invalidation stream
+        public let invalidationBaseURL: URL
+
         /// Initializes the ``MVVMEnvironment``
         ///
         /// - Parameters:
         ///   - serverBaseURL: The base URL of the web service used to retrieve ``ViewModel``s
         ///   - resourcesBaseURL: The base URL of the web service used to retrieve images (default: ``serverBaseURL``)
-        public init(serverBaseURL: URL, resourcesBaseURL: URL? = nil) {
+        ///   - invalidationBaseURL: The base URL of the live-invalidation stream (default: ``serverBaseURL``)
+        public init(serverBaseURL: URL, resourcesBaseURL: URL? = nil, invalidationBaseURL: URL? = nil) {
             self.serverBaseURL = serverBaseURL
             self.resourcesBaseURL = resourcesBaseURL ?? serverBaseURL
+            self.invalidationBaseURL = invalidationBaseURL ?? serverBaseURL
         }
     }
 
@@ -104,6 +109,10 @@ public final class MVVMEnvironment: @unchecked Sendable {
     /// Use the stock ``BearerCredentialProvider`` for `Authorization: Bearer`
     /// authentication, or conform your own ``ClientCredentialProvider``.
     public let clientCredentialProvider: (any ClientCredentialProvider)?
+
+    /// The transport that delivers server invalidation nudges, or `nil` when live
+    /// invalidation is not configured — see ``InvalidationChannel``
+    public let invalidationChannel: (any InvalidationChannel)?
 
     /// A function that is called when there is an error processing a ``ServerRequest``
     public let requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)?
@@ -171,26 +180,32 @@ public final class MVVMEnvironment: @unchecked Sendable {
     /// Returns the URL for the web server that provides ``ViewModel``s for the current ``Deployment``
     public var serverBaseURL: URL {
         get async throws {
-            let deployment = await Deployment.current
-            guard let result = deploymentURLs[deployment] else {
-                throw MVVMEnvironmentError.missingDeploymentConfiguration(deployment: deployment)
-            }
-
-            return result.serverBaseURL
+            try await currentURLPackage().serverBaseURL
         }
     }
 
     /// Returns the URL for the web server that provides images and resources for the current ``Deployment``
     public var resourcesBaseURL: URL {
         get async throws {
-            let deployment = await Deployment.current
-            guard let result = deploymentURLs[deployment] else {
-                throw MVVMEnvironmentError.missingDeploymentConfiguration(deployment: deployment)
-            }
-
-            return result.resourcesBaseURL
+            try await currentURLPackage().resourcesBaseURL
         }
     }
+
+    /// The one Deployment → ``URLPackage`` resolution every base-URL accessor projects from.
+    private func currentURLPackage() async throws -> URLPackage {
+        let deployment = await Deployment.current
+        guard let result = deploymentURLs[deployment] else {
+            throw MVVMEnvironmentError.missingDeploymentConfiguration(deployment: deployment)
+        }
+
+        return result
+    }
+
+    @ObservationIgnored
+    private var _defaultInvalidationChannel: (any InvalidationChannel)?
+
+    @ObservationIgnored
+    private var _invalidationDispatcher: InvalidationDispatcher?
 
     #if canImport(SwiftUI)
     /// Initializes the ``MVVMEnvironment`` for SwiftUI
@@ -207,6 +222,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
     ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
     ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
+    ///   - invalidationChannel: The transport that delivers server invalidation nudges; supply one
+    ///     only to replace the standard transport — see ``InvalidationChannel`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
     ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
@@ -220,6 +237,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
         clientCredentialProvider: (any ClientCredentialProvider)? = nil,
+        invalidationChannel: (any InvalidationChannel)? = nil,
         deploymentURLs: [Deployment: URLPackage],
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil,
         session: URLSession? = nil,
@@ -230,6 +248,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         self.resourceDirectoryName = resourceDirectoryName
         self.requestHeaders = requestHeaders
         self.clientCredentialProvider = clientCredentialProvider
+        self.invalidationChannel = invalidationChannel
         self.deploymentURLs = deploymentURLs
         self.requestErrorHandler = requestErrorHandler
         self.session = session
@@ -257,6 +276,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
     ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
     ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
+    ///   - invalidationChannel: The transport that delivers server invalidation nudges; supply one
+    ///     only to replace the standard transport — see ``InvalidationChannel`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
     ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
@@ -270,6 +291,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
         clientCredentialProvider: (any ClientCredentialProvider)? = nil,
+        invalidationChannel: (any InvalidationChannel)? = nil,
         deploymentURLs: [Deployment: URL],
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil,
         session: URLSession? = nil,
@@ -282,6 +304,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
             resourceDirectoryName: resourceDirectoryName,
             requestHeaders: requestHeaders,
             clientCredentialProvider: clientCredentialProvider,
+            invalidationChannel: invalidationChannel,
             deploymentURLs: deploymentURLs.reduce([Deployment: URLPackage]()) { result, pair in
                 var result = result
                 let (deployment, url) = pair
@@ -311,6 +334,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         self.resourceDirectoryName = nil
         self.requestHeaders = [:]
         self.clientCredentialProvider = nil
+        self.invalidationChannel = nil
         self.deploymentURLs = deploymentURLs
         self.requestErrorHandler = nil
         self.session = session
@@ -334,6 +358,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
     ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
     ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
+    ///   - invalidationChannel: The transport that delivers server invalidation nudges; supply one
+    ///     only to replace the standard transport — see ``InvalidationChannel`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
@@ -345,6 +371,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
         clientCredentialProvider: (any ClientCredentialProvider)? = nil,
+        invalidationChannel: (any InvalidationChannel)? = nil,
         deploymentURLs: [Deployment: URLPackage],
         session: URLSession? = nil,
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil
@@ -357,6 +384,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         self.resourceDirectoryName = resourceDirectoryName
         self.requestHeaders = requestHeaders
         self.clientCredentialProvider = clientCredentialProvider
+        self.invalidationChannel = invalidationChannel
         self.deploymentURLs = deploymentURLs
         self.requestErrorHandler = requestErrorHandler
         self.session = session
@@ -396,6 +424,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - requestHeaders: A set of HTTP header fields for the URLRequest
     ///   - clientCredentialProvider: Supplies the authentication headers that accompany every
     ///     ``ServerRequest``; consulted per request — see ``ClientCredentialProvider`` (default: nil)
+    ///   - invalidationChannel: The transport that delivers server invalidation nudges; supply one
+    ///     only to replace the standard transport — see ``InvalidationChannel`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
@@ -407,6 +437,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
         resourceDirectoryName: String? = nil,
         requestHeaders: [String: String] = [:],
         clientCredentialProvider: (any ClientCredentialProvider)? = nil,
+        invalidationChannel: (any InvalidationChannel)? = nil,
         deploymentURLs: [Deployment: URL],
         session: URLSession? = nil,
         requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil
@@ -421,6 +452,7 @@ public final class MVVMEnvironment: @unchecked Sendable {
             resourceDirectoryName: resourceDirectoryName,
             requestHeaders: requestHeaders,
             clientCredentialProvider: clientCredentialProvider,
+            invalidationChannel: invalidationChannel,
             deploymentURLs: deploymentURLs.reduce([Deployment: URLPackage]()) { result, pair in
                 var result = result
                 let (deployment, url) = pair
@@ -442,6 +474,56 @@ public enum MVVMEnvironmentError: Error, CustomDebugStringConvertible {
         case .missingDeploymentConfiguration(deployment: let deployment):
             "debugDescription: Missing deployment configuration for \(deployment)"
         }
+    }
+}
+
+extension MVVMEnvironment {
+    /// The base URL of the live-invalidation stream for the current ``Deployment``
+    var invalidationBaseURL: URL {
+        get async throws {
+            try await currentURLPackage().invalidationBaseURL
+        }
+    }
+
+    /// The channel the live-invalidation dispatcher consumes: the app-supplied
+    /// ``invalidationChannel`` if set, otherwise the lazily-synthesized default SSE channel over
+    /// ``invalidationBaseURL`` and ``clientCredentialProvider``. `nil` only where no default
+    /// transport exists (e.g. WASI) — the app then degrades to fetch-once.
+    @MainActor
+    var effectiveInvalidationChannel: (any InvalidationChannel)? {
+        if let invalidationChannel {
+            return invalidationChannel
+        }
+        #if canImport(Darwin) || canImport(FoundationNetworking)
+        if let cached = _defaultInvalidationChannel {
+            return cached
+        }
+        let channel = SSEInvalidationChannel(
+            baseURL: { [weak self] in
+                guard let self else { throw await MVVMEnvironmentError.missingDeploymentConfiguration(deployment: Deployment.current) }
+                return try await invalidationBaseURL
+            },
+            credentialProvider: clientCredentialProvider,
+            session: session
+        )
+        _defaultInvalidationChannel = channel
+        return channel
+        #else
+        return nil
+        #endif
+    }
+
+    /// The dispatcher live screens register with — lazily created over ``effectiveInvalidationChannel``.
+    /// `@MainActor`-only, like the channel memo it mirrors: creation and every consultation happen on
+    /// the main actor, which is what leaves `_invalidationDispatcher` safe to store unsynchronized.
+    @MainActor
+    var invalidationDispatcher: InvalidationDispatcher {
+        if let _invalidationDispatcher {
+            return _invalidationDispatcher
+        }
+        let dispatcher = InvalidationDispatcher(channel: effectiveInvalidationChannel)
+        _invalidationDispatcher = dispatcher
+        return dispatcher
     }
 }
 

--- a/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
@@ -1,0 +1,232 @@
+// SSEInvalidationChannel.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The default ``InvalidationChannel`` transport (spec §3.2/§6). Compiled only where an async
+// streaming `URLSession` exists — Apple platforms and Linux (FoundationNetworking). On WASI and
+// any platform without it, `MVVMEnvironment.effectiveInvalidationChannel` degrades to `nil`
+// (no channel ⇒ fetch-once semantics, the north-star promise).
+#if canImport(Darwin) || canImport(FoundationNetworking)
+import FOSFoundation
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// The default Server-Sent-Events transport for live invalidation.
+///
+/// Consumes `<invalidationBaseURL>/invalidations` as a `text/event-stream`, decoding each `data:`
+/// event as a JSON array of ``ModelIdentity`` and yielding `.invalidated`. Emits `.connected` on
+/// every (re)open so the dispatcher can sweep; reconnects with exponential back-off after any drop.
+struct SSEInvalidationChannel: InvalidationChannel {
+    /// Resolves the current-deployment base URL at each open (mirrors the async `serverBaseURL`
+    /// resolution; picks up a deployment change without rebuilding the channel).
+    private let baseURL: @Sendable () async throws -> URL
+    private let credentialProvider: (any ClientCredentialProvider)?
+    private let session: URLSession?
+
+    // Reconnect seam — injectable so back-off is deterministically testable (no real sleeping).
+    private let sleep: @Sendable (Duration) async -> Void
+    private let initialBackoff: Duration
+    private let maxBackoff: Duration
+
+    init(
+        baseURL: @escaping @Sendable () async throws -> URL,
+        credentialProvider: (any ClientCredentialProvider)?,
+        session: URLSession?,
+        sleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) },
+        initialBackoff: Duration = .seconds(1),
+        maxBackoff: Duration = .seconds(30)
+    ) {
+        self.baseURL = baseURL
+        self.credentialProvider = credentialProvider
+        self.session = session
+        self.sleep = sleep
+        self.initialBackoff = initialBackoff
+        self.maxBackoff = maxBackoff
+    }
+
+    func events() -> AsyncStream<InvalidationEvent> {
+        AsyncStream { continuation in
+            // Structured under a single Task the stream owns: consumer cancellation (dispatcher
+            // shutdown / last registration gone) fires onTermination, which cancels this task; the
+            // in-flight `URLSession.bytes` read and the back-off sleep are both cancellation points,
+            // so teardown is prompt.
+            let task = Task {
+                await Self.runReconnectLoop(
+                    yielding: continuation,
+                    sleep: sleep,
+                    initialBackoff: initialBackoff,
+                    maxBackoff: maxBackoff
+                ) { continuation, onOpen in
+                    try await openAndStream(yielding: continuation, onOpen: onOpen)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// The reconnect cornerstone (spec §3.2), factored as the testable unit: it owns back-off and
+    /// the `.connected` signal; `streamOnce` performs one open-and-stream and calls `onOpen` the
+    /// moment the connection is live (resetting back-off and emitting `.connected`).
+    static func runReconnectLoop(
+        yielding continuation: AsyncStream<InvalidationEvent>.Continuation,
+        sleep: @Sendable (Duration) async -> Void,
+        initialBackoff: Duration,
+        maxBackoff: Duration,
+        streamOnce: (
+            _ continuation: AsyncStream<InvalidationEvent>.Continuation,
+            _ onOpen: () -> Void
+        ) async throws -> Void
+    ) async {
+        var backoff = initialBackoff
+        while !Task.isCancelled {
+            do {
+                try await streamOnce(continuation) {
+                    backoff = initialBackoff
+                    continuation.yield(.connected)
+                }
+            } catch is CancellationError {
+                break
+            } catch {
+                // Any open/stream failure is a drop → reconnect after back-off.
+            }
+            if Task.isCancelled { break }
+            await sleep(backoff)
+            backoff = min(backoff * 2, maxBackoff)
+        }
+        continuation.finish()
+    }
+
+    /// Opens one authenticated stream and pumps parsed events until EOF or failure. Re-consults the
+    /// credential provider on every call, so a rotated credential self-heals on reconnect (§3.2).
+    private func openAndStream(
+        yielding continuation: AsyncStream<InvalidationEvent>.Continuation,
+        onOpen: () -> Void
+    ) async throws {
+        let credentialHeaders = try await credentialProvider?.credentialHeaders() ?? []
+        let request = try await Self.makeRequest(baseURL: baseURL(), credentialHeaders: credentialHeaders)
+        let session = session ?? .shared
+
+        let (bytes, response) = try await session.bytes(for: request)
+
+        // `bytes(for:)` throws only on transport failure — a 401/404/5xx arrives as a normal
+        // response. Signaling open on one would emit a false `.connected` (spurious dispatcher
+        // sweep) and reset back-off into a ~1 Hz hot spin against a misconfigured URL or expired
+        // credential. Treat non-2xx as a drop: back-off grows, and the next open re-consults the
+        // credential provider (rotation still self-heals).
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw SSEStreamOpenError.badStatus(http.statusCode)
+        }
+        onOpen()
+
+        // Split on `\n` by hand rather than `bytes.lines`: Foundation's `AsyncLineSequence` swallows
+        // empty lines, and SSE's event terminator IS the blank line. The parser strips a trailing
+        // `\r`, so CRLF framing round-trips.
+        var parser = SSEEventParser()
+        var lineBytes = [UInt8]()
+        for try await byte in bytes {
+            try Task.checkCancellation()
+            guard byte == UInt8(ascii: "\n") else {
+                lineBytes.append(byte)
+                continue
+            }
+            // swiftlint:disable:next optional_data_string_conversion
+            let line = String(decoding: lineBytes, as: UTF8.self)
+            lineBytes.removeAll(keepingCapacity: true)
+            guard let payload = parser.consume(line) else { continue }
+            guard let identities = Self.decode(payload) else { continue }
+            continuation.yield(.invalidated(identities))
+        }
+    }
+
+    /// The stream-open request: the frozen §6 `invalidations` path with `Accept: text/event-stream`
+    /// and the provider's credential headers. Factored out so header attachment is unit-testable.
+    static func makeRequest(baseURL: URL, credentialHeaders: [(field: String, value: String)]) -> URLRequest {
+        // FROZEN §6 wire literal — the server keeps its own private copy in
+        // FOSMVVMVapor/LiveInvalidation/InvalidationRoute.swift (`InvalidationRoute.pathComponent`).
+        // Frozen contracts make this duplication safe; the FOSMVVMVaporTests round-trip locks it
+        // end-to-end. Do NOT promote to shared public surface.
+        var request = URLRequest(url: baseURL.appending(path: "invalidations"))
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        for header in credentialHeaders {
+            request.setValue(header.value, forHTTPHeaderField: header.field)
+        }
+        return request
+    }
+
+    /// Decodes one completed event's data payload. A malformed body is skipped (returns `nil`) so a
+    /// single bad event never kills the channel — the reconnect sweep would otherwise be needed for
+    /// a fault the stream itself survives.
+    static func decode(_ payload: String) -> Set<ModelIdentity>? {
+        // NEVER a raw JSONDecoder — PL-5; the server framed this with JSONEncoder.defaultEncoder.
+        guard let array = try? JSONDecoder.defaultDecoder.decode([ModelIdentity].self, from: Data(payload.utf8)) else {
+            return nil
+        }
+        return Set(array)
+    }
+}
+
+/// A stream-open that answered non-2xx — treated as a drop by the reconnect loop.
+enum SSEStreamOpenError: Error {
+    case badStatus(Int)
+}
+
+/// Line-oriented Server-Sent-Events reassembly (spec §6, frozen): joins one event's `data:` lines,
+/// dispatches on the blank-line terminator, and silently consumes comment lines (`:`-prefixed
+/// heartbeats / the open preamble) and any non-`data` field (`id:`/`event:` are ignored defensively,
+/// never an error). Tolerates CRLF.
+struct SSEEventParser {
+    private var dataLines: [String] = []
+
+    /// Feeds one line (the `\n` already removed by the caller's byte splitter; a trailing `\r` may
+    /// remain and is stripped here). Returns the completed event's joined data payload on a
+    /// blank-line terminator, else `nil`.
+    mutating func consume(_ rawLine: String) -> String? {
+        let line = rawLine.hasSuffix("\r") ? String(rawLine.dropLast()) : rawLine
+
+        if line.isEmpty {
+            guard !dataLines.isEmpty else { return nil }
+            let payload = dataLines.joined(separator: "\n")
+            dataLines.removeAll(keepingCapacity: true)
+            return payload
+        }
+        if line.hasPrefix(":") {
+            return nil
+        }
+
+        let (field, value) = Self.splitField(line)
+        if field == "data" {
+            dataLines.append(value)
+        }
+        // id:/event:/retry:/unknown fields — defensively ignored (§6: v1 events are data-only).
+        return nil
+    }
+
+    /// Splits a `field: value` line on the first colon; a single leading space after the colon is
+    /// stripped per the SSE grammar. A colon-less line is a field with an empty value.
+    static func splitField(_ line: String) -> (field: String, value: String) {
+        guard let colon = line.firstIndex(of: ":") else {
+            return (line, "")
+        }
+        let field = String(line[line.startIndex..<colon])
+        var valueStart = line.index(after: colon)
+        if valueStart < line.endIndex, line[valueStart] == " " {
+            valueStart = line.index(after: valueStart)
+        }
+        return (field, String(line[valueStart..<line.endIndex]))
+    }
+}
+#endif

--- a/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
@@ -14,16 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The default ``InvalidationChannel`` transport (spec §3.2/§6). Compiled only where an async
-// streaming `URLSession` exists — Apple platforms and Linux (FoundationNetworking). On WASI and
-// any platform without it, `MVVMEnvironment.effectiveInvalidationChannel` degrades to `nil`
-// (no channel ⇒ fetch-once semantics, the north-star promise).
-#if canImport(Darwin) || canImport(FoundationNetworking)
+// The default ``InvalidationChannel`` transport (spec §3.2/§6). Darwin-only: swift-corelibs
+// FoundationNetworking has no async `URLSession.bytes(for:)`. On every other platform
+// (Linux, WASI) `MVVMEnvironment.effectiveInvalidationChannel` degrades to `nil`
+// (no channel ⇒ fetch-once semantics, the north-star promise); a custom
+// ``InvalidationChannel`` remains the door for those clients.
+#if canImport(Darwin)
 import FOSFoundation
 import Foundation
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
 
 /// The default Server-Sent-Events transport for live invalidation.
 ///

--- a/Sources/FOSMVVM/SwiftUI Support/ViewModelView.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/ViewModelView.swift
@@ -403,6 +403,9 @@ private struct VMServerResolverView<VM: RequestableViewModel, VMV: ViewModelView
     @Environment(\.viewModelInvalidated) private var viewModelInvalidated
     @Environment(\.viewModelRefreshed) private var viewModelRefreshed
     @State private var viewModel: VM?
+    /// Inert unless `VM` is a `LiveViewModel`: only then is it ever handed a dispatcher (see
+    /// `registerLive`), so a non-live bind never touches the invalidation machinery.
+    @State private var liveCoordinator = LiveRegistrationCoordinator()
 
     private let query: VM.Request.Query?
     private let fragment: VM.Request.Fragment?
@@ -413,13 +416,13 @@ private struct VMServerResolverView<VM: RequestableViewModel, VMV: ViewModelView
                 VMV(viewModel: viewModel)
                     .id(viewModel.vmId)
                     .onChange(of: query, initial: true) { Task {
-                        self.viewModel = await resolveServerHostedRequest()
+                        await loadAndBind()
                         viewModelInvalidated.wrappedValue = false
                     } }
                     .onChange(of: fragment, initial: true) {
                         guard fragment != nil else { return }
                         Task {
-                            self.viewModel = await resolveServerHostedRequest()
+                            await loadAndBind()
                             viewModelInvalidated.wrappedValue = false
                         }
                     }
@@ -438,11 +441,16 @@ private struct VMServerResolverView<VM: RequestableViewModel, VMV: ViewModelView
                         else {
                             return
                         }
-                        self.viewModel = refreshedVM
+                        swapThroughFreshnessGate(refreshedVM)
+                    }
+                    // A matching server nudge advances `refreshSignal`; re-fetch in place through the
+                    // freshness gate (spec §3.4). Inert for a non-live VM — the signal never advances.
+                    .onChange(of: liveCoordinator.refreshSignal, initial: false) {
+                        Task { await refreshInPlace() }
                     }
             } else {
                 ProgressView().task {
-                    viewModel = await resolveServerHostedRequest()
+                    await loadAndBind()
                 }
             }
         }
@@ -453,7 +461,48 @@ private struct VMServerResolverView<VM: RequestableViewModel, VMV: ViewModelView
         self.fragment = fragment
     }
 
-    private func resolveServerHostedRequest() async -> VM? {
+    /// The gated in-place swap seam shared by same-request refresh arrivals — the pushed-JSON path
+    /// and the nudge-triggered re-fetch. Navigation (`query`/`fragment`) bypasses it: different data,
+    /// incomparable freshness (spec §3.3 scoping rule).
+    private func swapThroughFreshnessGate(_ incoming: VM) {
+        guard FreshnessGate.shouldReplace(current: viewModel, with: incoming) else { return }
+        viewModel = incoming
+    }
+
+    /// Navigation / initial load: replace the bound ViewModel outright (no gate — different data),
+    /// then (re-)register the live set if `VM` is live. A failed load registers nothing — the error
+    /// path's `(nil, [])` must not touch the registration (see `refreshInPlace`).
+    private func loadAndBind() async {
+        let (vm, registrations) = await resolveServerHostedRequest()
+        viewModel = vm
+        guard vm != nil else { return }
+        registerLive(registrations)
+    }
+
+    /// A nudge-triggered same-request refresh: re-fetch and swap through the freshness gate, then
+    /// re-register the latest response's set so newly-touched containers start listening.
+    ///
+    /// A failed re-fetch returns `(nil, [])`, so the guard covers the swap AND the registration:
+    /// the screen keeps showing its stale data and keeps listening with the prior set —
+    /// reregistering to the error path's empty set would deafen it until the next `.connected`
+    /// sweep or navigation. A genuinely-empty *successful* response still reregisters to empty.
+    private func refreshInPlace() async {
+        let (vm, registrations) = await resolveServerHostedRequest()
+        guard let vm else { return }
+        swapThroughFreshnessGate(vm)
+        registerLive(registrations)
+    }
+
+    private func registerLive(_ registrations: [ModelIdentity]) {
+        // A metatype conformance probe (not a stored existential): only a `LiveViewModel` registers,
+        // so a non-live bind never reaches the dispatcher and its behavior is wholly untouched. Where
+        // no channel is configured the dispatcher is inert (no socket, no events), degrading a live
+        // bind to fetch-once-on-appear (spec §3.4).
+        guard VM.self is any LiveViewModel.Type else { return }
+        liveCoordinator.update(registrations: registrations, dispatcher: mvvmEnv.invalidationDispatcher)
+    }
+
+    private func resolveServerHostedRequest() async -> (viewModel: VM?, registrations: [ModelIdentity]) {
         do {
             let request = VM.Request(
                 query: query,
@@ -462,9 +511,9 @@ private struct VMServerResolverView<VM: RequestableViewModel, VMV: ViewModelView
                 responseBody: nil
             )
 
-            try await request.processRequest(mvvmEnv: mvvmEnv)
+            let registrations = try await request.processRequestCapturingRegistrations(mvvmEnv: mvvmEnv)
 
-            return request.viewModel
+            return (request.viewModel, registrations)
         } catch { // fosmvvm-review:disable:this no-silent-failure -- Error handling is TBD
             print("ViewModel Bind Error: \(error)")
             // TODO: Error handling
@@ -474,7 +523,7 @@ private struct VMServerResolverView<VM: RequestableViewModel, VMV: ViewModelView
             // over the UI.  But instead, some top-level
             // way to display to the user that the app
             // encountered an error.
-            return nil
+            return (nil, [])
         }
     }
 }

--- a/Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift
+++ b/Sources/FOSMVVMVapor/Containment/ContainmentRelation.swift
@@ -40,6 +40,9 @@ public struct ContainmentRelation: Sendable {
     // and C6 needs the Fluent query capability.
     let containerType: any DataModel.Type // == From.self, captured by the factory
     let containedType: any DataModel.Type // == To.self, captured by the factory
+    /// == Through.self for `.siblings`, nil otherwise. A membership change IS a pivot save, so the
+    /// L2 emit sweep must cover the pivot type — the relation is the only place Through is concrete.
+    let pivotType: (any DataModel.Type)?
 
     /// ONE refinement-aware code path with two internal entries (refined/unrefined) — no drift.
     private let load: @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> [any DataModel]
@@ -55,18 +58,35 @@ public struct ContainmentRelation: Sendable {
     /// only the in-module write route calls it.
     private let create: (@Sendable (_ container: any DataModel, _ child: any DataModel, _ db: any Database) async throws -> Void)?
 
+    /// The inversion twin of `load`, captured at factory time: given a just-mutated instance, the
+    /// identities of the containers THIS relation attributes staleness to — read straight off the
+    /// instance's own join references (no DB). The L2 live-invalidation derivation
+    /// (`InvalidationIdentitySet.staleIdentities(forMutated:registry:)`) is its only caller. Empty
+    /// when the instance is not this
+    /// relation's invertible end, or a reference is unset/nil. `isRegisteredContainer` gates the
+    /// to-one target of `.parent` and the far end of `.siblings`: a target contributes only when it
+    /// is itself a registered container.
+    private let invert: @Sendable (
+        _ mutated: any DataModel,
+        _ isRegisteredContainer: @Sendable (any DataModel.Type) -> Bool
+    ) -> Set<ModelIdentity>
+
     private init(
         containerType: any DataModel.Type,
         containedType: any DataModel.Type,
+        pivotType: (any DataModel.Type)? = nil,
         load: @escaping @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> [any DataModel],
         count: @escaping @Sendable (any DataModel, any Database, ContainmentQueryRefinement) async throws -> Int,
-        create: (@Sendable (any DataModel, any DataModel, any Database) async throws -> Void)?
+        create: (@Sendable (any DataModel, any DataModel, any Database) async throws -> Void)?,
+        invert: @escaping @Sendable (any DataModel, @Sendable (any DataModel.Type) -> Bool) -> Set<ModelIdentity>
     ) {
         self.containerType = containerType
         self.containedType = containedType
+        self.pivotType = pivotType
         self.load = load
         self.count = count
         self.create = create
+        self.invert = invert
     }
 
     /// A to-many child relationship (child table holds the foreign key back to the container).
@@ -89,7 +109,8 @@ public struct ContainmentRelation: Sendable {
             create: { container, child, db in
                 // ChildrenProperty.create sets the child's FK back to the container and saves it.
                 try await container.cast(to: From.self)[keyPath: keyPath].create(child.cast(to: To.self), on: db)
-            }
+            },
+            invert: childInverter(keyPath)
         )
     }
 
@@ -100,6 +121,7 @@ public struct ContainmentRelation: Sendable {
         .init(
             containerType: From.self,
             containedType: To.self,
+            pivotType: siblingPivotType(keyPath),
             load: { container, db, refinement in
                 try await refinement
                     .apply(to: container.cast(to: From.self)[keyPath: keyPath].query(on: db))
@@ -119,7 +141,8 @@ public struct ContainmentRelation: Sendable {
                     try await to.create(on: tx)
                     try await from[keyPath: keyPath].attach(to, on: tx)
                 }
-            }
+            },
+            invert: siblingInverter(keyPath)
         )
     }
 
@@ -138,9 +161,93 @@ public struct ContainmentRelation: Sendable {
             count: { container, db, _ in
                 try await container.cast(to: From.self)[keyPath: keyPath].query(on: db).count()
             },
-            create: nil
+            create: nil,
+            invert: parentInverter(keyPath)
         )
     }
+}
+
+// MARK: - Invalidation inversion (L2 live-invalidation)
+
+extension ContainmentRelation {
+    /// The identities of the containers this relation attributes staleness to, given a just-mutated
+    /// instance — read straight off the instance's own join references, no DB. The derivation half
+    /// of the L2 emit middleware; empty when `mutated` is not this relation's invertible end.
+    func staleContainerIdentities(
+        forMutated mutated: any DataModel,
+        isRegisteredContainer: @Sendable (any DataModel.Type) -> Bool
+    ) -> Set<ModelIdentity> {
+        invert(mutated, isRegisteredContainer)
+    }
+
+    // `.children`: the mutated instance is the child (To); its FK back to the container (From) is
+    // named by the ChildrenProperty's own `parentKey` — read that field directly for the owner id.
+    private static func childInverter<From: DataModel, To: DataModel>(
+        _ keyPath: KeyPath<From, ChildrenProperty<From, To>> & Sendable
+    ) -> @Sendable (any DataModel, @Sendable (any DataModel.Type) -> Bool) -> Set<ModelIdentity> {
+        { mutated, _ in
+            guard let child = mutated as? To else { return [] }
+            let ownerId: From.IDValue? = switch From()[keyPath: keyPath].parentKey {
+            case .required(let parentKeyPath): child[keyPath: parentKeyPath].$id.value
+            case .optional(let parentKeyPath): child[keyPath: parentKeyPath].id
+            }
+            return mintIdentity(of: From.self, id: ownerId).map { [$0] } ?? []
+        }
+    }
+
+    // `.parent`: the mutated instance is the container (From) that holds the to-one FK; read the
+    // referenced parent (To) id directly. The parent contributes only when it is itself a
+    // registered container — the fixture's `.parent(\Dock.$pier)` names an unregistered Pier and so
+    // stays dormant; a child-declared owning container (`.parent(\Child.$owner)`) does not.
+    private static func parentInverter<From: DataModel, To: DataModel>(
+        _ keyPath: KeyPath<From, ParentProperty<From, To>> & Sendable
+    ) -> @Sendable (any DataModel, @Sendable (any DataModel.Type) -> Bool) -> Set<ModelIdentity> {
+        { mutated, isRegisteredContainer in
+            guard let owner = mutated as? From, isRegisteredContainer(To.self) else { return [] }
+            let parentId = owner[keyPath: keyPath].$id.value
+            return mintIdentity(of: To.self, id: parentId).map { [$0] } ?? []
+        }
+    }
+
+    /// Recovers Through concretely — the public `siblings` signature spells it `some DataModel`,
+    /// which the factory body cannot name.
+    private static func siblingPivotType<From: DataModel, Through: DataModel>(
+        _: KeyPath<From, SiblingsProperty<From, some DataModel, Through>> & Sendable
+    ) -> any DataModel.Type {
+        Through.self
+    }
+
+    // `.siblings`: inverted from the PIVOT (Through) — a membership change IS a pivot save/delete.
+    // The pivot's two `@Parent` references name both linked ends: the declaring container (From)
+    // always contributes; the far end (To) contributes only when it too is a registered container.
+    private static func siblingInverter<From: DataModel, To: DataModel, Through: DataModel>(
+        _ keyPath: KeyPath<From, SiblingsProperty<From, To, Through>> & Sendable
+    ) -> @Sendable (any DataModel, @Sendable (any DataModel.Type) -> Bool) -> Set<ModelIdentity> {
+        { mutated, isRegisteredContainer in
+            guard let pivot = mutated as? Through else { return [] }
+            let siblings = From()[keyPath: keyPath]
+            var identities: Set<ModelIdentity> = []
+            if let identity = mintIdentity(of: From.self, id: pivot[keyPath: siblings.from].$id.value) {
+                identities.insert(identity)
+            }
+            if isRegisteredContainer(To.self),
+               let identity = mintIdentity(of: To.self, id: pivot[keyPath: siblings.to].$id.value) {
+                identities.insert(identity)
+            }
+            return identities
+        }
+    }
+}
+
+/// Mints a container's opaque ``ModelIdentity`` from its type and a persisted id, via the sanctioned
+/// public seam (a fresh instance's ``Model/modelIdentity``) — FOSMVVMVapor cannot mint one from raw
+/// values. `nil` id (an unset/unloaded reference) yields `nil`, never a crash. `_$id.value` is the
+/// generic FluentKit id seam that sidesteps the FOSMVVM/FluentKit `id` ambiguity on `DataModel`.
+private func mintIdentity<M: DataModel>(of _: M.Type, id: M.IDValue?) -> ModelIdentity? {
+    guard let id else { return nil }
+    let model = M()
+    model._$id.value = id
+    return try? model.modelIdentity
 }
 
 extension ContainmentRelation {

--- a/Sources/FOSMVVMVapor/Containment/ModelTypeRegistry.swift
+++ b/Sources/FOSMVVMVapor/Containment/ModelTypeRegistry.swift
@@ -55,6 +55,9 @@ struct RegisteredModel: Sendable {
     let containment: [ContainmentRelation]
     let authorityFlow: AuthorityFlow
     let typeName: String
+    /// The registered concrete type — the L2 emit-middleware sweep opens it back into a generic
+    /// (a container with EMPTY containment has no relation to recover its type from).
+    let modelType: any DataModel.Type
 
     private let findById: @Sendable (ModelIdType, any Database) async throws -> (any DataModel)?
 
@@ -63,6 +66,7 @@ struct RegisteredModel: Sendable {
         self.containment = type.containment
         self.authorityFlow = type.authorityFlow
         self.typeName = String(describing: type)
+        self.modelType = type
         self.findById = { id, db in try await type.find(id, on: db) }
     }
 

--- a/Sources/FOSMVVMVapor/Containment/PlanExecutor.swift
+++ b/Sources/FOSMVVMVapor/Containment/PlanExecutor.swift
@@ -47,7 +47,39 @@ extension Vapor.Request {
 
         let resolved = try await resolveRecordLoadPlan(plan, for: vmRequest)
         try await resolved.execute(on: self)
+        depositRegistrationSet(from: resolved)
         try await runSupplementalLoads(of: factory)
+    }
+
+    /// The executed plan's staleness surface — ``touchedContainers(of:)`` — deposited for
+    /// ``ServerRequestBody/buildResponse(_:)`` to attach as the `X-FOS-Registrations` header.
+    /// Derived from the executed plan's tuples only (spec §3.4): containers touched solely by a
+    /// SupplementalRecordLoading hook are outside the v1 registration surface.
+    private func depositRegistrationSet(from resolved: ResolvedRecordLoadPlan) {
+        registrationSet = touchedContainers(of: resolved)
+    }
+
+    /// The containers an executed plan touched: its resolved root identities plus every container
+    /// its tuples' cache keys name. The ONE traversal behind both the read path's registration set
+    /// (`depositRegistrationSet`) and the write path's cache invalidation
+    /// (`invalidateWrittenContainers`, WriteRoute.swift) — the live-invalidation contract holds
+    /// only while a client registers on exactly what a write invalidates, so neither site may
+    /// re-derive this shape on its own.
+    func touchedContainers(of resolved: ResolvedRecordLoadPlan) -> Set<ModelIdentity> {
+        var identities = Set(resolved.rootIdentities.values)
+        for tuple in resolved.plan.tuples {
+            for key in tupleCacheKeys[tuple] ?? [] {
+                identities.insert(key.container)
+            }
+        }
+        return identities
+    }
+
+    /// The registration set the executor deposited for this served response (empty when no plan
+    /// executed). ``ServerRequestBody/buildResponse(_:)`` reads it to attach `X-FOS-Registrations`.
+    var registrationSet: Set<ModelIdentity> {
+        get { storage[RegistrationSetStore.self] ?? [] }
+        set { storage[RegistrationSetStore.self] = newValue }
     }
 
     /// The executor's per-request side map: each executed tuple → the record-level cache keys
@@ -62,6 +94,10 @@ extension Vapor.Request {
 
 private struct TupleCacheKeysStore: StorageKey {
     typealias Value = [RecordLoadPlan.Tuple: [ContainerRecordCacheKey]]
+}
+
+private struct RegistrationSetStore: StorageKey {
+    typealias Value = Set<ModelIdentity>
 }
 
 /// A ``RecordLoadPlan`` bound to one request: each root source resolved to an identity and

--- a/Sources/FOSMVVMVapor/Containment/WriteRoute.swift
+++ b/Sources/FOSMVVMVapor/Containment/WriteRoute.swift
@@ -177,17 +177,12 @@ extension Vapor.Request {
         return typed
     }
 
-    /// Invalidates the cached records of every container the candidate load touched (its roots and
-    /// each branch container) — the C6 pass-#2 contract, so the refresh re-serves fresh. Touches
-    /// records only; the per-Request grant memo stands.
+    /// Invalidates the cached records of every container the candidate load touched —
+    /// ``touchedContainers(of:)``, the same traversal the registration set derives from — the C6
+    /// pass-#2 contract, so the refresh re-serves fresh. Touches records only; the per-Request
+    /// grant memo stands.
     func invalidateWrittenContainers(_ context: WriteCandidateContext) {
-        var touched = Set(context.resolved.rootIdentities.values)
-        for tuple in context.plan.tuples {
-            for key in tupleCacheKeys[tuple] ?? [] {
-                touched.insert(key.container)
-            }
-        }
-        for container in touched {
+        for container in touchedContainers(of: context.resolved) {
             invalidateContainerRecords(of: container)
         }
     }

--- a/Sources/FOSMVVMVapor/Extensions/Application+Containment.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Application+Containment.swift
@@ -56,10 +56,17 @@ public extension Application {
 
         // Boot-time fail-fast #1 (duplicate namespace) lives in insert(_:).
         var registry = modelTypeRegistry
-        try registry.insert(RegisteredModel(for: type))
+        let descriptor = RegisteredModel(for: type)
+        try registry.insert(descriptor)
         storage[ModelTypeRegistryStore.self] = registry
 
         migrations.add(migration)
+
+        // L2 live invalidation honors registrations made AFTER useLiveInvalidation(on:) — the
+        // boot switch sweeps the earlier ones (either call order works, spec §3.1).
+        if let hub = invalidationHub {
+            registerInvalidationEmitMiddleware(for: descriptor, hub: hub)
+        }
     }
 }
 

--- a/Sources/FOSMVVMVapor/Extensions/Application+LiveInvalidation.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Application+LiveInvalidation.swift
@@ -1,0 +1,122 @@
+// Application+LiveInvalidation.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FluentKit
+import FOSMVVM
+import Foundation
+import Vapor
+
+public extension Vapor.Application {
+    /// Turns on live invalidation for this server
+    ///
+    /// Call once at boot, passing the route group your clients authenticate
+    /// against; every registered container model then nudges connected clients
+    /// after each committed change:
+    ///
+    /// ```swift
+    /// let authed = app.grouped(MyAuthMiddleware())
+    /// try app.useLiveInvalidation(on: authed)
+    /// ```
+    ///
+    /// Model registrations made before or after this call are both honored.
+    func useLiveInvalidation(on routes: any RoutesBuilder) throws {
+        guard storage[InvalidationHubStore.self] == nil else {
+            throw LiveInvalidationError.alreadyEnabled
+        }
+
+        let hub = InvalidationHub()
+        storage[InvalidationHubStore.self] = hub
+
+        // Sweep registrations made BEFORE this call; register(_:migration:) covers the ones
+        // made after (spec §3.1: either call order works).
+        for descriptor in modelTypeRegistry.allRegistered {
+            registerInvalidationEmitMiddleware(for: descriptor, hub: hub)
+        }
+
+        mountInvalidationStream(on: routes, hub: hub)
+    }
+}
+
+extension Vapor.Application {
+    /// The hub's presence IS the layer's enabled flag — set once by useLiveInvalidation(on:).
+    var invalidationHub: InvalidationHub? {
+        storage[InvalidationHubStore.self]
+    }
+
+    /// Wires the emit middleware for one registration: the container itself, every contained
+    /// type, and every `.siblings` pivot (a membership change IS a pivot save — spec §3.1). Each
+    /// model type gets exactly one middleware no matter how many descriptors reach it — a
+    /// duplicate would double-emit.
+    func registerInvalidationEmitMiddleware(for descriptor: RegisteredModel, hub: InvalidationHub) {
+        var modelTypes: [any DataModel.Type] = [descriptor.modelType]
+        for relation in descriptor.containment {
+            modelTypes.append(relation.containedType)
+            if let pivotType = relation.pivotType {
+                modelTypes.append(pivotType)
+            }
+        }
+
+        // Weak: the middleware lives in the Databases configuration the Application owns — a
+        // strong capture would cycle. After shutdown the reader degrades to an empty registry.
+        let registryReader: @Sendable () -> ModelTypeRegistry = { [weak self] in
+            self?.modelTypeRegistry ?? ModelTypeRegistry()
+        }
+
+        var covered = storage[InvalidationEmitCoverageStore.self] ?? []
+        for modelType in modelTypes {
+            guard covered.insert(ObjectIdentifier(modelType)).inserted else {
+                continue
+            }
+            databases.middleware.use(
+                emitMiddleware(for: modelType, hub: hub, registryReader: registryReader)
+            )
+        }
+        storage[InvalidationEmitCoverageStore.self] = covered
+    }
+}
+
+/// Opens the erased model type into the generic middleware (SE-0352): FluentKit's middleware
+/// protocol type-filters per concrete model, so each covered type needs its own instance.
+private func emitMiddleware<M: DataModel>(
+    for _: M.Type,
+    hub: InvalidationHub,
+    registryReader: @escaping @Sendable () -> ModelTypeRegistry
+) -> any AnyModelMiddleware {
+    InvalidationEmitMiddleware<M>(hub: hub, registryReader: registryReader)
+}
+
+private struct InvalidationHubStore: StorageKey {
+    typealias Value = InvalidationHub
+}
+
+/// The model types whose emit middleware is already wired — a type can enter through several
+/// descriptors (its own registration, a container's contained side, a pivot).
+private struct InvalidationEmitCoverageStore: StorageKey {
+    typealias Value = Set<ObjectIdentifier>
+}
+
+/// Boot-time misconfiguration; internal like ContainmentError — apps never catch it, its value
+/// is the diagnostic message in Vapor's failed configure(_:).
+enum LiveInvalidationError: Error, CustomDebugStringConvertible {
+    case alreadyEnabled
+
+    var debugDescription: String {
+        switch self {
+        case .alreadyEnabled:
+            "useLiveInvalidation(on:) was called twice. Enable live invalidation exactly once at boot — a second enable would double-wire the emit middleware."
+        }
+    }
+}

--- a/Sources/FOSMVVMVapor/Extensions/Response+FOS.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Response+FOS.swift
@@ -61,7 +61,11 @@ public extension Response {
     @discardableResult func addSystemVersion() throws -> Response {
         let version = try SystemVersion.current.toJSON()
 
-        headers.add(name: SystemVersion.httpHeader, value: version)
+        // replaceOrAdd, not add: `buildResponse` runs this AND `buildJSONResponse` already ran it,
+        // so an appending `add` attached `X-FOS-Version` twice. Idempotent here is a belt against
+        // any current or future double-call — one served response, one version header — and matches
+        // `addJSONContentType`'s replaceOrAdd idiom.
+        headers.replaceOrAdd(name: SystemVersion.httpHeader, value: version)
 
         return self
     }

--- a/Sources/FOSMVVMVapor/Extensions/Response+FOS.swift
+++ b/Sources/FOSMVVMVapor/Extensions/Response+FOS.swift
@@ -33,6 +33,7 @@ public extension ServerRequestBody {
     func buildResponse(_ req: Vapor.Request) throws -> Response {
         try Response.buildJSONResponse(req, content: self)
             .addSystemVersion()
+            .addRegistrations(from: req)
     }
 }
 
@@ -61,6 +62,21 @@ public extension Response {
         let version = try SystemVersion.current.toJSON()
 
         headers.add(name: SystemVersion.httpHeader, value: version)
+
+        return self
+    }
+
+    /// Attaches the executed plan's registration set — the roots and touched containers the
+    /// executor deposited on `req` — as the `X-FOS-Registrations` header, so a live client can
+    /// register exactly what the response depended on. A response that executed no plan (empty
+    /// set) carries no header.
+    @discardableResult internal func addRegistrations(from req: Vapor.Request) throws -> Response {
+        let identities = req.registrationSet
+        guard !identities.isEmpty else {
+            return self
+        }
+
+        try headers.replaceOrAdd(name: ModelIdentity.registrationsHeader, value: Array(identities).toJSON())
 
         return self
     }

--- a/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationEmitMiddleware.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationEmitMiddleware.swift
@@ -1,0 +1,122 @@
+// InvalidationEmitMiddleware.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FluentKit
+import FOSMVVM
+import Foundation
+
+// L2 live-invalidation, emit side (spec §3.1): the DERIVATION half (InvalidationIdentitySet —
+// given a just-mutated record and the type registry, the set of ``ModelIdentity`` that just went
+// stale, zero author code, D-L2-2) and the ROUTING half composed onto it
+// (InvalidationEmitMiddleware — the per-type Fluent ModelMiddleware that is the layer's only
+// emit point).
+
+/// The only emit point (spec §3.1): fires after each completed Fluent mutation of `M` and routes
+/// the derived staleness set in pinned order — task-local collector present → COLLECT (its
+/// `liveTransaction` flushes on commit); else `db.inTransaction` → SUPPRESS + warn once per model
+/// type (a bare transaction exposes no commit hook, and an early emit is a stale-forever hazard);
+/// else → EMIT to the hub (an auto-commit save's middleware completion IS post-commit). The hub
+/// is injected at registration — never attached to `Database`. One instance exists per model type
+/// in the registered graph (`Application.registerInvalidationEmitMiddleware`): FluentKit's
+/// generic middleware type-filters, and only the generic async path preserves the task-local.
+struct InvalidationEmitMiddleware<M: DataModel>: AsyncModelMiddleware {
+    let hub: InvalidationHub
+    /// Reads the LIVE registry (weak-app closure): containers registered after this middleware
+    /// was wired must still contribute to the inversion — a snapshot would silently pin the
+    /// derivation to registration order.
+    let registryReader: @Sendable () -> ModelTypeRegistry
+
+    func create(model: M, on db: any Database, next: any AnyAsyncModelResponder) async throws {
+        try await next.create(model, on: db)
+        await route(model, on: db)
+    }
+
+    func update(model: M, on db: any Database, next: any AnyAsyncModelResponder) async throws {
+        try await next.update(model, on: db)
+        await route(model, on: db)
+    }
+
+    func delete(model: M, force: Bool, on db: any Database, next: any AnyAsyncModelResponder) async throws {
+        try await next.delete(model, force: force, on: db)
+        await route(model, on: db)
+    }
+
+    /// softDelete/restore are membership-visibility mutations — routed like the three verbs.
+    func softDelete(model: M, on db: any Database, next: any AnyAsyncModelResponder) async throws {
+        try await next.softDelete(model, on: db)
+        await route(model, on: db)
+    }
+
+    func restore(model: M, on db: any Database, next: any AnyAsyncModelResponder) async throws {
+        try await next.restore(model, on: db)
+        await route(model, on: db)
+    }
+
+    private func route(_ model: M, on db: any Database) async {
+        let stale = InvalidationIdentitySet.staleIdentities(
+            forMutated: model,
+            registry: registryReader()
+        )
+
+        if let collector = LiveTransactionState.collector {
+            await collector.collect(stale)
+        } else if db.inTransaction {
+            let typeName = String(describing: M.self)
+            if await hub.shouldWarnSuppressedEmit(for: typeName) {
+                db.logger.warning(
+                    "A \(typeName) write inside a bare database.transaction { } cannot notify live clients — FOSMVVM cannot see whether the transaction commits, so this write's invalidation was suppressed. Use liveTransaction { } to nudge live clients on commit. (Warned once per model type.)"
+                )
+            }
+        } else {
+            await hub.emit(stale)
+        }
+    }
+}
+
+/// The containment-derived staleness surface of a single mutation.
+enum InvalidationIdentitySet {
+    /// The identities that just went stale when `mutated` was saved/deleted: its own identity plus
+    /// the identities of every registered container it belongs to. Read straight off the instance's
+    /// join references (no DB): a `.children` member reads its owner FK, a `.siblings` pivot reads
+    /// both linked ends, a `.parent`-declared owner reads its to-one target. A record no registered
+    /// container declares yields only its own identity.
+    static func staleIdentities(
+        forMutated mutated: any DataModel,
+        registry: ModelTypeRegistry
+    ) -> Set<ModelIdentity> {
+        var identities: Set<ModelIdentity> = []
+        if let own = try? mutated.modelIdentity {
+            identities.insert(own)
+        }
+
+        let isRegisteredContainer: @Sendable (any DataModel.Type) -> Bool = { type in
+            registry.registered(for: type.modelIdentityNamespace) != nil
+        }
+
+        for descriptor in registry.allRegistered {
+            for relation in descriptor.containment {
+                identities.formUnion(
+                    relation.staleContainerIdentities(
+                        forMutated: mutated,
+                        isRegisteredContainer: isRegisteredContainer
+                    )
+                )
+            }
+        }
+
+        return identities
+    }
+}

--- a/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationHub.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationHub.swift
@@ -1,0 +1,81 @@
+// InvalidationHub.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSMVVM
+import Foundation
+
+/// The single-process broadcast point of L2 live invalidation (spec §3.1): every committed
+/// mutation's derived identity set arrives at `emit`, which fans it out to every subscriber
+/// (DEF-1: no per-client filtering). Owned by `Application.storage`
+/// (`Application.invalidationHub`); injected into each emit middleware and into `liveTransaction`
+/// — never attached to `Database`. It is the seam behind which multi-instance fan-out plugs in
+/// later (DEF-L2-4). Task 4's SSE endpoint is the production subscriber.
+actor InvalidationHub {
+    /// Per-subscriber buffer bound — overflow terminates that subscriber's stream (spec §3.2
+    /// slow-client policy). No nudge is silently dropped on a healthy stream; a terminated
+    /// client recovers through its reconnect sweep.
+    static let subscriberBufferLimit = 64
+
+    private var subscribers: [UUID: AsyncStream<Set<ModelIdentity>>.Continuation] = [:]
+    private var suppressionWarnedTypes: Set<String> = []
+
+    /// One subscriber's live feed of emitted identity sets. The stream ends when the hub
+    /// terminates it (buffer overflow) or the consumer cancels.
+    func subscribe() -> AsyncStream<Set<ModelIdentity>> {
+        let id = UUID()
+        let (stream, continuation) = AsyncStream<Set<ModelIdentity>>.makeStream(
+            bufferingPolicy: .bufferingOldest(Self.subscriberBufferLimit)
+        )
+        continuation.onTermination = { _ in
+            Task { [weak self] in
+                await self?.removeSubscriber(id)
+            }
+        }
+        subscribers[id] = continuation
+        return stream
+    }
+
+    /// Fans one emitted identity set out to every subscriber. An empty set is a no-op — nothing
+    /// went stale, no client is nudged.
+    func emit(_ identities: Set<ModelIdentity>) {
+        guard !identities.isEmpty else {
+            return
+        }
+
+        // COW-safe: the iterator holds a snapshot, so removing from `subscribers` below is sound.
+        for (id, continuation) in subscribers {
+            switch continuation.yield(identities) {
+            case .enqueued:
+                break
+            case .dropped, .terminated:
+                continuation.finish()
+                subscribers.removeValue(forKey: id)
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    /// True exactly once per model type — gates the bare-transaction suppress warning
+    /// (spec §3.1: "suppresses the emit and logs one warning naming the model type").
+    func shouldWarnSuppressedEmit(for modelType: String) -> Bool {
+        suppressionWarnedTypes.insert(modelType).inserted
+    }
+
+    private func removeSubscriber(_ id: UUID) {
+        subscribers.removeValue(forKey: id)?.finish()
+    }
+}

--- a/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationRoute.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationRoute.swift
@@ -1,0 +1,153 @@
+// InvalidationRoute.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+import NIOCore
+import Vapor
+
+extension Vapor.Application {
+    /// Mounts the SSE endpoint on the passed group (spec §3.2/§6): `GET <group>/invalidations`,
+    /// `text/event-stream`, one `data:` event per hub emission, comment-line heartbeats between
+    /// events. No auth here — the group carries whatever middleware the app hung it on.
+    func mountInvalidationStream(on routes: any RoutesBuilder, hub: InvalidationHub) {
+        routes.get(InvalidationRoute.pathComponent) { req -> Response in
+            let subscription = await hub.subscribe()
+            let heartbeat = req.application.invalidationHeartbeatInterval
+
+            var headers = HTTPHeaders()
+            headers.contentType = HTTPMediaType(type: "text", subType: "event-stream")
+            headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+
+            let logger = req.logger
+            let body = Response.Body(asyncStream: { writer in
+                await InvalidationRoute.pump(
+                    subscription,
+                    heartbeat: heartbeat,
+                    to: writer,
+                    logger: logger
+                )
+            })
+            return Response(status: .ok, headers: headers, body: body)
+        }
+    }
+
+    /// The SSE heartbeat interval — comment lines emitted on an idle stream so intermediaries don't
+    /// cut it (spec §3.2). Internal-only override: tests shorten it; no public surface.
+    var invalidationHeartbeatInterval: Duration {
+        get { storage[InvalidationHeartbeatIntervalKey.self] ?? InvalidationRoute.defaultHeartbeatInterval }
+        set { storage[InvalidationHeartbeatIntervalKey.self] = newValue }
+    }
+}
+
+private struct InvalidationHeartbeatIntervalKey: StorageKey {
+    typealias Value = Duration
+}
+
+/// The wire-framing and pump for one connected SSE client (spec §6, frozen): `data:`-only events
+/// carrying a JSON array of ``ModelIdentity`` via `JSONEncoder.defaultEncoder`, comment-line
+/// heartbeats, no `id:`/`event:` fields.
+private enum InvalidationRoute {
+    static let pathComponent: PathComponent = "invalidations"
+    static let defaultHeartbeatInterval: Duration = .seconds(15)
+
+    /// One connected client's feed: a single consumer serializes every write, selecting between the
+    /// next hub emission and a heartbeat deadline (merged into one stream so the two producers never
+    /// race on the writer). Ends the client stream cleanly when the hub terminates the subscription
+    /// (overflow) or a write fails (client disconnect).
+    static func pump(
+        _ subscription: AsyncStream<Set<ModelIdentity>>,
+        heartbeat: Duration,
+        to writer: any AsyncBodyStreamWriter,
+        logger: Logger
+    ) async {
+        // Unbounded by design: heartbeat ticks can accumulate here on a wedged, emission-less
+        // connection until the next blocked write throws (bounded in practice by the write failing).
+        let merged = AsyncStream<Tick> { continuation in
+            let hubTask = Task {
+                for await identities in subscription {
+                    continuation.yield(.event(identities))
+                }
+                continuation.yield(.hubEnded)
+                continuation.finish()
+            }
+            let heartbeatTask = Task {
+                while !Task.isCancelled {
+                    do {
+                        try await Task.sleep(for: heartbeat)
+                    } catch {
+                        break
+                    }
+                    continuation.yield(.heartbeat)
+                }
+            }
+            // The SOLE reaper of both producer tasks — fires when the consumer drops the stream
+            // (client gone, pump returned) or the stream finishes. Without it a heartbeat task
+            // would outlive its connection.
+            continuation.onTermination = { _ in
+                hubTask.cancel()
+                heartbeatTask.cancel()
+            }
+        }
+
+        do {
+            // Open the stream immediately so the client receives response headers without waiting
+            // for the first event or heartbeat (the server flushes the head with the first body
+            // byte). A comment line is inert to SSE consumers.
+            try await writer.write(.buffer(ByteBuffer(string: ": open\n\n")))
+
+            consume: for await tick in merged {
+                switch tick {
+                case .event(let identities):
+                    let frame: ByteBuffer
+                    do {
+                        frame = try dataFrame(identities)
+                    } catch {
+                        // A frame that cannot encode is a bug, not a disconnect — surface it, then
+                        // end the stream so the client's reconnect sweep covers the missed nudge.
+                        logger.error("Live invalidation: failed to encode an identity set — ending this client's stream. \(String(reflecting: error))")
+                        break consume
+                    }
+                    try await writer.write(.buffer(frame))
+                case .heartbeat:
+                    try await writer.write(.buffer(ByteBuffer(string: ": keep-alive\n\n")))
+                case .hubEnded:
+                    break consume
+                }
+            }
+            try await writer.write(.end)
+        } catch {
+            // Client disconnected mid-write: end the stream.
+            try? await writer.write(.end)
+        }
+    }
+
+    /// `data: <JSON array of ModelIdentity>\n\n` — the frozen §6 frame.
+    static func dataFrame(_ identities: Set<ModelIdentity>) throws -> ByteBuffer {
+        let json = try JSONEncoder.defaultEncoder.encode(Array(identities))
+        var buffer = ByteBuffer(string: "data: ")
+        buffer.writeBytes(json)
+        buffer.writeString("\n\n")
+        return buffer
+    }
+
+    private enum Tick: Sendable {
+        case event(Set<ModelIdentity>)
+        case heartbeat
+        case hubEnded
+    }
+}

--- a/Sources/FOSMVVMVapor/LiveInvalidation/LiveTransaction.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/LiveTransaction.swift
@@ -1,0 +1,114 @@
+// LiveTransaction.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import FluentKit
+import FOSMVVM
+import Foundation
+import Vapor
+
+public extension Vapor.Request {
+    /// A Fluent transaction whose writes still notify live clients
+    ///
+    /// Inside a bare `database.transaction { }` FOSMVVM cannot know whether your
+    /// writes commit, so it stays silent (and logs a warning). Use
+    /// `liveTransaction` instead and every write inside the closure nudges live
+    /// clients if — and only if — the transaction commits:
+    ///
+    /// ```swift
+    /// try await req.liveTransaction { db in
+    ///     dock.status = .closed
+    ///     try await dock.save(on: db)
+    /// }
+    /// ```
+    func liveTransaction<T: Sendable>(
+        _ closure: @Sendable @escaping (any Database) async throws -> T
+    ) async throws -> T {
+        try await runLiveTransaction(hub: application.invalidationHub, db: db, closure)
+    }
+}
+
+public extension Vapor.Application {
+    /// A Fluent transaction whose writes still notify live clients
+    ///
+    /// Inside a bare `database.transaction { }` FOSMVVM cannot know whether your
+    /// writes commit, so it stays silent (and logs a warning). Use
+    /// `liveTransaction` instead — from background jobs and other
+    /// application-level work — and every write inside the closure nudges live
+    /// clients if — and only if — the transaction commits:
+    ///
+    /// ```swift
+    /// try await app.liveTransaction { db in
+    ///     dock.status = .closed
+    ///     try await dock.save(on: db)
+    /// }
+    /// ```
+    func liveTransaction<T: Sendable>(
+        _ closure: @Sendable @escaping (any Database) async throws -> T
+    ) async throws -> T {
+        try await runLiveTransaction(hub: invalidationHub, db: db, closure)
+    }
+}
+
+/// The wrappers' shared core: run the transaction with the collector installed, flush the
+/// collected union to the hub only after `db.transaction` returns (committed); a throw skips the
+/// flush — discard is automatic. With no hub (live invalidation not enabled) the wrapper IS the
+/// plain transaction.
+private func runLiveTransaction<T: Sendable>(
+    hub: InvalidationHub?,
+    db: any Database,
+    _ closure: @Sendable @escaping (any Database) async throws -> T
+) async throws -> T {
+    guard let hub else {
+        return try await db.transaction(closure)
+    }
+
+    let collector = InvalidationCollector()
+    // Binding site (spec §3.1, pinned): INSIDE the closure handed to db.transaction. FluentKit's
+    // async transaction bridges through an unstructured Task (Database+Concurrency.swift:26,
+    // eventLoop.makeFutureWithTask), so a binding AROUND the transaction call never reaches the
+    // middleware — spike-verified both placements.
+    let result = try await db.transaction { tx in
+        try await LiveTransactionState.$collector.withValue(collector) {
+            try await closure(tx)
+        }
+    }
+    await hub.emit(collector.drain())
+    return result
+}
+
+/// The collect-vs-suppress discriminator (spec §3.1, pinned): `liveTransaction` installs the
+/// collector for its closure's duration; the emit middleware routes on its presence — ambient to
+/// the transaction's task tree, attached to nothing, invisible in any API (the north star's
+/// no-`Database`-attachment rule).
+enum LiveTransactionState {
+    @TaskLocal static var collector: InvalidationCollector?
+}
+
+/// Accumulates the identity sets the emit middleware derives inside one `liveTransaction`.
+/// Drained to the hub on commit; never drained on rollback (the wrapper's throw path skips it).
+actor InvalidationCollector {
+    private var identities: Set<ModelIdentity> = []
+
+    func collect(_ stale: Set<ModelIdentity>) {
+        identities.formUnion(stale)
+    }
+
+    func drain() -> Set<ModelIdentity> {
+        defer { identities = [] }
+        return identities
+    }
+}

--- a/Sources/FOSMacros/ViewModelMacro.swift
+++ b/Sources/FOSMacros/ViewModelMacro.swift
@@ -17,6 +17,7 @@
 #if os(macOS) || os(Linux) || os(Windows)
 public import SwiftSyntax
 public import SwiftSyntaxMacros
+import SwiftDiagnostics
 import SwiftSyntaxBuilder
 
 public enum ViewModelMacroError: Error, CustomDebugStringConvertible {
@@ -28,6 +29,21 @@ public enum ViewModelMacroError: Error, CustomDebugStringConvertible {
             "ViewModelMacroError: @ViewModel can only be applied to structs"
         }
     }
+}
+
+// The customer-facing message for the `.live` + `.clientHostedFactory` conflict (spec §3.4 v1
+// constraint): a client-hosted ViewModel is composed on the client, so there is no server response
+// header from which to derive its live-invalidation registrations.
+private struct ViewModelMacroDiagnostic: DiagnosticMessage {
+    let message: String
+    let diagnosticID: MessageID
+    let severity: DiagnosticSeverity
+
+    static let liveClientHostedConflict = ViewModelMacroDiagnostic(
+        message: "'.live' cannot be combined with '.clientHostedFactory': a client-hosted ViewModel is built on the client and has no server response to derive live registrations from",
+        diagnosticID: MessageID(domain: "FOSMacros", id: "liveClientHostedConflict"),
+        severity: .error
+    )
 }
 
 // Example:
@@ -48,6 +64,9 @@ public enum ViewModelMacroError: Error, CustomDebugStringConvertible {
 private enum ViewModelOptions: String {
     /// Generate ``ClientHostedViewModelFactory`` support
     case clientHostedFactory
+
+    /// Emit the ``LiveViewModel`` marker conformance
+    case live
 }
 
 public struct ViewModelMacro: ExtensionMacro, MemberMacro {
@@ -83,6 +102,17 @@ public struct ViewModelMacro: ExtensionMacro, MemberMacro {
         }
 
         let options = node.vmOptions
+
+        // v1 constraint (spec §3.4): `.live` derives its registration set from the server response,
+        // which a client-hosted ViewModel never has. Reject the combination up front.
+        if options.contains(.live), options.contains(.clientHostedFactory) {
+            context.diagnose(Diagnostic(
+                node: node,
+                message: ViewModelMacroDiagnostic.liveClientHostedConflict
+            ))
+            return []
+        }
+
         var result = [ExtensionDeclSyntax]()
 
         // Skip extension generation if ViewModel is explicitly declared
@@ -132,6 +162,20 @@ public struct ViewModelMacro: ExtensionMacro, MemberMacro {
             }
         }
 
+        // `.live` synthesizes the ``LiveViewModel`` marker and nothing else (spec §3.4). It refines
+        // `RequestableViewModel`, so declaring `: LiveViewModel` carries that conformance — no
+        // separate `RequestableViewModel` extension is needed here.
+        if options.contains(.live), !structDecl.conformsTo("LiveViewModel") {
+            let extensionDecl = try ExtensionDeclSyntax(
+                """
+                extension \(type): LiveViewModel {
+                }
+                """
+            )
+
+            result.append(extensionDecl)
+        }
+
         return result
     }
 
@@ -151,6 +195,13 @@ public struct ViewModelMacro: ExtensionMacro, MemberMacro {
         }
 
         let options = node.vmOptions
+
+        // The conflict is diagnosed once in the extension role; here we only decline to emit members
+        // so the invalid combination produces no half-formed expansion.
+        if options.contains(.live), options.contains(.clientHostedFactory) {
+            return []
+        }
+
         let viewModelName = structDecl.name.text
 
         // Collect properties with _LocalizedProperty wrapper

--- a/Sources/FOSTestingVapor/ServedFluentTestHarness.swift
+++ b/Sources/FOSTestingVapor/ServedFluentTestHarness.swift
@@ -1,0 +1,106 @@
+// ServedFluentTestHarness.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FOSMVVMVapor)
+import Fluent
+import FluentKit
+import FluentSQLiteDriver
+import Foundation
+import Vapor
+
+/// Runs `body` against a booted Vapor application that is **listening on a real localhost port**,
+/// backed by a fresh in-memory SQLite database.
+///
+/// Reach for this when a test must exercise a genuine HTTP connection — a streaming response, an
+/// SSE feed — that `app.test(...)` cannot hold open. Configure the application in `configure`, then
+/// use the application and the base `URL` handed to `body` to open a live socket to it:
+///
+/// ```swift
+/// try await withServedFluentTestApp { app in
+///     try app.register(Dock.self, migration: CreateDock())
+///     try app.useLiveInvalidation(on: app.routes)
+/// } _: { app, baseURL in
+///     let url = baseURL.appending(path: "invalidations")
+///     let (bytes, _) = try await URLSession(configuration: .ephemeral).bytes(from: url)
+///     for try await line in bytes.lines where line.hasPrefix("data:") {
+///         // decode the pushed identity set …
+///         break
+///     }
+/// }
+/// ```
+///
+/// The harness binds the HTTP server to `127.0.0.1` on an ephemeral port (`port 0`) and hands
+/// `body` `http://127.0.0.1:<bound-port>`. Each call owns a private database, a bound port, and a
+/// full application lifecycle — server and application are always shut down — so tests stay isolated
+/// and run safely in parallel.
+public func withServedFluentTestApp<R: Sendable>(
+    configure: @Sendable (Application) async throws -> Void,
+    _ body: @Sendable (Application, URL) async throws -> R
+) async throws -> R {
+    let app = try await Application.make(.testing)
+    // Teardown discipline: the server is shut down only after a successful start, and each
+    // shutdown runs at most once — a happy-path asyncShutdown() throw must not be retried by
+    // the catch (Vapor asserts on double shutdown).
+    var serverStarted = false
+    var appShutDown = false
+    do {
+        app.databases.use(.sqlite(.memory), as: .sqlite)
+        try await configure(app)
+        try await app.autoMigrate()
+
+        app.http.server.configuration.hostname = "127.0.0.1"
+        app.http.server.configuration.port = 0
+
+        // asyncBoot (not startup()): async lifecycle handlers only run under async boot, and
+        // startup()'s console parser chokes on test-runner arguments (see FluentTestHarness).
+        try await app.asyncBoot()
+        try await app.server.start()
+        serverStarted = true
+
+        guard let port = app.http.server.shared.localAddress?.port,
+              let baseURL = URL(string: "http://127.0.0.1:\(port)") else {
+            throw ServedFluentTestHarnessError.noBoundPort
+        }
+
+        let result = try await body(app, baseURL)
+
+        await app.server.shutdown()
+        serverStarted = false
+        appShutDown = true
+        try await app.asyncShutdown()
+        return result
+    } catch {
+        if serverStarted {
+            await app.server.shutdown()
+        }
+        if !appShutDown {
+            try? await app.asyncShutdown()
+        }
+        throw error
+    }
+}
+
+enum ServedFluentTestHarnessError: Error, CustomDebugStringConvertible {
+    case noBoundPort
+
+    var debugDescription: String {
+        switch self {
+        case .noBoundPort:
+            "withServedFluentTestApp: the HTTP server started but reported no bound local port."
+        }
+    }
+}
+#endif

--- a/Tests/FOSFoundationTests/Networking/FoundationDataFetchTests.swift
+++ b/Tests/FOSFoundationTests/Networking/FoundationDataFetchTests.swift
@@ -135,6 +135,58 @@ struct FoundationDataFetchTests {
         }
     }
 
+    // MARK: Response-header capture (the live-invalidation `package` seam)
+
+    @Test func sendCapturesNamedResponseHeader() async throws {
+        let model = TestModel.stub()
+        let response = HTTPURLResponse(
+            url: dummyURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: [
+                "Content-Type": "application/json;charset=utf-8",
+                "X-FOS-Registrations": #"["opaque"]"#
+            ]
+        )
+        let session = try MockURLSession(data: model.toJSONData(), error: nil, response: response)
+        let dataFetch = DataFetch(urlSession: session)
+
+        let (value, header): (TestModel, String?) = try await dataFetch.send(
+            data: nil,
+            to: dummyURL,
+            httpMethod: "GET",
+            headers: nil,
+            locale: nil,
+            errorType: TestError.self,
+            capturingResponseHeader: "X-FOS-Registrations"
+        )
+        #expect(value == model)
+        #expect(header == #"["opaque"]"#)
+    }
+
+    @Test func sendReturnsNilWhenHeaderAbsent() async throws {
+        let model = TestModel.stub()
+        let response = HTTPURLResponse(
+            url: dummyURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json;charset=utf-8"]
+        )
+        let session = try MockURLSession(data: model.toJSONData(), error: nil, response: response)
+        let dataFetch = DataFetch(urlSession: session)
+
+        let (_, header): (TestModel, String?) = try await dataFetch.send(
+            data: nil,
+            to: dummyURL,
+            httpMethod: "GET",
+            headers: nil,
+            locale: nil,
+            errorType: TestError.self,
+            capturingResponseHeader: "X-FOS-Registrations"
+        )
+        #expect(header == nil)
+    }
+
     private let dummyURL = URL(string: "https://my.domain")!
 }
 

--- a/Tests/FOSMVVMTests/Protocols/InvalidationChannelTests.swift
+++ b/Tests/FOSMVVMTests/Protocols/InvalidationChannelTests.swift
@@ -1,0 +1,115 @@
+// InvalidationChannelTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+import Testing
+
+@Suite("InvalidationChannel")
+struct InvalidationChannelTests {
+    @Test("A channel yields .connected then .invalidated through events()")
+    func channelYieldsEvents() async {
+        let channel = TestInvalidationChannel()
+
+        var received: [InvalidationEvent] = []
+        for await event in channel.events() {
+            received.append(event)
+        }
+
+        #expect(received.count == 2)
+
+        guard case .connected = received.first else {
+            Issue.record("Expected the first event to be .connected")
+            return
+        }
+
+        guard case .invalidated(let identities) = received.last else {
+            Issue.record("Expected the second event to be .invalidated")
+            return
+        }
+        #expect(identities.isEmpty)
+    }
+
+    @Test("URLPackage.invalidationBaseURL defaults to serverBaseURL")
+    func invalidationBaseURLDefaultsToServer() throws {
+        let server = try #require(URL(string: "https://api.example.com"))
+
+        let package = MVVMEnvironment.URLPackage(serverBaseURL: server)
+
+        #expect(package.invalidationBaseURL == server)
+    }
+
+    @Test("URLPackage.invalidationBaseURL honors an explicit override")
+    func invalidationBaseURLHonorsOverride() throws {
+        let server = try #require(URL(string: "https://api.example.com"))
+        let invalidation = try #require(URL(string: "wss://live.example.com"))
+
+        let package = MVVMEnvironment.URLPackage(
+            serverBaseURL: server,
+            invalidationBaseURL: invalidation
+        )
+
+        #expect(package.invalidationBaseURL == invalidation)
+    }
+
+    @Test("MVVMEnvironment stores the supplied invalidation channel")
+    func environmentStoresChannel() async throws {
+        let url = try #require(URL(string: "http://localhost:8080"))
+
+        let environment = MVVMEnvironment(
+            appBundle: .module,
+            invalidationChannel: TestInvalidationChannel(),
+            deploymentURLs: [.debug: url],
+            session: nil,
+            requestErrorHandler: nil
+        )
+
+        let stored = try #require(environment.invalidationChannel as? TestInvalidationChannel)
+
+        var sawConnected = false
+        for await event in stored.events() {
+            if case .connected = event { sawConnected = true }
+        }
+        #expect(sawConnected)
+    }
+
+    @Test("MVVMEnvironment leaves the invalidation channel nil by default")
+    func environmentChannelNilByDefault() throws {
+        let url = try #require(URL(string: "http://localhost:8080"))
+
+        let environment = MVVMEnvironment(
+            appBundle: .module,
+            deploymentURLs: [.debug: url],
+            session: nil,
+            requestErrorHandler: nil
+        )
+
+        #expect(environment.invalidationChannel == nil)
+    }
+}
+
+/// A channel that replays a fixed script — models a transport that reconnects and then
+/// reports one (empty) invalidation before closing.
+private struct TestInvalidationChannel: InvalidationChannel {
+    func events() -> AsyncStream<InvalidationEvent> {
+        AsyncStream { continuation in
+            continuation.yield(.connected)
+            continuation.yield(.invalidated([]))
+            continuation.finish()
+        }
+    }
+}

--- a/Tests/FOSMVVMTests/Protocols/LiveRegistrationsDecodeTests.swift
+++ b/Tests/FOSMVVMTests/Protocols/LiveRegistrationsDecodeTests.swift
@@ -1,0 +1,56 @@
+// LiveRegistrationsDecodeTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+@testable import FOSMVVM
+import Foundation
+import Testing
+
+private enum AlphaModel {}
+private enum BetaModel {}
+
+@Suite("LiveRegistrations header decode")
+struct LiveRegistrationsDecodeTests {
+    @Test("An absent header decodes to the empty set")
+    func absentHeaderIsEmpty() {
+        #expect(LiveRegistrations.decode(nil).isEmpty)
+    }
+
+    @Test("An empty header value decodes to the empty set")
+    func emptyHeaderIsEmpty() {
+        #expect(LiveRegistrations.decode("").isEmpty)
+    }
+
+    @Test("A valid header round-trips to exactly the encoded identity set")
+    func validHeaderRoundTrips() throws {
+        let identities = [
+            ModelIdentity(namespace: ModelNamespace(for: AlphaModel.self), id: UUID()),
+            ModelIdentity(namespace: ModelNamespace(for: BetaModel.self), id: UUID())
+        ]
+        // The server frames this header exactly this way (Response+FOS.swift): the JSON array of
+        // the identity set via the frozen `ModelIdentity` encoding.
+        let headerValue = try identities.toJSON()
+
+        let decoded = LiveRegistrations.decode(headerValue)
+        #expect(Set(decoded) == Set(identities))
+    }
+
+    @Test("A malformed header value decodes to empty — a broken header never fails the fetch")
+    func malformedHeaderIsEmpty() {
+        #expect(LiveRegistrations.decode("not json at all").isEmpty)
+        #expect(LiveRegistrations.decode("{\"unexpected\":true}").isEmpty)
+    }
+}

--- a/Tests/FOSMVVMTests/SwiftUI Support/FreshnessGateTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/FreshnessGateTests.swift
@@ -1,0 +1,73 @@
+// FreshnessGateTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+@testable import FOSMVVM
+import Foundation
+import Testing
+
+// ── Honest gap (needs a hosted SwiftUI test) ──────────────────────────────────────────────────────
+// The gate DECISION (older-drops / newer-swaps / equal-drops) is pinned headless below. The gate's
+// one deliberate BYPASS is not reachable here: a navigation whose URL differs only by query/fragment
+// takes the full-reload path rather than the in-place gated swap ("query/fragment change bypasses the
+// gate" — spec §8 group 8). That routing is structural in private view methods — `loadAndBind` vs
+// `refreshInPlace` (`ViewModelView.swift`) — which only run when SwiftUI drives the view, so a
+// headless unit test cannot reach it. A hosted UI test (FOSTestingUI's `ViewModelDisplayTestCase` →
+// `XCUIApplication`, which needs a host app target FOSUtilities itself does not ship — so this lives
+// in a consumer app's UI-test target) must cover: a same-path/different-query navigation reloads
+// (bypasses the gate) while a same-URL push swaps through it. The gate decision itself is pinned here.
+
+@Suite("FreshnessGate")
+struct FreshnessGateTests {
+    // Freshness comes only from construction-order `ViewModelId()` (public path); never forged —
+    // `Freshness.init` is internal. Two `.now` reads are distinct; the sleep removes any doubt.
+
+    @Test("A newer arrival replaces the current ViewModel")
+    func newerSwaps() async throws {
+        let older = TestViewModel()
+        try await Task.sleep(nanoseconds: 2000000)
+        let newer = TestViewModel()
+
+        #expect(FreshnessGate.shouldReplace(current: older, with: newer))
+    }
+
+    @Test("An older arrival is dropped")
+    func olderDrops() async throws {
+        let older = TestViewModel()
+        try await Task.sleep(nanoseconds: 2000000)
+        let newer = TestViewModel()
+
+        #expect(!FreshnessGate.shouldReplace(current: newer, with: older))
+    }
+
+    @Test("A nil current always accepts the arrival")
+    func nilCurrentAccepts() {
+        let incoming = TestViewModel()
+
+        #expect(FreshnessGate.shouldReplace(current: nil, with: incoming))
+    }
+
+    @Test("An equal-freshness self-nudge is dropped")
+    func equalFreshnessDrops() {
+        // The redundant nudge a client's own write races back to it: same vmId (same birth moment)
+        // ⇒ not strictly fresher ⇒ drop.
+        let current = TestViewModel()
+        var echo = TestViewModel()
+        echo.vmId = current.vmId
+
+        #expect(!FreshnessGate.shouldReplace(current: current, with: echo))
+    }
+}

--- a/Tests/FOSMVVMTests/SwiftUI Support/InvalidationDispatcherTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/InvalidationDispatcherTests.swift
@@ -1,0 +1,326 @@
+// InvalidationDispatcherTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+@testable import FOSMVVM
+import Foundation
+import Testing
+
+// Marker types anchoring test namespaces — distinct kinds of model.
+private enum AlphaModel {}
+private enum BetaModel {}
+
+@MainActor
+@Suite("InvalidationDispatcher")
+struct InvalidationDispatcherTests {
+    @Test("An exact-tier nudge fires the matching registration and only it")
+    func exactMatchFiresOnlyTheMatch() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let a = Self.identity(AlphaModel.self)
+        let c = Self.identity(AlphaModel.self)
+
+        let hitA = Counter()
+        let hitC = Counter()
+        let tokenA = dispatcher.register(identities: [a], namespaces: []) { hitA.count += 1 }
+        let tokenC = dispatcher.register(identities: [c], namespaces: []) { hitC.count += 1 }
+
+        channel.send(.invalidated([a]))
+        await waitUntil { hitA.count == 1 }
+
+        #expect(hitA.count == 1)
+        #expect(hitC.count == 0)
+
+        withExtendedLifetime(tokenA) {}
+        withExtendedLifetime(tokenC) {}
+    }
+
+    @Test("A namespace-tier registration fires for any identity in that namespace")
+    func namespaceMatchFiresForAnyIdentityInNamespace() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let namespace = ModelNamespace(for: AlphaModel.self)
+        let hit = Counter()
+        let token = dispatcher.register(identities: [], namespaces: [namespace]) { hit.count += 1 }
+
+        // An identity the registration never named exactly, but sharing its namespace.
+        channel.send(.invalidated([Self.identity(AlphaModel.self)]))
+        await waitUntil { hit.count == 1 }
+        #expect(hit.count == 1)
+
+        // A different namespace does not fire it.
+        channel.send(.invalidated([Self.identity(BetaModel.self)]))
+        await pump()
+        #expect(hit.count == 1)
+
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Several identities in one event matching one registration fire it once")
+    func oneEventManyIdentitiesFiresOnce() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let a = Self.identity(AlphaModel.self)
+        let b = Self.identity(AlphaModel.self)
+        let hit = Counter()
+        let token = dispatcher.register(identities: [a, b], namespaces: []) { hit.count += 1 }
+
+        channel.send(.invalidated([a, b]))
+        await waitUntil { hit.count >= 1 }
+        await pump()
+        #expect(hit.count == 1)
+
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("A released token unregisters — its registration no longer fires")
+    func releasedTokenUnregisters() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let a = Self.identity(AlphaModel.self)
+        let hit = Counter()
+        var token: InvalidationDispatcher.Token? =
+            dispatcher.register(identities: [a], namespaces: []) { hit.count += 1 }
+        weak var weakToken = token
+
+        // Sanity: alive and firing.
+        channel.send(.invalidated([a]))
+        await waitUntil { hit.count == 1 }
+
+        token = nil // the registrant releases — the only strong reference is gone
+        #expect(weakToken == nil, "the dispatcher must hold the token weakly")
+
+        channel.send(.invalidated([a]))
+        await pump()
+        #expect(hit.count == 1, "a dead registration must not fire")
+    }
+
+    @Test("Re-registration replaces the identity set — old identities stop firing")
+    func reregistrationReplacesTheSet() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let old = Self.identity(AlphaModel.self)
+        let new = Self.identity(BetaModel.self)
+        let hit = Counter()
+        let token = dispatcher.register(identities: [old], namespaces: []) { hit.count += 1 }
+
+        dispatcher.reregister(token, identities: [new], namespaces: [])
+
+        channel.send(.invalidated([old]))
+        await pump()
+        #expect(hit.count == 0, "the replaced identity must no longer fire")
+
+        channel.send(.invalidated([new]))
+        await waitUntil { hit.count == 1 }
+        #expect(hit.count == 1)
+
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("A .connected event sweeps every registration once")
+    func connectedSweepsAll() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let hit1 = Counter()
+        let hit2 = Counter()
+        let hit3 = Counter()
+        let t1 = dispatcher.register(identities: [Self.identity(AlphaModel.self)], namespaces: []) { hit1.count += 1 }
+        let t2 = dispatcher.register(identities: [Self.identity(BetaModel.self)], namespaces: []) { hit2.count += 1 }
+        let t3 = dispatcher.register(identities: [], namespaces: [ModelNamespace(for: AlphaModel.self)]) { hit3.count += 1 }
+
+        channel.send(.connected)
+        await waitUntil { hit1.count == 1 && hit2.count == 1 && hit3.count == 1 }
+        await pump()
+
+        #expect(hit1.count == 1)
+        #expect(hit2.count == 1)
+        #expect(hit3.count == 1)
+
+        withExtendedLifetime(t1) {}
+        withExtendedLifetime(t2) {}
+        withExtendedLifetime(t3) {}
+    }
+
+    @Test("The channel opens on the first registration only")
+    func channelOpensOnFirstRegistrationOnly() {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        #expect(channel.eventsCallCount == 0, "no registration ⇒ no socket")
+
+        let t1 = dispatcher.register(identities: [Self.identity(AlphaModel.self)], namespaces: []) {}
+        #expect(channel.eventsCallCount == 1, "the first registration opens the channel")
+
+        let t2 = dispatcher.register(identities: [Self.identity(BetaModel.self)], namespaces: []) {}
+        #expect(channel.eventsCallCount == 1, "a later registration must not reopen the channel")
+
+        withExtendedLifetime(t1) {}
+        withExtendedLifetime(t2) {}
+    }
+
+    @Test("Explicit unregister stops the registration firing while the token stays alive")
+    func explicitUnregisterStopsFiring() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let a = Self.identity(AlphaModel.self)
+        let hit = Counter()
+        let token = dispatcher.register(identities: [a], namespaces: []) { hit.count += 1 }
+
+        channel.send(.invalidated([a]))
+        await waitUntil { hit.count == 1 }
+
+        dispatcher.unregister(token)
+
+        channel.send(.invalidated([a]))
+        await pump()
+        #expect(hit.count == 1, "an explicitly unregistered token must not fire")
+
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("A trigger may register and unregister during a fire (reentrancy snapshot safety)")
+    func triggerMayMutateRegistrationsDuringFire() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let a = Self.identity(AlphaModel.self)
+        let b = Self.identity(BetaModel.self)
+        let selfHit = Counter()
+        let lateHit = Counter()
+
+        // Deterministic reentrancy: the trigger unregisters ITSELF and registers a new
+        // registration mid-fire — pins that fire iterates a snapshot and survives mutation.
+        let holder = TokenHolder()
+        holder.token = dispatcher.register(identities: [a], namespaces: []) {
+            selfHit.count += 1
+            if let token = holder.token {
+                dispatcher.unregister(token)
+            }
+            holder.lateToken = dispatcher.register(identities: [b], namespaces: []) {
+                lateHit.count += 1
+            }
+        }
+
+        channel.send(.invalidated([a]))
+        await waitUntil { selfHit.count == 1 }
+        #expect(lateHit.count == 0, "a registration added mid-fire must not fire for that event")
+
+        channel.send(.invalidated([a]))
+        await pump()
+        #expect(selfHit.count == 1, "the self-unregistered trigger must not fire again")
+
+        channel.send(.invalidated([b]))
+        await waitUntil { lateHit.count == 1 }
+        #expect(lateHit.count == 1, "the mid-fire registration must fire for later events")
+    }
+
+    @Test("A .connected sweep over a dead token prunes it and fires only the living")
+    func connectedSweepPrunesDeadToken() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let liveHit = Counter()
+        let deadHit = Counter()
+        let liveToken = dispatcher.register(identities: [Self.identity(AlphaModel.self)], namespaces: []) {
+            liveHit.count += 1
+        }
+        var deadToken: InvalidationDispatcher.Token? =
+            dispatcher.register(identities: [Self.identity(BetaModel.self)], namespaces: []) {
+                deadHit.count += 1
+            }
+        deadToken = nil // dead but never nudged — only the sweep's fire→remove prune touches it
+        _ = deadToken
+
+        channel.send(.connected)
+        await waitUntil { liveHit.count == 1 }
+        await pump()
+
+        #expect(liveHit.count == 1)
+        #expect(deadHit.count == 0, "a dead token must be pruned by the sweep, not fired")
+
+        withExtendedLifetime(liveToken) {}
+    }
+}
+
+/// Lets a trigger closure reach its own token without capturing it before `register` returns.
+@MainActor
+private final class TokenHolder {
+    var token: InvalidationDispatcher.Token?
+    var lateToken: InvalidationDispatcher.Token?
+}
+
+private extension InvalidationDispatcherTests {
+    static func identity(_ type: Any.Type) -> ModelIdentity {
+        .init(namespace: ModelNamespace(for: type), id: UUID())
+    }
+
+    func pump(_ times: Int = 20) async {
+        for _ in 0..<times {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 500000)
+        }
+    }
+
+    func waitUntil(_ predicate: @MainActor () -> Bool) async {
+        for _ in 0..<200 {
+            if predicate() { return }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 500000)
+        }
+    }
+}
+
+/// A MainActor-confined tally the fired triggers increment — no cross-actor sharing.
+@MainActor
+private final class Counter {
+    var count = 0
+}
+
+/// A channel whose events are pushed by the test and that records when `events()` is first
+/// consumed — the "opens on first registration" probe (the Task 1 channel idiom, made drivable).
+private final class ScriptedChannel: InvalidationChannel, @unchecked Sendable {
+    private let stream: AsyncStream<InvalidationEvent>
+    private let continuation: AsyncStream<InvalidationEvent>.Continuation
+    private let lock = NSLock()
+    private var _eventsCallCount = 0
+
+    var eventsCallCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _eventsCallCount
+    }
+
+    init() {
+        var captured: AsyncStream<InvalidationEvent>.Continuation!
+        self.stream = AsyncStream { captured = $0 }
+        self.continuation = captured
+    }
+
+    func events() -> AsyncStream<InvalidationEvent> {
+        lock.lock(); _eventsCallCount += 1; lock.unlock()
+        return stream
+    }
+
+    func send(_ event: InvalidationEvent) {
+        continuation.yield(event)
+    }
+}

--- a/Tests/FOSMVVMTests/SwiftUI Support/InvalidationSeamTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/InvalidationSeamTests.swift
@@ -1,0 +1,130 @@
+// InvalidationSeamTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// First-ever tests for the pre-existing client invalidation seams (spec test group 10): the
+// `viewModelInvalidated` teardown binding behind `invalidateBinding(_:)` (`View.swift:84`) and the
+// `viewModelRefreshed` in-place-swap binding behind `refreshedViewModel(_:)` (`View.swift:90`, now
+// gated through `swapThroughFreshnessGate`, Task 7). Both seams live as SwiftUI `@Entry` environment
+// values consumed inside `VMServerResolverView`'s `body` (`ViewModelView.swift:403-445`).
+//
+// ── What these tests reach ──────────────────────────────────────────────────────────────────────
+// The seams' EXTRACTABLE contract is their environment layer: the `@Entry` defaults (what a screen
+// sees when the modifier is absent) and that the entry carries a caller-supplied binding intact.
+// Those defaults are load-bearing — the `false` default is precisely why a screen with no
+// `.invalidateBinding` is never torn down, and the `""` default is why no phantom refresh fires.
+// Reached headless below via a bare `EnvironmentValues()`.
+//
+// ── Honest gap (needs a hosted SwiftUI test) ────────────────────────────────────────────────────
+// The seams' REACTIONS are `.onChange` handlers inside `VMServerResolverView.body`; they only run
+// when SwiftUI drives the view, so they are out of reach of a headless unit test. Not faked here.
+// A hosted UI test (FOSTestingUI's `ViewModelDisplayTestCase` → `XCUIApplication`, which needs a
+// host app target FOSUtilities itself does not ship — so this lives in a consumer app's UI-test
+// target) must cover:
+//   1. `invalidateBinding($flag)` → set `flag = true` → the resolver nils its ViewModel, shows the
+//      `ProgressView`, and re-fetches (`ViewModelView.swift:429-434` + the `.task` reload).
+//   2. `refreshedViewModel($vm)` → push a strictly-fresher VM → the resolver decodes it and swaps
+//      in place THROUGH the freshness gate (`ViewModelView.swift:435-445`); push a stale-freshness
+//      VM → the gate drops it, the visible VM is unchanged.
+//   3. The `refreshedViewModel(_:)` modifier's own `Binding<String>` get/set closures
+//      (`View.swift:91-100`): the get encodes the bound VM to JSON, the set decodes and reassigns —
+//      these fire only under SwiftUI's binding machinery.
+// The gate DECISION itself (older-drops / newer-swaps / equal-drops) is already pinned headless in
+// `FreshnessGateTests`; the gap above is the WIRING from these bindings into that gate.
+
+#if canImport(SwiftUI)
+@testable import FOSMVVM
+import Foundation
+import SwiftUI
+import Testing
+
+@MainActor
+@Suite("Invalidation seams (spec test group 10)")
+struct InvalidationSeamTests {
+    // MARK: viewModelInvalidated (invalidateBinding teardown seam)
+
+    @Test("Absent `.invalidateBinding`, the teardown flag defaults to false — no screen is torn down")
+    func invalidatedDefaultsFalse() {
+        let env = EnvironmentValues()
+
+        #expect(env.viewModelInvalidated.wrappedValue == false)
+    }
+
+    @Test("The default teardown binding ignores writes — its setter is a no-op")
+    func invalidatedDefaultSetterIsNoOp() {
+        let env = EnvironmentValues()
+
+        // The default entry's setter discards writes (View.swift:105-108); a stray write must not
+        // latch a phantom teardown into a screen that never applied `.invalidateBinding`.
+        env.viewModelInvalidated.wrappedValue = true
+
+        #expect(env.viewModelInvalidated.wrappedValue == false)
+    }
+
+    @Test("`invalidateBinding` plumbing: the entry carries a caller-supplied binding intact")
+    func invalidatedEntryCarriesCallerBinding() {
+        // Mirrors what `invalidateBinding($flag)` writes into the environment: the entry must return
+        // exactly the caller's binding, both value and writes, so the resolver's `.onChange` sees the
+        // app's teardown request.
+        final class Box { var flag = false }
+        let box = Box()
+        var env = EnvironmentValues()
+        env.viewModelInvalidated = Binding(get: { box.flag }, set: { box.flag = $0 })
+
+        #expect(env.viewModelInvalidated.wrappedValue == false)
+
+        env.viewModelInvalidated.wrappedValue = true
+        #expect(box.flag == true)
+        #expect(env.viewModelInvalidated.wrappedValue == true)
+    }
+
+    // MARK: viewModelRefreshed (refreshedViewModel in-place-swap seam)
+
+    @Test("Absent `.refreshedViewModel`, the refresh binding defaults to empty — no phantom swap")
+    func refreshedDefaultsEmpty() {
+        let env = EnvironmentValues()
+
+        #expect(env.viewModelRefreshed.wrappedValue == "")
+    }
+
+    @Test("The default refresh binding ignores writes — its setter is a no-op")
+    func refreshedDefaultSetterIsNoOp() {
+        let env = EnvironmentValues()
+
+        // The default entry's setter discards writes (View.swift:110-113); the resolver's
+        // `.onChange` must never observe a refresh a caller never pushed.
+        env.viewModelRefreshed.wrappedValue = "phantom"
+
+        #expect(env.viewModelRefreshed.wrappedValue == "")
+    }
+
+    @Test("`refreshedViewModel` plumbing: the entry carries a pushed payload intact")
+    func refreshedEntryCarriesPushedPayload() {
+        // The seam transports a VM as JSON — the entry is `Binding<String>`: `refreshedViewModel`
+        // encodes on the way in, the resolver's `.onChange` decodes on the way out. The reachable
+        // contract here is transport: the entry must return exactly the payload a caller pushed. The
+        // decode-and-gate that consumes it runs only under SwiftUI (the hosted gap above).
+        final class Box { var payload = "" }
+        let box = Box()
+        var env = EnvironmentValues()
+        env.viewModelRefreshed = Binding(get: { box.payload }, set: { box.payload = $0 })
+
+        let pushed = #"{"vmId":"sentinel"}"#
+        env.viewModelRefreshed.wrappedValue = pushed
+        #expect(box.payload == pushed)
+        #expect(env.viewModelRefreshed.wrappedValue == pushed)
+    }
+}
+#endif

--- a/Tests/FOSMVVMTests/SwiftUI Support/LiveRegistrationCoordinatorTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/LiveRegistrationCoordinatorTests.swift
@@ -1,0 +1,176 @@
+// LiveRegistrationCoordinatorTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(SwiftUI)
+import FOSFoundation
+@testable import FOSMVVM
+import Foundation
+import Testing
+
+// Marker types anchoring distinct test namespaces.
+private enum AlphaModel {}
+private enum BetaModel {}
+
+@MainActor
+@Suite("LiveRegistrationCoordinator")
+struct LiveRegistrationCoordinatorTests {
+    @Test("A response's set registers exactly, and only a matching nudge advances the refresh signal")
+    func registersExactSetAndFiresOnMatch() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+        let coordinator = LiveRegistrationCoordinator()
+
+        let a = Self.identity(AlphaModel.self)
+        coordinator.update(registrations: [a], dispatcher: dispatcher)
+        #expect(coordinator.isRegistered)
+
+        channel.send(.invalidated([a]))
+        await waitUntil { coordinator.refreshSignal == 1 }
+        #expect(coordinator.refreshSignal == 1)
+
+        // An identity the coordinator never registered must not advance the signal.
+        channel.send(.invalidated([Self.identity(BetaModel.self)]))
+        await pump()
+        #expect(coordinator.refreshSignal == 1)
+    }
+
+    @Test("A second response re-registers — the prior identity stops firing, the new one fires")
+    func secondUpdateReRegisters() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+        let coordinator = LiveRegistrationCoordinator()
+
+        let old = Self.identity(AlphaModel.self)
+        let new = Self.identity(BetaModel.self)
+
+        coordinator.update(registrations: [old], dispatcher: dispatcher)
+        coordinator.update(registrations: [new], dispatcher: dispatcher)
+
+        channel.send(.invalidated([old]))
+        await pump()
+        #expect(coordinator.refreshSignal == 0, "the replaced identity must no longer fire")
+
+        channel.send(.invalidated([new]))
+        await waitUntil { coordinator.refreshSignal == 1 }
+        #expect(coordinator.refreshSignal == 1)
+    }
+
+    @Test("Releasing the coordinator frees the token — no retain cycle, and the dead registration is inert")
+    func releaseFreesTokenNoCycle() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+
+        let a = Self.identity(AlphaModel.self)
+        var coordinator: LiveRegistrationCoordinator? = .init()
+        weak var weakCoordinator = coordinator
+        coordinator?.update(registrations: [a], dispatcher: dispatcher)
+
+        // Sanity: alive and firing.
+        channel.send(.invalidated([a]))
+        await waitUntil { coordinator?.refreshSignal == 1 }
+
+        coordinator = nil
+        #expect(
+            weakCoordinator == nil,
+            "the token's trigger must capture the coordinator weakly — a strong capture would leak it"
+        )
+
+        // The now-dead registration must be a harmless no-op (the dispatcher pruned its weak token).
+        channel.send(.invalidated([a]))
+        await pump()
+    }
+
+    @Test("With no channel configured the dispatcher is inert — registration is safe and never fires")
+    func degradesInertWithoutChannel() async {
+        let dispatcher = InvalidationDispatcher(channel: nil)
+        let coordinator = LiveRegistrationCoordinator()
+
+        coordinator.update(registrations: [Self.identity(AlphaModel.self)], dispatcher: dispatcher)
+
+        #expect(coordinator.isRegistered, "registration must succeed even with no channel")
+        await pump()
+        #expect(coordinator.refreshSignal == 0, "an inert dispatcher never delivers events")
+    }
+
+    // Pins the resolver's failed-refresh guard (`refreshInPlace`/`loadAndBind`,
+    // ViewModelView.swift): the guard itself lives in the SwiftUI view — unreachable headless —
+    // so its load-bearing contract is asserted here at the coordinator+dispatcher seam it protects.
+    @Test("A failed refresh skips update — the prior set keeps firing; a successful empty response replaces it")
+    func failedRefreshPreservesPriorSet() async {
+        let channel = ScriptedChannel()
+        let dispatcher = InvalidationDispatcher(channel: channel)
+        let coordinator = LiveRegistrationCoordinator()
+
+        let a = Self.identity(AlphaModel.self)
+        coordinator.update(registrations: [a], dispatcher: dispatcher)
+
+        // A transient fetch failure returns (nil, []) and the resolver's guard makes NO update
+        // call — the original identity must still fire.
+        channel.send(.invalidated([a]))
+        await waitUntil { coordinator.refreshSignal == 1 }
+        #expect(coordinator.refreshSignal == 1, "the prior registration must survive a failed refresh")
+
+        // The regression the guard prevents: reregistering to the error path's empty set would
+        // deafen the screen. Only a genuinely-empty SUCCESSFUL response reregisters to empty —
+        // and then, correctly, the old identity stops firing.
+        coordinator.update(registrations: [], dispatcher: dispatcher)
+        channel.send(.invalidated([a]))
+        await pump()
+        #expect(coordinator.refreshSignal == 1, "an empty successful response replaces the set")
+    }
+}
+
+private extension LiveRegistrationCoordinatorTests {
+    static func identity(_ type: Any.Type) -> ModelIdentity {
+        .init(namespace: ModelNamespace(for: type), id: UUID())
+    }
+
+    func pump(_ times: Int = 20) async {
+        for _ in 0..<times {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 500000)
+        }
+    }
+
+    func waitUntil(_ predicate: @MainActor () -> Bool) async {
+        for _ in 0..<200 {
+            if predicate() { return }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 500000)
+        }
+    }
+}
+
+/// A channel whose events are pushed by the test (the dispatcher-test idiom, reused here).
+private final class ScriptedChannel: InvalidationChannel, @unchecked Sendable {
+    private let stream: AsyncStream<InvalidationEvent>
+    private let continuation: AsyncStream<InvalidationEvent>.Continuation
+
+    init() {
+        var captured: AsyncStream<InvalidationEvent>.Continuation!
+        self.stream = AsyncStream { captured = $0 }
+        self.continuation = captured
+    }
+
+    func events() -> AsyncStream<InvalidationEvent> {
+        stream
+    }
+
+    func send(_ event: InvalidationEvent) {
+        continuation.yield(event)
+    }
+}
+#endif

--- a/Tests/FOSMVVMTests/SwiftUI Support/SSEChannelParsingTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/SSEChannelParsingTests.swift
@@ -1,0 +1,213 @@
+// SSEChannelParsingTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// @testable coverage of the internal default-channel parser and reconnect loop (spec §3.2/§6,
+// test group 6). The types are compiled only where an async streaming URLSession exists, so the
+// suite carries the same guard.
+#if canImport(Darwin) || canImport(FoundationNetworking)
+import FOSFoundation
+@testable import FOSMVVM
+import Foundation
+import Testing
+
+@Suite("SSE default channel — parsing & reconnect (spec §3.2/§6, group 6)")
+struct SSEChannelParsingTests {
+    // MARK: - Parser
+
+    /// A single `data:` line + blank terminator yields exactly that data payload, which decodes
+    /// back to the emitted identity set.
+    @Test func dataLineEventRoundTrips() throws {
+        let identity = try TestGadget().modelIdentity
+        let json = try String(decoding: JSONEncoder.defaultEncoder.encode([identity]), as: UTF8.self)
+
+        var parser = SSEEventParser()
+        #expect(parser.consume("data: \(json)") == nil)
+        let terminated = parser.consume("")
+        let payload = try #require(terminated)
+        #expect(payload == json)
+
+        let decoded = try #require(SSEInvalidationChannel.decode(payload))
+        #expect(decoded == Set([identity]))
+    }
+
+    /// Multiple `data:` lines in one event are joined with `\n` per the SSE grammar.
+    @Test func multiDataLineEventJoinsWithNewline() {
+        var parser = SSEEventParser()
+        #expect(parser.consume("data: line-1") == nil)
+        #expect(parser.consume("data: line-2") == nil)
+        #expect(parser.consume("") == "line-1\nline-2")
+    }
+
+    /// Comment lines (`:`-prefixed heartbeats / the open preamble) are consumed and ignored; only
+    /// the real data event surfaces.
+    @Test func commentLinesAreIgnored() {
+        var parser = SSEEventParser()
+        #expect(parser.consume(": open") == nil)
+        #expect(parser.consume(": keep-alive") == nil)
+        #expect(parser.consume("data: payload") == nil)
+        #expect(parser.consume("") == "payload")
+    }
+
+    /// A blank line with no accumulated data lines produces nothing (no spurious empty event).
+    @Test func blankLineWithoutDataProducesNothing() {
+        var parser = SSEEventParser()
+        #expect(parser.consume("") == nil)
+        #expect(parser.consume("") == nil)
+    }
+
+    /// Trailing CR on `data:` and terminator lines is tolerated (CRLF framing).
+    @Test func crlfIsTolerated() {
+        var parser = SSEEventParser()
+        #expect(parser.consume("data: payload\r") == nil)
+        #expect(parser.consume("\r") == "payload")
+    }
+
+    /// `id:`/`event:` fields are skipped defensively (§6: v1 events are data-only) — never an error.
+    @Test func idAndEventFieldsAreSkipped() {
+        var parser = SSEEventParser()
+        #expect(parser.consume("id: 42") == nil)
+        #expect(parser.consume("event: nudge") == nil)
+        #expect(parser.consume("data: payload") == nil)
+        #expect(parser.consume("") == "payload")
+    }
+
+    /// A malformed JSON body decodes to `nil` — the channel skips that event and keeps the stream
+    /// alive (it must never kill the channel).
+    @Test func malformedJSONIsSkipped() {
+        #expect(SSEInvalidationChannel.decode("not-json") == nil)
+        #expect(SSEInvalidationChannel.decode("") == nil)
+    }
+
+    // MARK: - Reconnect back-off
+
+    /// Failed opens back off exponentially and hold at the cap (no `onOpen` ⇒ no reset).
+    @Test func backoffGrowsExponentiallyToCap() async {
+        let sleeps = await collectSleeps(
+            count: 6,
+            opens: Array(repeating: false, count: 8),
+            initialBackoff: .milliseconds(1),
+            maxBackoff: .milliseconds(8)
+        )
+        #expect(sleeps == [
+            .milliseconds(1), .milliseconds(2), .milliseconds(4),
+            .milliseconds(8), .milliseconds(8), .milliseconds(8)
+        ])
+    }
+
+    /// A successful open resets the back-off: growth resumes from the floor after a live connection
+    /// drops.
+    @Test func backoffResetsAfterSuccessfulOpen() async {
+        // fail, fail, succeed-then-drop, fail, fail
+        let sleeps = await collectSleeps(
+            count: 5,
+            opens: [false, false, true, false, false],
+            initialBackoff: .milliseconds(1),
+            maxBackoff: .milliseconds(8)
+        )
+        #expect(sleeps == [
+            .milliseconds(1), .milliseconds(2), // growth
+            .milliseconds(1), // reset after the successful open
+            .milliseconds(2), .milliseconds(4) // growth resumes
+        ])
+    }
+
+    /// `.connected` is (re)emitted on every successful open — the dispatcher's sweep trigger.
+    @Test func connectedReemittedOnEachReopen() async {
+        let connects = await collectConnects(count: 3)
+        #expect(connects == 3)
+    }
+}
+
+// MARK: - Reconnect harness
+
+/// Scripts per-iteration open success for `runReconnectLoop`.
+private actor CallScript {
+    private let opens: [Bool]
+    private var index = 0
+    init(_ opens: [Bool]) {
+        self.opens = opens
+    }
+
+    func nextShouldOpen() -> Bool {
+        defer { index += 1 }
+        return index < opens.count ? opens[index] : false
+    }
+}
+
+private struct DropError: Error {}
+
+/// Drives `runReconnectLoop` with a scripted `streamOnce` and a no-sleep clock that records the
+/// requested back-off durations, returning the first `count` of them.
+private func collectSleeps(
+    count: Int,
+    opens: [Bool],
+    initialBackoff: Duration,
+    maxBackoff: Duration
+) async -> [Duration] {
+    let script = CallScript(opens)
+    let (durations, durationsCont) = AsyncStream.makeStream(of: Duration.self)
+    let (_, eventsCont) = AsyncStream.makeStream(of: InvalidationEvent.self)
+
+    let loop = Task {
+        await SSEInvalidationChannel.runReconnectLoop(
+            yielding: eventsCont,
+            sleep: { durationsCont.yield($0) },
+            initialBackoff: initialBackoff,
+            maxBackoff: maxBackoff
+        ) { _, onOpen in
+            if await script.nextShouldOpen() { onOpen() }
+            throw DropError()
+        }
+    }
+
+    var collected: [Duration] = []
+    for await duration in durations {
+        collected.append(duration)
+        if collected.count == count { break }
+    }
+    loop.cancel()
+    durationsCont.finish()
+    eventsCont.finish()
+    return collected
+}
+
+/// Drives `runReconnectLoop` with always-succeeding opens, counting the first `count` `.connected`
+/// events.
+private func collectConnects(count: Int) async -> Int {
+    let (events, eventsCont) = AsyncStream.makeStream(of: InvalidationEvent.self)
+
+    let loop = Task {
+        await SSEInvalidationChannel.runReconnectLoop(
+            yielding: eventsCont,
+            sleep: { _ in },
+            initialBackoff: .milliseconds(1),
+            maxBackoff: .milliseconds(8)
+        ) { _, onOpen in
+            onOpen()
+            throw DropError()
+        }
+    }
+
+    var connects = 0
+    for await event in events {
+        if case .connected = event { connects += 1 }
+        if connects == count { break }
+    }
+    loop.cancel()
+    eventsCont.finish()
+    return connects
+}
+#endif

--- a/Tests/FOSMVVMTests/SwiftUI Support/SSEChannelParsingTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/SSEChannelParsingTests.swift
@@ -15,9 +15,9 @@
 // limitations under the License.
 
 // @testable coverage of the internal default-channel parser and reconnect loop (spec §3.2/§6,
-// test group 6). The types are compiled only where an async streaming URLSession exists, so the
-// suite carries the same guard.
-#if canImport(Darwin) || canImport(FoundationNetworking)
+// test group 6). The subject types are Darwin-only (FoundationNetworking lacks
+// `URLSession.bytes`), so the suite carries the same guard.
+#if canImport(Darwin)
 import FOSFoundation
 @testable import FOSMVVM
 import Foundation

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift
@@ -1,0 +1,231 @@
+// ClientChannelRoundTripTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end: the default SSE client channel (FOSMVVM) against the real served endpoint
+// (FOSMVVMVapor), locking the frozen §6 wire across the module boundary (spec §3.2, test group 6).
+#if canImport(Darwin) || canImport(FoundationNetworking)
+import Fluent
+import FluentKit
+import FOSFoundation
+@testable import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("Default SSE channel — end-to-end round-trip (spec §3.2, test group 6)")
+struct ClientChannelRoundTripTests {
+    /// The default channel opens against the served endpoint, signals `.connected`, and — after a
+    /// real Fluent save — delivers `.invalidated` with the containment-derived set {Berth, Dock}.
+    @Test func connectsThenReceivesInvalidation() async throws {
+        try await withServedFluentTestApp { app in
+            app.invalidationHeartbeatInterval = .milliseconds(200)
+            try configureLiveHarbor(app, on: app.routes)
+        } _: { app, baseURL in
+            let (dock1, _) = try await seedHarbor(on: app.db)
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() }
+
+            let channel = SSEInvalidationChannel(
+                baseURL: { baseURL },
+                credentialProvider: nil,
+                session: session
+            )
+
+            let (received, expected) = try await withTimeout(.seconds(15)) {
+                var iterator = channel.events().makeAsyncIterator()
+
+                // The stream is open once `.connected` arrives ⇒ the server has already subscribed
+                // this client to the hub, so the save below reaches a connected subscriber.
+                guard case .connected = await iterator.next() else {
+                    throw RoundTripError.expectedConnected
+                }
+
+                let berth = try Berth(number: 777, dockName: dock1.name, dockId: dock1.requireId())
+                try await berth.save(on: app.db)
+                let expected = try Set([berth.modelIdentity, dock1.modelIdentity])
+
+                while let event = await iterator.next() {
+                    if case .invalidated(let identities) = event {
+                        return (identities, expected)
+                    }
+                }
+                throw RoundTripError.streamEndedBeforeInvalidation
+            }
+            #expect(received == expected)
+        }
+    }
+
+    /// The channel attaches `ClientCredentialProvider.credentialHeaders()` at stream-open: a group
+    /// middleware captures the `Authorization` header the served request carried.
+    @Test func attachesCredentialHeadersAtOpen() async throws {
+        let capture = HeaderCapture()
+        try await withServedFluentTestApp { app in
+            app.invalidationHeartbeatInterval = .milliseconds(200)
+            let secured = app.grouped(CapturingMiddleware(capture))
+            try configureLiveHarbor(app, on: secured)
+        } _: { _, baseURL in
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() }
+
+            let channel = SSEInvalidationChannel(
+                baseURL: { baseURL },
+                credentialProvider: BearerCredentialProvider { "round-trip-token" },
+                session: session
+            )
+
+            try await withTimeout(.seconds(15)) {
+                var iterator = channel.events().makeAsyncIterator()
+                guard case .connected = await iterator.next() else {
+                    throw RoundTripError.expectedConnected
+                }
+            }
+            // `.connected` fired ⇒ the request reached the server ⇒ the middleware already recorded.
+            #expect(await capture.value == "Bearer round-trip-token")
+        }
+    }
+
+    /// A non-2xx open (here a 401 group) is a drop, not a connection: no `.connected` is ever
+    /// emitted (no false dispatcher sweep) and back-off GROWS across the retries instead of
+    /// resetting into a hot spin.
+    @Test func non2xxOpenBacksOffWithoutConnected() async throws {
+        try await withServedFluentTestApp { app in
+            app.invalidationHeartbeatInterval = .milliseconds(200)
+            let denied = app.grouped(DenyAllMiddleware())
+            try configureLiveHarbor(app, on: denied)
+        } _: { _, baseURL in
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() }
+
+            let sleeps = SleepRecorder()
+            let channel = SSEInvalidationChannel(
+                baseURL: { baseURL },
+                credentialProvider: nil,
+                session: session,
+                sleep: { await sleeps.record($0) },
+                initialBackoff: .milliseconds(1),
+                maxBackoff: .milliseconds(8)
+            )
+
+            let log = EventLog()
+            let consumer = Task {
+                for await event in channel.events() {
+                    await log.record(event)
+                }
+            }
+
+            // Each retry re-opens against the live 401 endpoint; wait until four real attempts
+            // have backed off, then tear the channel down.
+            try await withTimeout(.seconds(15)) {
+                while await sleeps.durations.count < 4 {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+            }
+            consumer.cancel()
+
+            let durations = await sleeps.durations
+            #expect(Array(durations.prefix(4)) == [
+                .milliseconds(1), .milliseconds(2), .milliseconds(4), .milliseconds(8)
+            ])
+            #expect(await log.events.isEmpty)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private enum RoundTripError: Error {
+    case expectedConnected
+    case streamEndedBeforeInvalidation
+}
+
+/// Records the `Authorization` header of the request that reached the SSE endpoint.
+private actor HeaderCapture {
+    private(set) var value: String?
+    func record(_ header: String?) {
+        value = header
+    }
+}
+
+private struct CapturingMiddleware: AsyncMiddleware {
+    let capture: HeaderCapture
+    init(_ capture: HeaderCapture) {
+        self.capture = capture
+    }
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        await capture.record(request.headers.first(name: .authorization))
+        return try await next.respond(to: request)
+    }
+}
+
+/// Answers every request 401 — an expired-credential / misconfigured-auth stand-in.
+private struct DenyAllMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        Response(status: .unauthorized)
+    }
+}
+
+/// Records the back-off durations the channel requested (injected as its `sleep`; never sleeps).
+private actor SleepRecorder {
+    private(set) var durations: [Duration] = []
+    func record(_ duration: Duration) {
+        durations.append(duration)
+    }
+}
+
+/// Records every event the channel yielded.
+private actor EventLog {
+    private(set) var events: [InvalidationEvent] = []
+    func record(_ event: InvalidationEvent) {
+        events.append(event)
+    }
+}
+
+/// Registers the harbor graph and enables live invalidation, mounting the SSE endpoint on `routes`.
+private func configureLiveHarbor(_ app: Application, on routes: any RoutesBuilder) throws {
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreatePier())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useLiveInvalidation(on: routes)
+}
+
+private struct TimeoutError: Error {}
+
+/// Races `operation` against a deadline so no stream read can hang the suite.
+private func withTimeout<T: Sendable>(
+    _ duration: Duration,
+    _ operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        group.addTask {
+            try await Task.sleep(for: duration)
+            throw TimeoutError()
+        }
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}
+#endif

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift
@@ -16,7 +16,7 @@
 
 // End-to-end: the default SSE client channel (FOSMVVM) against the real served endpoint
 // (FOSMVVMVapor), locking the frozen §6 wire across the module boundary (spec §3.2, test group 6).
-#if canImport(Darwin) || canImport(FoundationNetworking)
+#if canImport(Darwin)
 import Fluent
 import FluentKit
 import FOSFoundation
@@ -26,9 +26,6 @@ import FOSTestingVapor
 import Foundation
 import Testing
 import Vapor
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
 
 @Suite("Default SSE channel — end-to-end round-trip (spec §3.2, test group 6)")
 struct ClientChannelRoundTripTests {

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/EmitMiddlewareTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/EmitMiddlewareTests.swift
@@ -1,0 +1,182 @@
+// EmitMiddlewareTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: emissions are observed by subscribing a test stream to the INTERNAL
+// hub via `@testable import FOSMVVMVapor` (sanctioned — block coverage of an internal seam); the
+// assertions themselves are contract assertions: SET equality of what arrives after each mutation.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+@Suite("Invalidation emit middleware (spec §3.1, test group 1)")
+struct EmitMiddlewareTests {
+    /// An auto-commit save of an existing Berth (registered graph, live enabled) emits post-save
+    /// with the containment-derived set {Berth, owning Dock}.
+    @Test func autoCommitUpdateEmitsDerivedSet() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let berth = try #require(
+                await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).first()
+            )
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            berth.number += 100
+            try await berth.save(on: db)
+
+            let expected = try Set([berth.modelIdentity, dock1.modelIdentity])
+            #expect(await events.next() == expected)
+        }
+    }
+
+    /// Creating a new Berth emits the membership change on its container: {new Berth, Dock}.
+    @Test func createEmitsMembershipChangeOnContainer() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let berth = try Berth(number: 42, dockName: dock1.name, dockId: dock1.requireId())
+            try await berth.save(on: db)
+
+            let expected = try Set([berth.modelIdentity, dock1.modelIdentity])
+            #expect(await events.next() == expected)
+        }
+    }
+
+    /// Deleting a Berth emits the membership change on its container: {deleted Berth, Dock}.
+    @Test func deleteEmitsMembershipChangeOnContainer() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let berth = try #require(
+                await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).first()
+            )
+            let expected = try Set([berth.modelIdentity, dock1.modelIdentity])
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            try await berth.delete(on: db)
+
+            #expect(await events.next() == expected)
+        }
+    }
+
+    /// Double-emit guard (T3 carry-forward): `Dock` enters the emit-middleware coverage set through
+    /// TWO containment descriptors — its own registration AND `Harbor`'s contained side
+    /// (`.children(\Harbor.$docks)`). The `ObjectIdentifier`-deduped coverage store must still wire
+    /// exactly ONE middleware for it, so one save produces exactly ONE hub event, not two.
+    ///
+    /// Counted deterministically with a sentinel rather than a timeout: after the Dock save's event,
+    /// a distinct Berth save is enqueued; the very next event MUST be the Berth's set. A duplicate
+    /// Dock middleware would have enqueued a second `{Dock, Harbor}` ahead of it, failing the
+    /// equality — pinning the count at one without racing an open, idle stream.
+    @Test func doubleReachedModelEmitsExactlyOnce() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.query(on: db).first())
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let dock = try #require(await Dock.find(dock1.requireId(), on: db))
+            dock.name = "Renamed Dock"
+            try await dock.save(on: db)
+
+            // Exactly one Dock emit — its derived set, once.
+            let expectedDock = try Set([dock.modelIdentity, harbor.modelIdentity])
+            #expect(await events.next() == expectedDock)
+
+            // Sentinel: a duplicate Dock middleware would surface a SECOND {Dock, Harbor} here.
+            let berth = try #require(
+                await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).first()
+            )
+            berth.number += 100
+            try await berth.save(on: db)
+
+            let expectedBerth = try Set([berth.modelIdentity, dock1.modelIdentity])
+            #expect(await events.next() == expectedBerth)
+        }
+    }
+
+    /// `useLiveInvalidation` called BEFORE any registration: later `register(_:migration:)` calls
+    /// wire the emit middleware themselves — the graph still emits.
+    @Test func enableThenRegisterWiresMiddleware() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app, enableFirst: true)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let berth = try Berth(number: 7, dockName: dock1.name, dockId: dock1.requireId())
+            try await berth.save(on: db)
+
+            let expected = try Set([berth.modelIdentity, dock1.modelIdentity])
+            #expect(await events.next() == expected)
+        }
+    }
+
+    /// `useLiveInvalidation` called AFTER the registrations: the boot switch sweeps the existing
+    /// registry — the graph emits identically.
+    @Test func registerThenEnableWiresMiddleware() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app, enableFirst: false)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let dock1Refetched = try #require(await Dock.find(dock1.requireId(), on: db))
+            dock1Refetched.name = "Renamed Dock"
+            try await dock1Refetched.save(on: db)
+
+            let harbor = try #require(await Harbor.query(on: db).first())
+            let expected = try Set([dock1Refetched.modelIdentity, harbor.modelIdentity])
+            #expect(await events.next() == expected)
+        }
+    }
+}
+
+/// Registers the harbor graph and enables live invalidation, in either order (spec §3.1: both
+/// call orders work).
+private func configureLiveHarbor(_ app: Application, enableFirst: Bool = false) throws {
+    if enableFirst {
+        try app.useLiveInvalidation(on: app.routes)
+    }
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreatePier())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    if !enableFirst {
+        try app.useLiveInvalidation(on: app.routes)
+    }
+}

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/IdentitySetDerivationTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/IdentitySetDerivationTests.swift
@@ -1,0 +1,306 @@
+// IdentitySetDerivationTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: exercises the internal L2 emit-derivation via `@testable import
+// FOSMVVMVapor` (sanctioned — below C8's public surface). No access level is widened for tests.
+
+import Fluent // app.migrations lives in vapor/fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+
+/// The `.siblings` fixtures give CrewMember a docks relation but no container conformance. Declaring
+/// it here (same module as the fixtures — not retroactive) lets the pivot test register BOTH ends of
+/// DockCrew as containers, so the pivot inversion's far-end branch is exercised, not just the near.
+extension CrewMember: ContainerDataModel {
+    static var containedRecordTypes: [any FOSMVVM.Model.Type] {
+        [Dock.self]
+    }
+
+    static var containment: [ContainmentRelation] {
+        [.siblings(\CrewMember.$docks)]
+    }
+}
+
+/// The `.parent` inverter's EMITTING branch needs a registered `.parent` target — the shared
+/// fixtures register none, so `.parent(\Dock.$pier)` stays dormant everywhere else. Declaring Pier
+/// a (leaf) container here lets one test register it and assert the Dock→Pier contribution.
+/// Registration is per-app, so suites that don't register Pier are untouched.
+extension Pier: ContainerDataModel {
+    static var containedRecordTypes: [any FOSMVVM.Model.Type] {
+        []
+    }
+
+    static var containment: [ContainmentRelation] {
+        []
+    }
+}
+
+// MARK: - Optional-parent fixtures (the child inverter's `.optional(parentKeyPath)` branch)
+
+/// Every shared-fixture `@Parent` is required; Marina/Buoy pin the `@OptionalParent` join —
+/// `ChildrenProperty.parentKey == .optional` — through the same derivation path.
+final class Marina: ContainerDataModel, @unchecked Sendable {
+    static let schema = "marinas"
+    static var containedRecordTypes: [any FOSMVVM.Model.Type] {
+        [Buoy.self]
+    }
+
+    static var containment: [ContainmentRelation] {
+        [.children(\Marina.$buoys)]
+    }
+
+    @ID(key: .id) var id: UUID?
+    @Field(key: "name") var name: String
+    @Children(for: \.$marina) var buoys: [Buoy]
+    init() {}
+    init(name: String) {
+        self.name = name
+    }
+
+    func validate(fields: [any FormFieldBase]?, validations: FOSMVVM.Validations) -> FOSMVVM.ValidationResult.Status? {
+        nil
+    }
+}
+
+final class Buoy: DataModel, @unchecked Sendable {
+    static let schema = "buoys"
+    @ID(key: .id) var id: UUID?
+    @Field(key: "label") var label: String
+    @OptionalParent(key: "marina_id") var marina: Marina?
+    init() {}
+    init(label: String, marinaId: ModelIdType?) {
+        self.label = label
+        $marina.id = marinaId
+    }
+
+    func validate(fields: [any FormFieldBase]?, validations: FOSMVVM.Validations) -> FOSMVVM.ValidationResult.Status? {
+        nil
+    }
+}
+
+struct CreateMarina: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema(Marina.schema).id().field("name", .string, .required).create()
+    }
+
+    func revert(on database: any Database) async throws {
+        try await database.schema(Marina.schema).delete()
+    }
+}
+
+struct CreateBuoy: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema(Buoy.schema).id()
+            .field("label", .string, .required)
+            .field("marina_id", .uuid, .references(Marina.schema, "id"))
+            .create()
+    }
+
+    func revert(on database: any Database) async throws {
+        try await database.schema(Buoy.schema).delete()
+    }
+}
+
+@Suite("Invalidation identity-set derivation (spec §3.1, group 3)")
+struct IdentitySetDerivationTests {
+    /// A mutated `.children` member emits its own identity + its owning container's — read off the
+    /// Berth's `dock_id` FK through Dock's `.children(\Dock.$berths)` parent key.
+    @Test func childEmitsOwnAndOwningContainer() async throws {
+        try await withFluentTestApp { app in
+            try app.register(Harbor.self, migration: CreateHarbor())
+            try app.register(Dock.self, migration: CreateDock())
+            app.migrations.add(CreatePier())
+            app.migrations.add(CreateBerth())
+            app.migrations.add(CreateCrewMember())
+            app.migrations.add(CreateDockCrew())
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let berth = try #require(
+                await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).first()
+            )
+
+            let derived = InvalidationIdentitySet.staleIdentities(
+                forMutated: berth,
+                registry: app.modelTypeRegistry
+            )
+
+            #expect(try derived == Set([berth.modelIdentity, dock1.modelIdentity]))
+        }
+    }
+
+    /// A mutated Dock emits its own identity + its apex Harbor's — read off the Dock's `harbor_id`
+    /// FK through Harbor's `.children(\Harbor.$docks)`. Its unregistered `.parent(\Dock.$pier)`
+    /// target (Pier) contributes nothing.
+    @Test func containedContainerEmitsOwnAndApex() async throws {
+        try await withFluentTestApp { app in
+            try app.register(Harbor.self, migration: CreateHarbor())
+            try app.register(Dock.self, migration: CreateDock())
+            app.migrations.add(CreatePier())
+            app.migrations.add(CreateBerth())
+            app.migrations.add(CreateCrewMember())
+            app.migrations.add(CreateDockCrew())
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.query(on: db).first())
+
+            let derived = InvalidationIdentitySet.staleIdentities(
+                forMutated: dock1,
+                registry: app.modelTypeRegistry
+            )
+
+            #expect(try derived == Set([dock1.modelIdentity, harbor.modelIdentity]))
+        }
+    }
+
+    /// A mutated pivot (DockCrew) covers `.siblings` membership: it emits its own identity + both
+    /// linked ends that are registered containers. With Dock AND CrewMember both registered, that is
+    /// both ends.
+    @Test func pivotEmitsBothRegisteredLinkedContainers() async throws {
+        try await withFluentTestApp { app in
+            try app.register(Harbor.self, migration: CreateHarbor())
+            try app.register(Dock.self, migration: CreateDock())
+            try app.register(CrewMember.self, migration: CreateCrewMember())
+            app.migrations.add(CreatePier())
+            app.migrations.add(CreateBerth())
+            app.migrations.add(CreateDockCrew())
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let pivot = try #require(
+                await DockCrew.query(on: db).filter(\.$dock.$id == dock1.requireId()).first()
+            )
+            let crew = try #require(await CrewMember.find(pivot.$crewMember.id, on: db))
+
+            let derived = InvalidationIdentitySet.staleIdentities(
+                forMutated: pivot,
+                registry: app.modelTypeRegistry
+            )
+
+            #expect(try derived == Set([
+                pivot.modelIdentity,
+                dock1.modelIdentity,
+                crew.modelIdentity
+            ]))
+        }
+    }
+
+    /// A registered model that no container declares (the apex Harbor) emits only its own identity.
+    @Test func uncontainedModelEmitsOnlyItself() async throws {
+        try await withFluentTestApp { app in
+            try app.register(Harbor.self, migration: CreateHarbor())
+            try app.register(Dock.self, migration: CreateDock())
+            app.migrations.add(CreatePier())
+            app.migrations.add(CreateBerth())
+            app.migrations.add(CreateCrewMember())
+            app.migrations.add(CreateDockCrew())
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.find(dock1.$harbor.id, on: db))
+
+            let derived = InvalidationIdentitySet.staleIdentities(
+                forMutated: harbor,
+                registry: app.modelTypeRegistry
+            )
+
+            #expect(try derived == Set([harbor.modelIdentity]))
+        }
+    }
+
+    /// The `.parent` inverter's EMITTING branch: with Pier registered, a mutated Dock's own
+    /// `.parent(\Dock.$pier)` reads the to-one target directly and the Pier identity joins the set —
+    /// alongside the apex Harbor from the `.children` inversion.
+    @Test func registeredParentTargetContributes() async throws {
+        try await withFluentTestApp { app in
+            try app.register(Harbor.self, migration: CreateHarbor())
+            try app.register(Pier.self, migration: CreatePier())
+            try app.register(Dock.self, migration: CreateDock())
+            app.migrations.add(CreateBerth())
+            app.migrations.add(CreateCrewMember())
+            app.migrations.add(CreateDockCrew())
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.find(dock1.$harbor.id, on: db))
+            let pier = try #require(await Pier.find(dock1.$pier.id, on: db))
+
+            let derived = InvalidationIdentitySet.staleIdentities(
+                forMutated: dock1,
+                registry: app.modelTypeRegistry
+            )
+
+            #expect(try derived == Set([
+                dock1.modelIdentity,
+                harbor.modelIdentity,
+                pier.modelIdentity
+            ]))
+        }
+    }
+
+    /// The child inverter's `.optional(parentKeyPath)` branch: a Buoy with its `@OptionalParent`
+    /// marina SET derives its Marina; the SAME join left nil contributes nothing — {self} only.
+    @Test func optionalParentKeyEmitsWhenSetAndSkipsWhenNil() async throws {
+        try await withFluentTestApp { app in
+            try app.register(Marina.self, migration: CreateMarina())
+            app.migrations.add(CreateBuoy())
+        } _: { app, db in
+            let marina = Marina(name: "West Marina")
+            try await marina.save(on: db)
+            let moored = try Buoy(label: "B-1", marinaId: marina.requireId())
+            let adrift = Buoy(label: "B-2", marinaId: nil)
+            try await moored.save(on: db)
+            try await adrift.save(on: db)
+
+            let mooredSet = InvalidationIdentitySet.staleIdentities(
+                forMutated: moored,
+                registry: app.modelTypeRegistry
+            )
+            #expect(try mooredSet == Set([moored.modelIdentity, marina.modelIdentity]))
+
+            let adriftSet = InvalidationIdentitySet.staleIdentities(
+                forMutated: adrift,
+                registry: app.modelTypeRegistry
+            )
+            #expect(try adriftSet == Set([adrift.modelIdentity]))
+        }
+    }
+
+    /// An UNSET required reference contributes nothing and never crashes: an unsaved Berth with an
+    /// id but no `dock_id` set derives {self} only (the required-parent `$id.value` read is nil).
+    @Test func unsetRequiredReferenceContributesNothing() async throws {
+        try await withFluentTestApp { app in
+            try app.register(Harbor.self, migration: CreateHarbor())
+            try app.register(Dock.self, migration: CreateDock())
+            app.migrations.add(CreatePier())
+            app.migrations.add(CreateBerth())
+            app.migrations.add(CreateCrewMember())
+            app.migrations.add(CreateDockCrew())
+        } _: { app, _ in
+            let berth = Berth()
+            berth._$id.value = ModelIdType()
+            let ownIdentity = try berth.modelIdentity
+
+            let derived = InvalidationIdentitySet.staleIdentities(
+                forMutated: berth,
+                registry: app.modelTypeRegistry
+            )
+
+            #expect(derived == Set([ownIdentity]))
+        }
+    }
+}

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidationRouteTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidationRouteTests.swift
@@ -32,6 +32,10 @@ import Vapor
 
 @Suite("Invalidation SSE endpoint (spec §3.2/§6, test group 4)")
 struct InvalidationRouteTests {
+    // The wire-consuming assertions are Darwin-only: they read the stream via `URLSession.bytes`,
+    // which swift-corelibs FoundationNetworking does not provide. The hub-level overflow proof
+    // stays unguarded (no HTTP client involved).
+    #if canImport(Darwin)
     /// A connected client receives one framed `data:` event whose JSON array round-trips (via
     /// `defaultDecoder`) to the containment-derived set of a real save: {Berth, owning Dock}.
     @Test func framedEventRoundTrip() async throws {
@@ -88,6 +92,7 @@ struct InvalidationRouteTests {
             #expect(sawHeartbeat)
         }
     }
+    #endif
 
     /// Overflow closes — proven at the internal hub-subscription seam (deterministic): emitting past
     /// the buffer limit without consuming terminates the subscriber's stream.
@@ -121,6 +126,7 @@ struct InvalidationRouteTests {
         }
     }
 
+    #if canImport(Darwin)
     /// Overflow closes — observed at the client: while the client reads nothing, a burst large
     /// enough to fill the OS socket buffer makes the server pump block, so the hub overflows and
     /// finishes the subscription. When the client then drains, it reaches a clean EOF (the line
@@ -169,6 +175,7 @@ struct InvalidationRouteTests {
             #expect(root == 404)
         }
     }
+    #endif
 }
 
 // MARK: - Helpers
@@ -184,6 +191,7 @@ private func configureLiveHarbor(_ app: Application, on routes: any RoutesBuilde
     try app.useLiveInvalidation(on: routes)
 }
 
+#if canImport(Darwin)
 /// Opens a bounded GET, reads only the status, and cancels the (possibly streaming) body so the
 /// server can tear down promptly.
 private func status(of url: URL) async throws -> Int {
@@ -195,6 +203,7 @@ private func status(of url: URL) async throws -> Int {
         return status
     }
 }
+#endif
 
 private struct TimeoutError: Error {}
 

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidationRouteTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidationRouteTests.swift
@@ -1,0 +1,216 @@
+// InvalidationRouteTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SSE endpoint + frozen wire framing (spec §3.2/§6, test group 4). The endpoint is internal
+// infrastructure; the assertions are CONTRACT assertions on the wire the client channel will
+// consume: a `data:`-only frame whose JSON array round-trips through `defaultDecoder` to the
+// emitted identity set. Overflow termination is proven at the internal hub-subscription seam
+// (deterministic, @testable) and separately observed as a clean client-side EOF.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+@Suite("Invalidation SSE endpoint (spec §3.2/§6, test group 4)")
+struct InvalidationRouteTests {
+    /// A connected client receives one framed `data:` event whose JSON array round-trips (via
+    /// `defaultDecoder`) to the containment-derived set of a real save: {Berth, owning Dock}.
+    @Test func framedEventRoundTrip() async throws {
+        try await withServedFluentTestApp { app in
+            // Short heartbeat so the pump notices the client's disconnect promptly at teardown.
+            app.invalidationHeartbeatInterval = .milliseconds(200)
+            try configureLiveHarbor(app, on: app.routes)
+        } _: { app, baseURL in
+            let (dock1, _) = try await seedHarbor(on: app.db)
+
+            let url = baseURL.appending(path: "invalidations")
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() } // close the held stream so server teardown is prompt
+            let (bytes, response) = try await session.bytes(from: url)
+            #expect((response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") == "text/event-stream")
+
+            // Headers have arrived ⇒ the route handler already ran hub.subscribe(); the save below
+            // therefore reaches a connected subscriber.
+            let berth = try Berth(number: 555, dockName: dock1.name, dockId: dock1.requireId())
+            try await berth.save(on: app.db)
+            let expected = try Set([berth.modelIdentity, dock1.modelIdentity])
+
+            let received = try await withTimeout(.seconds(10)) {
+                for try await line in bytes.lines where line.hasPrefix("data:") {
+                    let payload = line.dropFirst("data:".count).trimmingCharacters(in: .whitespaces)
+                    let data = Data(payload.utf8)
+                    return try JSONDecoder.defaultDecoder.decode([ModelIdentity].self, from: data)
+                }
+                return [ModelIdentity]()
+            }
+            #expect(Set(received) == expected)
+        }
+    }
+
+    /// With a shortened heartbeat interval, a comment line (`:`-prefixed) arrives on an idle stream.
+    @Test func heartbeatsFlow() async throws {
+        try await withServedFluentTestApp { app in
+            app.invalidationHeartbeatInterval = .milliseconds(100)
+            try configureLiveHarbor(app, on: app.routes)
+        } _: { _, baseURL in
+            let url = baseURL.appending(path: "invalidations")
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() }
+            let (bytes, _) = try await session.bytes(from: url)
+
+            // Match the periodic heartbeat specifically — NOT the one-shot `: open` preamble that
+            // flushes the response head.
+            let sawHeartbeat = try await withTimeout(.seconds(10)) {
+                for try await line in bytes.lines where line.contains("keep-alive") {
+                    return true
+                }
+                return false
+            }
+            #expect(sawHeartbeat)
+        }
+    }
+
+    /// Overflow closes — proven at the internal hub-subscription seam (deterministic): emitting past
+    /// the buffer limit without consuming terminates the subscriber's stream.
+    @Test func overflowTerminatesSubscriptionAtHub() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app, on: app.routes)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let identity = try Set([dock1.modelIdentity])
+            let hub = try #require(app.invalidationHub)
+            let subscription = await hub.subscribe()
+
+            // Flood past the per-subscriber buffer without draining: the overflow emit finishes
+            // this subscriber (InvalidationHub.subscriberBufferLimit).
+            for _ in 0...(InvalidationHub.subscriberBufferLimit + 8) {
+                await hub.emit(identity)
+            }
+
+            // The stream terminates: draining reaches the end (nil) within a bounded count.
+            let terminated = try await withTimeout(.seconds(10)) {
+                var seen = 0
+                for await _ in subscription {
+                    seen += 1
+                    if seen > InvalidationHub.subscriberBufferLimit + 64 {
+                        return false // never ended — would have hung without the guard
+                    }
+                }
+                return true
+            }
+            #expect(terminated)
+        }
+    }
+
+    /// Overflow closes — observed at the client: while the client reads nothing, a burst large
+    /// enough to fill the OS socket buffer makes the server pump block, so the hub overflows and
+    /// finishes the subscription. When the client then drains, it reaches a clean EOF (the line
+    /// stream completes) rather than hanging. Burst sized to defeat any reasonable socket buffer so
+    /// the pump is guaranteed to block; a smaller burst that the fast pump drains into TCP would not
+    /// deterministically overflow (see `overflowTerminatesSubscriptionAtHub` for the deterministic
+    /// hub-level proof).
+    @Test func overflowClosesObservedByClient() async throws {
+        try await withServedFluentTestApp { app in
+            try configureLiveHarbor(app, on: app.routes)
+        } _: { app, baseURL in
+            let (dock1, _) = try await seedHarbor(on: app.db)
+            let identity = try Set([dock1.modelIdentity])
+
+            let url = baseURL.appending(path: "invalidations")
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() }
+            let (bytes, _) = try await session.bytes(from: url)
+            let hub = try #require(app.invalidationHub)
+
+            // Client reads nothing during the burst: the pump fills the socket buffer, blocks, and
+            // the continuing emits overflow the 64-slot subscription ⇒ the hub finishes it.
+            for _ in 0..<200000 {
+                await hub.emit(identity)
+            }
+
+            let endedCleanly = try await withTimeout(.seconds(15)) {
+                for try await _ in bytes.lines {} // drain to EOF, unthrottled
+                return true // the line stream completed ⇒ server ended the response, no hang
+            }
+            #expect(endedCleanly)
+        }
+    }
+
+    /// The endpoint answers on the passed group and NOT at the root.
+    @Test func mountedGroupIsHonored() async throws {
+        try await withServedFluentTestApp { app in
+            app.invalidationHeartbeatInterval = .milliseconds(200)
+            let api = app.grouped("api")
+            try configureLiveHarbor(app, on: api)
+        } _: { _, baseURL in
+            let grouped = try await status(of: baseURL.appending(path: "api/invalidations"))
+            #expect(grouped == 200)
+
+            let root = try await status(of: baseURL.appending(path: "invalidations"))
+            #expect(root == 404)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// Registers the harbor graph and enables live invalidation, mounting the SSE endpoint on `routes`.
+private func configureLiveHarbor(_ app: Application, on routes: any RoutesBuilder) throws {
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreatePier())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useLiveInvalidation(on: routes)
+}
+
+/// Opens a bounded GET, reads only the status, and cancels the (possibly streaming) body so the
+/// server can tear down promptly.
+private func status(of url: URL) async throws -> Int {
+    try await withTimeout(.seconds(10)) {
+        let session = URLSession(configuration: .ephemeral)
+        let (_, response) = try await session.bytes(from: url)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        session.invalidateAndCancel()
+        return status
+    }
+}
+
+private struct TimeoutError: Error {}
+
+/// Races `operation` against a deadline so no stream read can hang the suite.
+private func withTimeout<T: Sendable>(
+    _ duration: Duration,
+    _ operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        group.addTask {
+            try await Task.sleep(for: duration)
+            throw TimeoutError()
+        }
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/LiveTransactionTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/LiveTransactionTests.swift
@@ -1,0 +1,254 @@
+// LiveTransactionTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-taxonomy discipline: emission ABSENCE is asserted with a sentinel — the hub is emitted a
+// known identity set directly after the exercised writes, and the FIRST event the test subscriber
+// sees must be that sentinel (every middleware emission completes before its save returns, so the
+// buffer is final by then). The internal hub/@testable use is block coverage of an internal seam.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import NIOConcurrencyHelpers
+import Testing
+import Vapor
+
+@Suite("liveTransaction + bare-transaction suppression (spec §3.1/D-L2-1, test group 2)")
+struct LiveTransactionTests {
+    /// A save inside a bare `db.transaction { }` emits NOTHING — FOSMVVM cannot see whether the
+    /// transaction commits — and warns exactly once per model type, naming the type.
+    @Test func bareTransactionEmitsNothingAndWarnsOnce() async throws {
+        let captured = CapturedWarnings()
+        try await withFluentTestApp { app in
+            captureWarnings(of: app, into: captured)
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.query(on: db).first())
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            try await db.transaction { tx in
+                let berthA = try Berth(number: 60, dockName: dock1.name, dockId: dock1.requireId())
+                let berthB = try Berth(number: 61, dockName: dock1.name, dockId: dock1.requireId())
+                try await berthA.save(on: tx)
+                try await berthB.save(on: tx)
+            }
+
+            // The transaction committed (writes landed) …
+            let count = try await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).count()
+            #expect(count == 5) // 3 seeded + 2
+
+            // … but nothing was emitted: the first event the subscriber sees is the sentinel.
+            let sentinel = try Set([harbor.modelIdentity])
+            await hub.emit(sentinel)
+            #expect(await events.next() == sentinel)
+
+            // Warned once for Berth (two suppressed saves, one warning), naming type + remedy.
+            #expect(captured.all.count(where: { $0.contains("Berth") }) == 1)
+            #expect(captured.contains(allOf: "Berth", "liveTransaction"))
+        }
+    }
+
+    /// `Application.liveTransaction` collects every write's derived set and flushes exactly the
+    /// UNION to the hub — one event — after the transaction commits.
+    @Test func liveTransactionFlushesUnionOnCommit() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, dock2) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.query(on: db).first())
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let berthA = try Berth(number: 70, dockName: dock1.name, dockId: dock1.requireId())
+            let berthB = try Berth(number: 71, dockName: dock2.name, dockId: dock2.requireId())
+            let value = try await app.liveTransaction { tx in
+                try await berthA.save(on: tx)
+                try await berthB.save(on: tx)
+                return 7
+            }
+            #expect(value == 7)
+
+            let expected = try Set([
+                berthA.modelIdentity,
+                dock1.modelIdentity,
+                berthB.modelIdentity,
+                dock2.modelIdentity
+            ])
+            #expect(await events.next() == expected)
+
+            // Exactly one flush: the next event is the sentinel, not a second emission.
+            let sentinel = try Set([harbor.modelIdentity])
+            await hub.emit(sentinel)
+            #expect(await events.next() == sentinel)
+        }
+    }
+
+    /// `Request.liveTransaction` — the request-side door — flushes the same way.
+    @Test func requestLiveTransactionFlushesOnCommit() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let req = Request(
+                application: app,
+                method: .GET,
+                url: URI(string: "/"),
+                on: app.eventLoopGroup.next()
+            )
+            let berth = try Berth(number: 80, dockName: dock1.name, dockId: dock1.requireId())
+            try await req.liveTransaction { tx in
+                try await berth.save(on: tx)
+            }
+
+            let expected = try Set([berth.modelIdentity, dock1.modelIdentity])
+            #expect(await events.next() == expected)
+        }
+    }
+
+    /// A THROWING `liveTransaction` rolls back and emits nothing — the collected sets are discarded.
+    @Test func throwingLiveTransactionEmitsNothing() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.query(on: db).first())
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let berth = try Berth(number: 90, dockName: dock1.name, dockId: dock1.requireId())
+            await #expect(throws: Boom.self) {
+                try await app.liveTransaction { tx in
+                    try await berth.save(on: tx)
+                    throw Boom()
+                }
+            }
+
+            // Rolled back …
+            let count = try await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).count()
+            #expect(count == 3) // the seeded three only
+
+            // … and nothing was emitted.
+            let sentinel = try Set([harbor.modelIdentity])
+            await hub.emit(sentinel)
+            #expect(await events.next() == sentinel)
+        }
+    }
+
+    /// With live invalidation NOT enabled, `liveTransaction` is still a correct transaction —
+    /// the wrapper degrades to `db.transaction` (no hub, no flush, no crash).
+    @Test func liveTransactionWithoutHubRunsTransaction() async throws {
+        try await withFluentTestApp { app in
+            // Registered graph, live NOT enabled.
+            try app.register(Harbor.self, migration: CreateHarbor())
+            try app.register(Dock.self, migration: CreateDock())
+            app.migrations.add(CreatePier())
+            app.migrations.add(CreateBerth())
+            app.migrations.add(CreateCrewMember())
+            app.migrations.add(CreateDockCrew())
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+
+            let berth = try Berth(number: 95, dockName: dock1.name, dockId: dock1.requireId())
+            let value = try await app.liveTransaction { tx in
+                try await berth.save(on: tx)
+                return "committed"
+            }
+            #expect(value == "committed")
+
+            let count = try await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).count()
+            #expect(count == 4)
+        }
+    }
+}
+
+private struct Boom: Error {}
+
+/// Registers the harbor graph and enables live invalidation.
+private func configureLiveHarbor(_ app: Application) throws {
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreatePier())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useLiveInvalidation(on: app.routes)
+}
+
+// MARK: - Warning capture (mirrors the PlanRegistrationTests idiom)
+
+/// Lock-guarded warning sink shared between the handler (inside the app) and the assertion.
+private final class CapturedWarnings: @unchecked Sendable {
+    private let lock = NIOLock()
+    private var messages: [String] = []
+
+    func append(_ message: String) {
+        lock.withLock { messages.append(message) }
+    }
+
+    var all: [String] {
+        lock.withLock { messages }
+    }
+
+    func contains(allOf fragments: String...) -> Bool {
+        all.contains { message in fragments.allSatisfy { message.contains($0) } }
+    }
+}
+
+/// Captures `.warning`+ messages; forwards nothing (tests stay quiet).
+private struct CapturingLogHandler: LogHandler {
+    let captured: CapturedWarnings
+
+    var metadata: Logger.Metadata = [:]
+    var logLevel: Logger.Level = .warning
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        guard level >= .warning else {
+            return
+        }
+        captured.append(message.description)
+    }
+}
+
+/// Rebinds the app's logger to the capturing sink — the emit middleware warns through the
+/// database's logger, which Fluent derives from `Application.logger`.
+private func captureWarnings(of app: Application, into captured: CapturedWarnings) {
+    app.logger = Logger(label: "live-transaction-tests") { _ in
+        CapturingLogHandler(captured: captured)
+    }
+}

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/RegistrationHeaderTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/RegistrationHeaderTests.swift
@@ -1,0 +1,285 @@
+// RegistrationHeaderTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Spec §3.4 / §6, test group 5: every served response that executed a RecordLoadPlan carries the
+// plan's staleness surface — its resolved roots plus every touched container — as the
+// `X-FOS-Registrations` response header (a JSON array of ModelIdentity via the frozen default
+// coder). Exercised through the real HTTP responder so the executor's deposit reaches the shared
+// `buildResponse` on the same Request the header rides.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+// MARK: - Fixtures
+
+/// An apex-rooted read whose berths load through Dock — so its registration set's roots (the
+/// Harbor) and touched containers (each Dock) are DISTINCT, proving both halves land in the header.
+private struct HarborBerthsVM: RequestableViewModel, ComposableFactory, VaporResponseBodyFactory {
+    typealias Request = HarborBerthsRequest
+
+    static let berths = LoadRequirement.read(Berth.self, in: .newRoot(.apex), via: Dock.self)
+    static var dataRequirements: [any DataRequirement] {
+        [berths]
+    }
+
+    var vmId = ViewModelId()
+    var berthNumbers: [Int] = []
+
+    init() {}
+    init(berthNumbers: [Int]) {
+        self.berthNumbers = berthNumbers
+    }
+
+    func propertyNames() -> [LocalizableId: String] {
+        [:]
+    }
+
+    static func stub() -> Self {
+        .init()
+    }
+
+    static func body<R: ServerRequest>(context: ProjectionContext<R, Void>) throws -> Self where R.ResponseBody == Self {
+        try .init(berthNumbers: context.records(berths).map(\.number).sorted())
+    }
+}
+
+private final class HarborBerthsRequest: ViewModelRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias ResponseError = EmptyError
+
+    let id: String
+    var responseBody: HarborBerthsVM?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil, requestBody: EmptyBody? = nil, responseBody: HarborBerthsVM? = nil) {
+        self.id = .random(length: 10)
+        self.responseBody = responseBody
+    }
+}
+
+/// A zero-data body: no ``ComposableFactory``, no plan — so serving it executes no
+/// RecordLoadPlan and the response carries NO registration header.
+private struct PlainVM: RequestableViewModel, VaporResponseBodyFactory {
+    typealias Request = PlainRequest
+
+    var vmId = ViewModelId()
+    var value: Int = 0
+
+    init() {}
+    init(value: Int) {
+        self.value = value
+    }
+
+    func propertyNames() -> [LocalizableId: String] {
+        [:]
+    }
+
+    static func stub() -> Self {
+        .init()
+    }
+
+    static func body<R: ServerRequest>(context _: ProjectionContext<R, Void>) throws -> Self where R.ResponseBody == Self {
+        .init(value: 7)
+    }
+}
+
+private final class PlainRequest: ViewModelRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias ResponseError = EmptyError
+
+    let id: String
+    var responseBody: PlainVM?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil, requestBody: EmptyBody? = nil, responseBody: PlainVM? = nil) {
+        self.id = .random(length: 10)
+        self.responseBody = responseBody
+    }
+}
+
+// MARK: - Harness
+
+/// Registers the Harbor → Dock → Berth graph and drives auth through the storage-backed grants
+/// provider (grants are set per test, after seeding, once identities exist).
+private func configureHarbor(_ app: Application) throws {
+    try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
+    app.migrations.add(CreatePier())
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useContainerAuthorizationProvider(TestGrantsProvider())
+}
+
+private func registerApexHarborResolver(_ app: Application) throws {
+    try app.useApexContainerResolver { req in
+        guard let harbor = try await Harbor.query(on: req.db).first() else {
+            throw Abort(.internalServerError, reason: "no harbor seeded")
+        }
+        return try harbor.modelIdentity
+    }
+}
+
+private func setGrants(_ app: Application, _ grants: [TestGrant]) {
+    app.storage[TestGrantsKey.self] = grants
+}
+
+private func berthReadGrant(container: ModelIdentity, _ ops: [ContainerOperation], types: [ModelNamespace]) -> TestGrant {
+    TestGrant(authorizedContainer: container, operations: ops, recordTypes: types)
+}
+
+private func registrationSet(from response: Vapor.Response) throws -> Set<ModelIdentity>? {
+    guard let value = response.headers.first(name: ModelIdentity.registrationsHeader) else {
+        return nil
+    }
+    let identities: [ModelIdentity] = try value.fromJSON()
+    return Set(identities)
+}
+
+private func getResponse(_ app: Application, for request: some ServerRequest) async throws -> Vapor.Response {
+    let base = try #require(URL(string: "http://localhost"))
+    let url = try #require(try base.appending(serverRequest: request))
+    let headers = HTTPHeaders([(HTTPHeaders.Name.acceptLanguage.description, "en")])
+    let httpReq = Request(
+        application: app, method: .GET, url: URI(string: url.absoluteString),
+        headers: headers, collectedBody: .init(), on: app.eventLoopGroup.next()
+    )
+    return try await app.responder.respond(to: httpReq).get()
+}
+
+// MARK: - Tests
+
+@Suite("Live invalidation: X-FOS-Registrations header")
+struct RegistrationHeaderTests {
+    /// A registered GET whose apex-rooted plan resolves against the Harbor graph carries the
+    /// executed plan's set — the Harbor root PLUS every Dock the berths loaded from.
+    @Test func servedGetCarriesExecutedPlanSet() async throws {
+        try await withFluentTestApp { app in
+            try configureHarbor(app)
+            try registerApexHarborResolver(app)
+            try app.register(request: HarborBerthsRequest.self)
+        } _: { app, db in
+            let (dock1, dock2) = try await seedHarbor(on: db)
+            let harbor = try #require(try await Harbor.query(on: db).first())
+            try setGrants(app, [
+                berthReadGrant(
+                    container: harbor.modelIdentity,
+                    [.readRecords],
+                    types: [Dock.modelIdentityNamespace, Berth.modelIdentityNamespace]
+                )
+            ])
+
+            let response = try await getResponse(app, for: HarborBerthsRequest())
+            #expect(response.status == .ok)
+
+            let expected: Set<ModelIdentity> = try [
+                harbor.modelIdentity,
+                dock1.modelIdentity,
+                dock2.modelIdentity
+            ]
+            let carried = try #require(try registrationSet(from: response))
+            #expect(carried == expected)
+        }
+    }
+
+    /// A write door (PATCH) responds with the REFRESHED set: the write re-serves itself through the
+    /// genuine read pipeline, whose executor deposits the set the refresh depended on.
+    @Test func writeDoorCarriesRefreshedSet() async throws {
+        try await withFluentTestApp { app in
+            try configureHarbor(app)
+            try app.register(request: UpdateBerthRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            try setGrants(app, [
+                berthReadGrant(
+                    container: dock1.modelIdentity,
+                    [.readRecords, .writeRecords],
+                    types: [Berth.modelIdentityNamespace]
+                )
+            ])
+            let berth = try #require(try await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).first())
+
+            let vmRequest = try UpdateBerthRequest(
+                query: .init(rootIdentity: dock1.modelIdentity, target: berth.modelIdentity),
+                sort: nil, fragment: nil, requestBody: nil, responseBody: nil
+            )
+            let base = try #require(URL(string: "http://localhost"))
+            let url = try #require(try base.appending(serverRequest: vmRequest))
+
+            var buffer = ByteBufferAllocator().buffer(capacity: 0)
+            try buffer.writeBytes(JSONEncoder().encode(UpdateBerthBody(number: 88, dockName: "Wired")))
+            var headers = HTTPHeaders([(HTTPHeaders.Name.acceptLanguage.description, "en")])
+            headers.contentType = .json
+            let httpReq = Request(
+                application: app, method: .PATCH, url: URI(string: url.absoluteString),
+                headers: headers, collectedBody: buffer, on: app.eventLoopGroup.next()
+            )
+
+            let response = try await app.responder.respond(to: httpReq).get()
+            #expect(response.status == .ok)
+
+            let carried = try #require(try registrationSet(from: response))
+            #expect(try carried == [dock1.modelIdentity])
+        }
+    }
+
+    /// §6 round-trip pin: the header value decodes (defaultDecoder), re-encodes (defaultEncoder),
+    /// and decodes again to the SAME set — a behavioral round-trip, not a byte assertion.
+    @Test func headerValueRoundTrips() async throws {
+        try await withFluentTestApp { app in
+            try configureHarbor(app)
+            try app.register(request: BerthListRequest.self)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            try setGrants(app, [
+                berthReadGrant(
+                    container: dock1.modelIdentity,
+                    [.readRecords],
+                    types: [Berth.modelIdentityNamespace]
+                )
+            ])
+
+            let response = try await getResponse(app, for: BerthListRequest(query: .init(rootIdentity: dock1.modelIdentity)))
+            #expect(response.status == .ok)
+
+            let value = try #require(response.headers.first(name: ModelIdentity.registrationsHeader))
+            let decoded: [ModelIdentity] = try value.fromJSON()
+            let reencoded = try decoded.toJSON()
+            let redecoded: [ModelIdentity] = try reencoded.fromJSON()
+
+            #expect(Set(decoded) == Set(redecoded))
+            #expect(try Set(decoded) == [dock1.modelIdentity])
+        }
+    }
+
+    /// A response whose request executed NO plan (a zero-data body) carries no header at all.
+    @Test func noPlanCarriesNoHeader() async throws {
+        try await withFluentTestApp { app in
+            try configureHarbor(app)
+            try app.register(request: PlainRequest.self)
+        } _: { app, _ in
+            let response = try await getResponse(app, for: PlainRequest())
+            #expect(response.status == .ok)
+            #expect(try registrationSet(from: response) == nil)
+        }
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Protocols/VaporResponseBodyFactoryTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/VaporResponseBodyFactoryTests.swift
@@ -60,4 +60,33 @@ struct VaporResponseBodyFactoryTests {
             #expect(try body.aLocalizedString.localizedString != "")
         }
     }
+
+    /// `X-FOS-Version` attaches exactly once. `buildResponse` and `buildJSONResponse` each stamp the
+    /// version; before the `replaceOrAdd` fix the appending `add` left the header on the served
+    /// response TWICE — a client reading `.first` was unaffected, but the duplicate was a latent
+    /// wire defect. Assert the served header carries exactly one value.
+    @Test func servedResponseCarriesExactlyOneVersionHeader() async throws {
+        try await withFluentTestApp { app in
+            try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
+            try app.register(request: TestViewModelRequest.self)
+        } _: { app, _ in
+            let prefix = "http://localhost"
+            let base = try #require(URL(string: prefix))
+            let url = try #require(try base.appending(serverRequest: TestViewModelRequest()))
+            let uriStr = String(url.absoluteString.trimmingPrefix(prefix))
+            let headers = HTTPHeaders([(HTTPHeaders.Name.acceptLanguage.description, "en")])
+            let req = Request(
+                application: app,
+                method: .GET,
+                url: URI(path: uriStr),
+                headers: headers,
+                collectedBody: .init(),
+                on: app.eventLoopGroup.next()
+            )
+
+            let response = try await app.responder.respond(to: req).get()
+            #expect(response.status == .ok)
+            #expect(response.headers[SystemVersion.httpHeader].count == 1)
+        }
+    }
 }

--- a/Tests/FOSMacrosTests/ViewModelMacroTests.swift
+++ b/Tests/FOSMacrosTests/ViewModelMacroTests.swift
@@ -18,6 +18,7 @@
 import FOSFoundation
 import FOSMacros
 import Foundation
+import SwiftDiagnostics
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
@@ -26,6 +27,76 @@ final class ViewModelMacroTests: XCTestCase {
     private let testMacros: [String: any Macro.Type] = [
         "ViewModel": ViewModelMacro.self
     ]
+
+    func testLiveConformanceExpansion() {
+        assertMacroExpansion(
+            #"""
+            @ViewModel(options: [.live]) struct TestViewModel: RequestableViewModel {
+                @LocalizedString public var name
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub() -> TestViewModel {
+                    .init()
+                }
+            }
+            """#,
+            expandedSource: #"""
+            struct TestViewModel: RequestableViewModel {
+                @LocalizedString public var name
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub() -> TestViewModel {
+                    .init()
+                }
+
+                public func propertyNames() -> [LocalizableId: String] {
+                    [_name.localizationId: "name"]
+                }
+            }
+
+            extension TestViewModel: ViewModel {
+            }
+
+            extension TestViewModel: RetrievablePropertyNames {
+            }
+
+            extension TestViewModel: LiveViewModel {
+            }
+            """#,
+            macros: testMacros,
+            indentationWidth: .spaces(4)
+        )
+    }
+
+    func testLiveAndClientHostedFactoryConflictDiagnoses() {
+        assertMacroExpansion(
+            #"""
+            @ViewModel(options: [.live, .clientHostedFactory]) struct TestViewModel: RequestableViewModel {
+                @LocalizedString public var name
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub() -> TestViewModel {
+                    .init()
+                }
+            }
+            """#,
+            expandedSource: #"""
+            struct TestViewModel: RequestableViewModel {
+                @LocalizedString public var name
+                var vmId: FOSMVVM.ViewModelId = .init()
+                static func stub() -> TestViewModel {
+                    .init()
+                }
+            }
+            """#,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'.live' cannot be combined with '.clientHostedFactory': a client-hosted ViewModel is built on the client and has no server response to derive live registrations from",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: testMacros,
+            indentationWidth: .spaces(4)
+        )
+    }
 
     func testBlankExpansion() {
         assertMacroExpansion(

--- a/docs/superpowers/plans/2026-07-09-l2-live-invalidation.md
+++ b/docs/superpowers/plans/2026-07-09-l2-live-invalidation.md
@@ -1,0 +1,379 @@
+# L2 Live Invalidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `.live` ViewModel refresh — server-pushed invalidation nudges over SSE,
+per the approved spec `docs/superpowers/specs/2026-07-09-live-invalidation-l2-design.md`.
+
+**Architecture:** One emit point (per-type Fluent `ModelMiddleware`, containment-derived
+identity sets, task-local transaction collector) → in-memory hub → SSE endpoint → client
+`InvalidationChannel` → `@MainActor` dispatcher + freshness gate → `.live` marker delivery
+with plan-derived registration sets riding the `X-FOS-Registrations` response header.
+
+**Tech Stack:** Swift 6 / Swift Testing (macro tests: XCTest) · Vapor + FluentKit
+(`ModelMiddleware`, `Request.storage`) · `URLSession.bytes` SSE · FOSMacros.
+
+**Read first:** the spec (§3 contract, §4 signature-normative surface, §6 frozen wire
+contracts, §8 test groups). On any conflict, **the spec wins**. Spec branch:
+`spec/live-invalidation-l2`. Precondition SATISFIED: `client-credential-provider` merged
+as PR #113; this branch is rebased onto it — Task 6 is unblocked.
+
+---
+
+## fosmvvm-planning gate output
+
+### Public surface (all names David-approved; justifications)
+
+| Symbol | Module | Justification (caller need) |
+|---|---|---|
+| `ViewModelOptions.live` | FOSMVVM (`Macros.swift:19` **public** enum) | the author's one-line opt-in |
+| `.live` twin case | FOSMacros (`ViewModelMacro.swift:48` **private** enum) | macro-side parsing (mirrors `clientHostedFactory`) |
+| `LiveViewModel` | FOSMVVM | macro-emitted conformance; the resolver's specialization hook |
+| `InvalidationEvent` | FOSMVVM | a custom channel must produce these |
+| `InvalidationChannel` | FOSMVVM | the DIP transport-override seam |
+| `MVVMEnvironment.invalidationChannel` / URL-package `invalidationBaseURL` | FOSMVVM | config; mirrors `resourcesBaseURL ?? serverBaseURL` |
+| `Application.useLiveInvalidation(on:)` | FOSMVVMVapor | server boot switch |
+| `Request.liveTransaction` / `Application.liveTransaction` | FOSMVVMVapor | the sanctioned transactional-write door (D-L2-1) |
+
+Everything else is **internal**: hub, dispatcher, emit middleware, SSE framing/parsing,
+registration token, the task-local collector, the `Request.storage` deposit key.
+
+Gate checklist: minimal surface ✓ (every symbol above has a named consumer; nothing else
+public) · encapsulation ✓ (nudges/headers carry sealed `ModelIdentity`; no raw getters) ·
+no stringly-typing ✓ (the two wire literals are §6 frozen contracts, not identities) ·
+one serialization ✓ (L0's frozen `ModelIdentity` Codable everywhere; no second format) ·
+requirement+default n/a (marker protocol; single-requirement channel — `nil` synthesizes the
+internal default, no extension-shadowing) · representation unpublished ✓ (DocC states
+contracts; encoded shapes live in spec §6 + internal tests) · boundaries ✓ (FOSMVVM touches
+only L0 types; all Fluent/Vapor pieces Vapor-side).
+
+**Gate finding (spec §4 refinement):** `.live` has **three** edit sites — the public
+`ViewModelOptions` (`Sources/FOSMVVM/Macros/Macros.swift:19`), the private FOSMacros twin
+(`Sources/FOSMacros/ViewModelMacro.swift:48`), and the conformances list of the
+`@attached(extension, …)` declaration (`Macros.swift:31`), which must gain `LiveViewModel`.
+
+### Customer DocC (drafted first; tasks carry these verbatim, refine only for compilability)
+
+`LiveViewModel`:
+```swift
+/// A ``ViewModel`` that refreshes automatically when its server data changes
+///
+/// Don't conform directly — opt in with the macro:
+///
+/// ```swift
+/// @ViewModel(options: [.live])
+/// public struct DocksViewModel: RequestableViewModel { ... }
+/// ```
+///
+/// Any view bound with `.bind()` then re-fetches whenever another actor mutates
+/// the data this ViewModel was served from — no polling, no manual invalidation,
+/// and nothing else to write. Where no live connection is configured the
+/// ViewModel behaves exactly like a non-live one (fetch once on appear), so
+/// adding `.live` to a shipped screen is purely additive.
+```
+
+`InvalidationEvent`:
+```swift
+/// One event from the server's live-invalidation stream
+///
+/// You only meet this type when supplying a custom ``InvalidationChannel``;
+/// the default channel produces it for you. Yield `.connected` whenever your
+/// transport (re)establishes its connection — FOSMVVM responds by refreshing
+/// every live screen — and `.invalidated` with each identity set the server
+/// pushes.
+```
+
+`InvalidationChannel`:
+```swift
+/// The transport that delivers server invalidation nudges to this client
+///
+/// Most apps never touch this: leave ``MVVMEnvironment/invalidationChannel``
+/// `nil` and FOSMVVM synthesizes the standard channel over your deployment
+/// URLs. Conform your own type only to replace the transport wholesale:
+///
+/// ```swift
+/// struct MyChannel: InvalidationChannel {
+///     func events() -> AsyncStream<InvalidationEvent> { ... }
+/// }
+///
+/// let environment = MVVMEnvironment(
+///     appBundle: Bundle.main,
+///     invalidationChannel: MyChannel(),
+///     deploymentURLs: ...
+/// )
+/// ```
+```
+
+`Application.useLiveInvalidation(on:)`:
+```swift
+/// Turns on live invalidation for this server
+///
+/// Call once at boot, passing the route group your clients authenticate
+/// against; every registered container model then nudges connected clients
+/// after each committed change:
+///
+/// ```swift
+/// let authed = app.grouped(MyAuthMiddleware())
+/// try app.useLiveInvalidation(on: authed)
+/// ```
+///
+/// Model registrations made before or after this call are both honored.
+```
+
+`liveTransaction`:
+```swift
+/// A Fluent transaction whose writes still notify live clients
+///
+/// Inside a bare `database.transaction { }` FOSMVVM cannot know whether your
+/// writes commit, so it stays silent (and logs a warning). Use
+/// `liveTransaction` instead and every write inside the closure nudges live
+/// clients if — and only if — the transaction commits:
+///
+/// ```swift
+/// try await req.liveTransaction { db in
+///     dock.status = .closed
+///     try await dock.save(on: db)
+/// }
+/// ```
+```
+
+`ViewModelOptions.live` (public enum case):
+```swift
+/// Refresh bound views automatically when server data changes — see ``LiveViewModel``
+case live
+```
+
+### Contract-test discipline (binding for every task)
+
+- Construct through public paths (`app.register`, door writes, `ViewModelId()`,
+  `try value.toJSON().fromJSON()`); `@testable` only for block-coverage of internals
+  (hub buffering, SSE parsing), never for contract assertions.
+- Assert behavior — set equality of emitted identities, freshness ordering, reconnect
+  sweep counts, degraded fetch-once — never encoded bytes, **except** the two §6 frozen
+  wire contracts (SSE framing, header round-trip), which get representation pins by design.
+- Freshness ordering comes from construction order (`ViewModelId()` twice), never forging.
+- Suites touching a shared app/hub: `.serialized`. Middleware is an async lifecycle concern:
+  use `app.asyncBoot()` in Vapor tests (the async-boot gotcha).
+- Fixtures: the existing harbor graph (`withFluentTestApp`, Pier/Dock/Berth + Harbor apex).
+
+### Rationale (implementer prose — none of this goes in DocC)
+
+- **Why one emit point:** door writes are Fluent saves; middleware catches those *and*
+  bypass writes. Emitting from the doors too would double-nudge (spec §3.1).
+- **Why task-local:** the middleware sees only `Database`; the north star forbids
+  attaching anything to it. Task-locals flow with the transaction's task tree (spec §3.1,
+  §11.1). Routing order: collector present → collect; `inTransaction` → suppress+warn;
+  else emit.
+- **Why the header:** response-scoped metadata beside `X-FOS-Version`; VM baselines stay
+  byte-identical (D-L2-4). Deposit seam: executor → `Request.storage` → `buildResponse`
+  (spec §3.4; the read path derives its own set — `invalidateWrittenContainers` is
+  write-path code, not reusable as-is).
+- **Why re-register per response:** membership drift self-heals; no client-side bookkeeping.
+- **Namespace tier may sit dormant** in v1 (spec §3.3 honesty note) — its tests assert the
+  dispatcher contract, not end-to-end namespace traffic.
+- **In-place swap, never teardown**, for nudge refreshes: mirrors the shipped
+  `viewModelRefreshed` path (`ViewModelView.swift:432`); teardown flash is a defect for
+  live screens.
+
+---
+
+## File structure
+
+```
+Sources/FOSMVVM/
+  Protocols/LiveViewModel.swift            (new: marker)
+  Protocols/InvalidationChannel.swift      (new: channel + InvalidationEvent)
+  SwiftUI Support/InvalidationDispatcher.swift (new: internal dispatcher + token)
+  SwiftUI Support/SSEInvalidationChannel.swift (new: internal default channel + parser)
+  SwiftUI Support/MVVMEnvironment.swift    (mod: channel + invalidationBaseURL seams)
+  SwiftUI Support/ViewModelView.swift      (mod: live resolver path, gate, swap)
+  Macros/Macros.swift                      (mod: .live case + LiveViewModel conformance)
+Sources/FOSMVVMVapor/
+  LiveInvalidation/InvalidationHub.swift   (new: internal hub actor)
+  LiveInvalidation/InvalidationEmitMiddleware.swift (new: internal per-type middleware
+                                            + identity-set derivation)
+  LiveInvalidation/LiveTransaction.swift   (new: wrappers + task-local collector)
+  LiveInvalidation/InvalidationRoute.swift (new: SSE endpoint + framing)
+  Extensions/Application+LiveInvalidation.swift (new: useLiveInvalidation)
+  Extensions/Response+FOS.swift            (mod: attach X-FOS-Registrations)
+  Containment/…executor seam…              (mod: deposit registration set in Request.storage)
+Sources/FOSMacros/ViewModelMacro.swift     (mod: .live twin, conformance, diagnostic)
+Tests/… mirrors sources; macro tests in Tests/FOSMacrosTests (XCTest)
+```
+
+---
+
+### Task 1: Client vocabulary + environment seams (FOSMVVM)
+
+**Files:** Create `Sources/FOSMVVM/Protocols/LiveViewModel.swift`,
+`Sources/FOSMVVM/Protocols/InvalidationChannel.swift`;
+Modify `Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift` (URL package
+`invalidationBaseURL: URL? = nil` → stored resolved like `resourcesBaseURL` at `:81`;
+`invalidationChannel: (any InvalidationChannel)? = nil` init param);
+Test `Tests/FOSMVVMTests/Protocols/InvalidationChannelTests.swift`.
+
+- [ ] Write failing tests: a test channel conforms and yields
+  `.connected` / `.invalidated(Set<ModelIdentity>)` through `events()`;
+  `invalidationBaseURL` defaults to `serverBaseURL` and honors an override;
+  `MVVMEnvironment` accepts a channel (Swift Testing).
+- [ ] Verify fail → implement (spec §4 signatures + gate DocC verbatim) → verify pass.
+- [ ] `swiftformat . && swiftlint` → commit `feat(FOSMVVM): live-invalidation vocabulary + environment seams`.
+
+### Task 2: Identity-set derivation (FOSMVVMVapor)
+
+**Files:** Create `Sources/FOSMVVMVapor/LiveInvalidation/InvalidationEmitMiddleware.swift`
+(derivation half: mutated model → `Set<ModelIdentity>` by inverting registry containment —
+own identity + `.parent` refs + owning containers via relation `parentKey`, per spec §3.1);
+Test `Tests/FOSMVVMVaporTests/LiveInvalidation/IdentitySetDerivationTests.swift`
+(`withFluentTestApp`, harbor fixtures).
+
+- [ ] Failing tests (spec test group 3): Berth ⇒ {Berth, owning Dock}; Dock (contained by
+  Harbor apex fixture) ⇒ {Dock, Harbor}; pivot-model save covers `.siblings`; an
+  uncontained model ⇒ {self} only.
+- [ ] Verify fail → implement derivation (internal; no new public surface) → pass.
+- [ ] Commit `feat(FOSMVVMVapor): containment-derived invalidation identity sets`.
+
+### Task 3: Hub, emit middleware routing, liveTransaction, useLiveInvalidation (middleware half)
+
+**Files:** Create `InvalidationHub.swift` (internal actor: `emit(Set<ModelIdentity>)`,
+subscriber streams, bounded buffers; **owned by `Application.storage`** under a storage key —
+mirror the `TupleCacheKeysStore` pattern, `PlanExecutor.swift:58-59`),
+`LiveTransaction.swift` (public wrappers on
+`Vapor.Request`/`Application` + internal task-local collector),
+`Extensions/Application+LiveInvalidation.swift` (`useLiveInvalidation(on:)` — this task:
+registry sweep + future-registration hook + hub creation; route mount lands in Task 4);
+finish `InvalidationEmitMiddleware` routing. Modify the C4 registration path so
+`app.register(type, migration:)` adds middleware when enabled.
+Test `…/EmitMiddlewareTests.swift`, `…/LiveTransactionTests.swift` (`.serialized`,
+`app.asyncBoot()`).
+
+- [ ] Failing tests (groups 1–2): auto-commit door write emits post-save with the derived
+  set; bare `db.transaction {}` write emits nothing + warns once; `liveTransaction` flushes
+  the collected sets on commit; thrown `liveTransaction` emits nothing; enable-then-register
+  and register-then-enable both wire middleware.
+- [ ] Verify fail → implement (routing order: collector → `inTransaction` → emit; hub
+  injected at registration, never on `Database`; gate DocC on the two public wrappers) → pass.
+- [ ] Commit `feat(FOSMVVMVapor): invalidation hub + emit middleware + liveTransaction`.
+
+### Task 4: SSE endpoint + wire framing
+
+**Files:** Create `InvalidationRoute.swift`; extend `useLiveInvalidation(on:)` to mount
+`GET <group>/invalidations` streaming from the hub (heartbeat comments; overflow closes the
+stream — spec §3.2/§6). Test `…/InvalidationRouteTests.swift`.
+
+**Test infrastructure (decided):** long-lived streams exceed `app.test(...)` — build a
+**serve-on-port streaming harness in FOSTestingVapor** as part of this task (mirror
+`withFluentTestApp`'s shape: boot on an ephemeral port, hand the test a base URL, drain the
+stream via `URLSession.bytes` with a bounded read + timeout). The implementer is authorized
+to add that file; Task 6's round-trip test reuses it.
+
+- [ ] Failing tests (group 4 + §6 pins): connected stream receives a framed `data:` event
+  whose JSON array round-trips to the emitted set via `defaultDecoder`; heartbeats flow;
+  overflow closes; endpoint honors the passed `RoutesBuilder` group.
+- [ ] Verify fail → implement → pass → commit `feat(FOSMVVMVapor): SSE invalidation endpoint`.
+
+### Task 5: Registration-set deposit + X-FOS-Registrations header
+
+**Files:** Modify the plan executor seam (deposit the resolved roots + touched containers in
+`Request.storage`) and `Extensions/Response+FOS.swift` — add a **sibling of
+`addSystemVersion`** (`:63`) invoked from the centralized `buildResponse` (`:33`), so the
+header rides every served response the same way the version header does. Read path derives its own set
+(mirror `invalidateWrittenContainers`'s shape, `WriteRoute.swift:183-193` — net-new).
+Test `…/RegistrationHeaderTests.swift`.
+
+- [ ] Failing tests (group 5): a served GET carries the executed plan's set; a write-door
+  refresh carries the refreshed set; header value round-trips via
+  `defaultEncoder`/`defaultDecoder` (§6 pin); a response with no plan carries no header.
+- [ ] Verify fail → implement → pass → commit
+  `feat(FOSMVVMVapor): plan-derived registration sets on X-FOS-Registrations`.
+
+### Task 6: Default SSE client channel (FOSMVVM)
+
+**Files:** Create `SwiftUI Support/SSEInvalidationChannel.swift` (internal: `URLSession.bytes`,
+line parser, reconnect back-off, `.connected` on (re)open, `credentialHeaders()` at open);
+wire `MVVMEnvironment` `nil`-channel synthesis. Test
+`Tests/FOSMVVMTests/SwiftUI Support/SSEChannelParsingTests.swift` (parser coverage via
+`@testable`) + a round-trip test in `Tests/FOSMVVMVaporTests` against the Task 4 endpoint.
+
+- [ ] Failing tests (group 6): framing parse (data lines, comment heartbeats ignored,
+  multi-line events); `.connected` emitted on open and re-open; credential headers attach.
+- [ ] Verify fail → implement → pass → commit `feat(FOSMVVM): default SSE invalidation channel`.
+
+### Task 7: Dispatcher + freshness gate (FOSMVVM)
+
+**Files:** Create `SwiftUI Support/InvalidationDispatcher.swift` (internal `@MainActor`:
+exact + namespace tiers, token, re-registration replaces, reconnect sweep; owned by
+`MVVMEnvironment`, channel opens on first registration). Modify `ViewModelView.swift`:
+gate at the swap point (`incoming.vmId.freshness > current.vmId.freshness`), in-place swap
+for refresh arrivals, navigation (`query`/`fragment` change) bypasses the gate.
+Test `…/InvalidationDispatcherTests.swift`, `…/FreshnessGateTests.swift`.
+
+- [ ] Failing tests (groups 7–8): exact and namespace matching; token death unregisters;
+  re-registration replaces; sweep fires all; older-drops/newer-swaps (construction-order
+  freshness); navigation bypass; redundant self-nudge absorbed.
+- [ ] Verify fail → implement → pass → commit `feat(FOSMVVM): invalidation dispatcher + freshness gate`.
+
+### Task 8: `.live` delivery (FOSMacros + FOSMVVM resolver)
+
+**Files:** Modify `Sources/FOSMVVM/Macros/Macros.swift` (`case live` + gate DocC;
+`LiveViewModel` added to the `@attached(extension …)` conformances at `:31`),
+`Sources/FOSMacros/ViewModelMacro.swift` (private twin; emit `LiveViewModel` conformance;
+`.live`+`.clientHostedFactory` ⇒ diagnostic error), `ViewModelView.swift` (live path:
+read `X-FOS-Registrations` on each response, register/re-register via dispatcher; degrade
+to fetch-once when no channel). Tests: `Tests/FOSMacrosTests` expansion fixtures +
+diagnostic (XCTest); `Tests/FOSMVVMTests` delivery behavior (group 9).
+
+- [ ] Failing tests: expansion fixture shows `LiveViewModel` conformance; the combined-options
+  diagnostic fires; degraded no-channel bind fetches once; response header registers.
+- [ ] Verify fail → implement → pass → commit `feat: @ViewModel(options: [.live]) delivery`.
+
+### Task 9: Seam hardening + docs sweep
+
+**Files:** Test `Tests/FOSMVVMTests/SwiftUI Support/InvalidationSeamTests.swift` (first tests
+for `viewModelInvalidated` teardown + `viewModelRefreshed` in-place swap — group 10).
+Modify: `CHANGELOG.md` (feature entry; wire contracts noted as contracts, never shapes);
+arch doc §C9 → implemented status + this spec pointer; north star §5 delivery note.
+Post-merge obligation (recorded, not on-branch): `fosutilities-api-catalog-update` + plugin bump.
+
+- [ ] Write seam tests → verify → docs sweep → full suite green (`swift test`) →
+  `swiftformat . && swiftlint` → commit `test(FOSMVVM): invalidation seam hardening + docs sweep`.
+
+---
+
+**Execution notes:** work in a dedicated worktree (L1 practice); Opus subagents implement,
+per-task dual review (spec-compliance + code-quality), escalate to Fable only where rigor
+decides; suite must stay green after every task; access minimalism audited at Task 9
+(zero new `package`).
+
+---
+
+## Execution deviations (recorded)
+
+What the execution refined against the plan above — kept here (implementer prose), not in DocC.
+
+- **T3 BLOCKED → binding-site discovery.** Task 3's `liveTransaction` collector first failed:
+  bound *around* `db.transaction`, the task-local never reached the middleware because FluentKit's
+  async `transaction` bridges through an unstructured `Task` (`makeFutureWithTask`). The fix binds
+  the collector *inside* the closure `db.transaction` runs; both placements were spike-tested
+  (outer fails, inner passes). Folded into spec §3.1's "Binding site" bullet (commit a2b008f).
+- **Graph-sweep coverage.** `useLiveInvalidation` wires emit middleware for each registered
+  container's whole graph (container + contained types + `.siblings` pivots), `ObjectIdentifier`-
+  deduped so a doubly-reachable type (e.g. `Dock`, reached via its own registration and `Harbor`'s
+  contained side) gets exactly one middleware — a duplicate would double-emit (guard test in
+  `EmitMiddlewareTests.doubleReachedModelEmitsExactlyOnce`).
+- **Fix rounds' notable finds** (post-task hardening, each its own commit):
+  - **T6** — the SSE channel now validates HTTP status at open: a non-2xx response backs off
+    instead of spinning and never falsely signals `.connected`.
+  - **T7** — the dispatcher evicts a stale same-address registration entry (opportunistic
+    dead-entry prune), preventing a collision from resurrecting a dead token.
+  - **T8** — the capturing fetch overloads were tightened to `internal` (the seam was never
+    public surface); and the resolver's failed-refresh guard preserves the prior registration set
+    so a transient fetch error never deafens a live screen (the deaf-screen guard, spec §3.4).
+- **Test harness — `withServedFluentTestApp`.** Task 4 added a serve-on-an-ephemeral-port
+  streaming harness in FOSTestingVapor (long-lived SSE streams exceed `app.test(...)`). The name
+  is provisional, pending owner naming arbitration.
+- **FOSFoundation `package` symbol.** The one new `package` declaration in the whole layer:
+  `DataFetch.send(…capturingResponseHeader:)`, so the FOSMVVM live resolver can read
+  `X-FOS-Registrations` off the producing fetch. Zero new `package` in FOSMVVMVapor (Task 9 audit).

--- a/docs/superpowers/specs/2026-07-03-authorized-container-data-loading-architecture.md
+++ b/docs/superpowers/specs/2026-07-03-authorized-container-data-loading-architecture.md
@@ -432,7 +432,10 @@ existing response builder.
   `DataRequirement` sealed: pure public marker + internal walk face; foreign conformers boot-reject
   (D-C8-5, §3.5). Opening members later is additive; freezing them public was forever.
 
-### C9 — Live invalidation  ·  Layer 2  ·  **SPECIFIED@arc-level, detail DEFERRED**  ·  [proven prior art; L0 freshness]
+### C9 — Live invalidation  ·  Layer 2  ·  **IMPLEMENTED**  ·  [proven prior art; L0 freshness]
+
+Delivered as L2 — full design and reconciliation:
+[`2026-07-09-live-invalidation-l2-design.md`](2026-07-09-live-invalidation-l2-design.md).
 
 Slotted here only to fix its seams to this layer: the L2 emit fires on the container's `ModelIdentity`
 after commit (C8 write path); the dispatcher routes by `ModelIdentity` (exact) or `ModelNamespace`

--- a/docs/superpowers/specs/2026-07-03-live-viewmodel-invalidation-architecture.md
+++ b/docs/superpowers/specs/2026-07-03-live-viewmodel-invalidation-architecture.md
@@ -1,6 +1,6 @@
 # Live ViewModel Invalidation — Architecture (North Star)
 
-**Status:** Design / reconciliation. Not yet implemented.
+**Status:** Delivered — L0 (2026-07-03), L1 (2026-07-05), L2 (2026-07-09; see `2026-07-09-live-invalidation-l2-design.md`).
 **Date:** 2026-07-03
 **Author:** David Hunt (design), with Claude (reconciliation)
 **Scope:** FOSFoundation, FOSMVVM, FOSMVVMVapor, FOSMacros

--- a/docs/superpowers/specs/2026-07-09-live-invalidation-l2-design.md
+++ b/docs/superpowers/specs/2026-07-09-live-invalidation-l2-design.md
@@ -1,0 +1,439 @@
+# L2 — Live ViewModel Invalidation: emit, transport, dispatch, delivery
+
+**Date:** 2026-07-09
+**Status:** Approved by David (live session 2026-07-09); dual-reviewed (spec-document:
+Approved, all citations verified · FOSMVVM-discipline: Sound, no violations); review
+advisories reconciled (§11)
+**Parent:** `2026-07-03-live-viewmodel-invalidation-architecture.md` (the north star; §5 is this
+layer's arc-level design) · `2026-07-03-authorized-container-data-loading-architecture.md` §C9
+**Depends on:** L0 (`ModelIdentity`, `ModelNamespace`, `ViewModelId.Freshness`) · L1 C1–C8a
+(registry, engine+cache, provider auth, plans, `ResponseBodyFactory`, write doors) — all merged
+to `main` · the `client-credential-provider` branch (`ClientCredentialProvider`,
+`ClientCredentialMiddleware`) — assumed merged before L2 lands
+**Scope:** FOSMVVM, FOSMVVMVapor, FOSMacros, FOSTestingVapor
+
+---
+
+## 1. Problem
+
+FOSMVVM is request/response only. A screen that another actor can mutate — a collection, a
+dashboard — learns of the change only by re-issuing a request it has no reason to re-issue.
+L1 closed the *caller's* half (pass #2: a write door re-serves its own caller through the genuine
+GET pipeline). This layer closes the *other clients'* half (pass #1): after a committed mutation,
+every **other** bound client showing affected data refreshes — invisibly to the ViewModel author,
+who opts in with `@ViewModel(options: [.live])` and writes nothing else.
+
+The north star §5 locked the architecture: the server pushes an **identity nudge, never VM data**
+(a `ModelIdentity` set) over **SSE**; the client re-fetches through the normal
+fetch→localize→project pipeline; a **monotonic freshness gate** (`ViewModelId.Freshness`, wire key
+`fsh`, shipped in L0) drops stale arrivals. This spec turns §5 into contracts, reconciled against
+what L1 actually shipped.
+
+## 2. Scope & north-star reconciliation
+
+**v1 scope (session decisions, 2026-07-09):**
+
+- SwiftUI native clients only; a browser/WASM channel is deferred (§9).
+- Framework-first; the Harbor-graph fixtures (Pier/Dock/Berth) carry the proof. No consumer
+  app gates the arc.
+- Single server process; the in-memory hub is the seam a multi-instance fan-out plugs into
+  later (§9).
+- The SSE stream authenticates via `ClientCredentialProvider.credentialHeaders()` at
+  stream-open (`Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift`).
+- One spec (this document); the implementation plan stages the work.
+
+**Where the north star §5 drifted from shipped L1 — reconciled here:**
+
+1. **Pass #2 is shipped.** §5's "Emit — two altitudes" second altitude (post-write refresh to
+   the caller) landed with C8/C8a: the write doors commit, invalidate
+   (`invalidateWrittenContainers`, `Sources/FOSMVVMVapor/Containment/WriteRoute.swift:183`),
+   and re-serve through the read pipeline. **L2 is pass #1 only.**
+2. **`RefreshRequest` no longer exists** (removed by the factory generalization). Any §5-era
+   text referencing it re-roots on the shipped write doors and
+   `ResponseBodyFactory` (`Sources/FOSMVVM/Protocols/ResponseBodyFactory.swift:38`).
+3. **The type registry exists** (C4 migration-as-registration, `ModelNamespace →
+   RegisteredModel`) — L2's emit middleware and identity-set derivation ride it.
+4. **The client invalidation seam is richer than §5 assumed**: `invalidateBinding(_:)` /
+   `viewModelInvalidated` (teardown) and `viewModelRefreshed` (in-place swap) both exist in
+   `VMServerResolverView` (`Sources/FOSMVVM/SwiftUI Support/ViewModelView.swift:397`), untested.
+   L2 replaces the *internals* with per-registration dispatch, keeps `invalidateBinding(_:)` as
+   the manual escape hatch, and brings both seams under test (the §5 hardening obligation).
+
+## 3. Contract
+
+### 3.1 Server emit — one altitude, one broadcast point
+
+**A per-type Fluent `ModelMiddleware` is the only emit point.** The write doors do not emit:
+every door write is itself a Fluent save the middleware sees, and writes that bypass the doors
+(app code, background jobs) are equally covered — no write silently fails to notify.
+
+- **Boot wiring piggybacks C4.** `Application.useLiveInvalidation(on:)` (§4) enables the layer:
+  it sweeps the existing type registry and registers emit middleware for every registered model,
+  and sets the flag so later `app.register(type, migration:)` calls do the same. Either
+  call order works. The hub is **injected into each middleware at registration** — the north
+  star's hard rule; nothing is ever attached to `Database`.
+- **The hub** (internal actor, FOSMVVMVapor) receives `emit(Set<ModelIdentity>)` and fans out
+  to every connected SSE client (DEF-1: no per-client filtering). It is the seam behind which
+  multi-instance fan-out plugs in later.
+- **The identity set is derived, zero author code (D-L2-2).** For a mutated record: its own
+  `ModelIdentity` **plus the identities of the containers it belongs to**, derived by inverting
+  the C4 containment declarations — the registry knows `Dock` declared
+  `.children(\Dock.$berths)`; the middleware on `Berth` reads the owning `Dock` id off the
+  instance through the relation's parent key (feasibility verified:
+  `ChildrenProperty.parentKey` is public, `fluent-kit/Sources/FluentKit/Properties/
+  Children.swift:16`; C4's own code walks it at `Children.swift:203`). `.parent` relations are
+  read directly; `.siblings` membership is covered by the registered pivot model's own parents.
+  A model no container declares emits only its own identity. Saving a Berth of Dock X therefore
+  emits `{ModelIdentity(Berth, b), ModelIdentity(Dock, X)}` — field change, membership change,
+  and grant change all land on the container identity the north star's worked example requires.
+- **Post-commit discipline (D-L2-1).** `Database.inTransaction`
+  (`fluent-kit/Sources/FluentKit/Database/Database.swift:20`) splits the world:
+  - `inTransaction == false` — every shipped door write (auto-commit single saves,
+    `WriteRoute.swift:83`): middleware completion *is* post-commit → **emit immediately**.
+  - `inTransaction == true` — app-side `database.transaction { }`: Fluent exposes no commit
+    hook, and an early emit is not a wasted fetch but a **stale-forever** hazard (the nudged
+    client re-fetches pre-commit state and no second nudge ever comes). The middleware
+    **suppresses** the emit and logs one warning naming the model type. The sanctioned path is
+    `Request.liveTransaction { db in … }` / `Application.liveTransaction { db in … }` (§4),
+    which collects the identity sets produced inside the closure and flushes them to the hub
+    **only after the transaction commits**; a throw/rollback discards them. The wrapper hangs
+    on `Request`/`Application` because that is where the hub lives — never on `Database`.
+  - **The discriminator is a Swift task-local (pinned here — it brushes the no-`Database`
+    rule).** Both a bare `db.transaction { }` and a `liveTransaction { }` run with
+    `inTransaction == true`, yet the middleware must suppress in the first and collect in the
+    second — and a `ModelMiddleware` sees only the `Database`. `liveTransaction` installs a
+    **task-local collector** for the closure's duration; the middleware routes in order:
+    task-local collector present → **collect**; else `inTransaction` → **suppress + warn**;
+    else → **emit**. Task-locals flow with structured concurrency — ambient to the transaction's
+    task tree, attached to nothing, invisible in any API — honoring the north star's rule.
+  - **Binding site (spike-verified 2026-07-09):** the wrapper binds the collector **inside the
+    closure it hands `db.transaction`**, not around the transaction call. FluentKit's async
+    `transaction` bridges through an *unstructured* Task
+    (`fluent-kit/Sources/FluentKit/Concurrency/Database+Concurrency.swift:26`,
+    `eventLoop.makeFutureWithTask`), so an outer binding never reaches the middleware; bound
+    inside the closure, save→middleware propagation holds (both placements spike-tested — outer
+    fails, inner passes). Same mechanism, same contract; the discriminator's semantics are
+    unchanged.
+- **Accepted overlap:** the writing client receives pass #2's fresh response *and* its own
+  broadcast nudge → one redundant re-fetch, absorbed by the freshness gate. DEF-1's later
+  per-client filtering removes it.
+
+### 3.2 Wire nudge + SSE transport
+
+**Payload.** One SSE event per emit; the `data:` line is the emitted identity set — a JSON array
+of `ModelIdentity` in L0's frozen `Codable` form, produced by `JSONEncoder.defaultEncoder` and
+consumed by `JSONDecoder.defaultDecoder` (never a raw `JSONDecoder()` — the PL-5 lesson). No VM
+data, no event names, **no SSE `id:` field**: v1 deliberately opts out of `Last-Event-ID` replay
+because the missed-nudge story is reconnect ⇒ sweep (below), which makes server-side replay
+memory unnecessary.
+
+**Server endpoint (FOSMVVMVapor).** One `GET` route streaming `text/event-stream`, fed from the
+hub. It is *not* a `ServerRequest` — it returns no `ResponseBody`; it is infrastructure, like
+the resource routes. `useLiveInvalidation(on:)` mounts it on the passed `RoutesBuilder` so apps
+hang it on their auth-middleware group (the C8a/PL-4 pattern: middleware-only groups, no
+parallel auth door).
+
+- **Heartbeat:** periodic SSE comment lines (`:` keep-alive) so intermediaries don't cut idle
+  streams and dead clients are detected. Transport hygiene; no API surface.
+- **Slow-client policy:** each client stream has a bounded buffer; on overflow the server
+  **closes that stream**. Correctness is preserved by the reconnect sweep — no nudge is ever
+  silently dropped on an open, healthy stream.
+
+**Client channel (FOSMVVM).** The DIP seam, exactly as the north star locked it:
+`MVVMEnvironment.invalidationChannel: (any InvalidationChannel)?` — `nil` synthesizes the
+default SSE channel (the sanctioned single-injected-dependency existential). The URL derives
+the way resources already do (`MVVMEnvironment.swift:81`, `resourcesBaseURL ?? serverBaseURL`):
+a `invalidationBaseURL: URL? = nil` sibling on the URL package; the common case configures
+nothing.
+
+- **Consumption:** `URLSession.bytes`, line-parsed `text/event-stream`.
+- **Auth:** `ClientCredentialProvider.credentialHeaders()` attaches at stream-open. Mid-stream
+  credential rotation self-heals: the stream drops → reconnect re-consults the provider.
+- **Lifecycle:** the channel opens on the **first** dispatcher registration (an app with no
+  `.live` screens never opens a socket) and stays open for the app's foreground lifetime.
+- **Reconnect — the correctness cornerstone:** on every (re)connect after a drop, the channel
+  signals `connected` and the dispatcher fires **all current registrations** as if nudged. One
+  refresh sweep covers whatever was missed while disconnected; the freshness gate absorbs the
+  redundancy. This single rule is why the server keeps no replay buffer, no `Last-Event-ID`,
+  no per-client memory.
+
+**Reversibility (restated):** none of this surfaces in ViewModel/View API — swapping SSE for a
+WebSocket or long-poll later is a channel-internal change.
+
+### 3.3 Client dispatcher + freshness gate
+
+**The dispatcher** is one `@MainActor` object owned by `MVVMEnvironment`, created with the
+channel, internal. Two registration tiers (north star two-granularity):
+
+- exact — `[ModelIdentity: registrations]`
+- namespace — `[ModelNamespace: registrations]` (unbounded screens only, DEF-3)
+
+A **registration** is a token pairing one bound view with a re-fetch trigger. An incoming nudge
+fires exact matches plus namespace matches (every `ModelIdentity` carries its namespace
+component). The token's death (view disappears) unregisters. The reconnect sweep fires every
+registration.
+
+*Honesty note for review:* every shipped plan root kind (query-rooted, `.apex`) resolves to an
+**exact** identity, so the derived registration header (§3.4) may never carry a bare
+`ModelNamespace` in v1 — the namespace tier ships (it is small and the north star locked the
+design) but may sit dormant until a namespace-scoped plan kind exists. DEF-3 anticipated this
+("designed-for; only unbounded containers use it").
+
+**Nudge-triggered refresh is an in-place swap, never a teardown.** A live screen must not flash
+a `ProgressView` on every remote mutation. The trigger re-fetches through the normal pipeline
+and swaps the VM the way the shipped `viewModelRefreshed` path already does
+(`ViewModelView.swift:432`); the current VM stays visible until its replacement arrives.
+`invalidateBinding(_:)` (`Sources/FOSMVVM/SwiftUI Support/View.swift:84`) keeps its teardown
+semantics as the manual escape hatch, unchanged.
+
+**The freshness gate** guards the swap point in the resolver: an arriving VM replaces the
+current one **only if `incoming.vmId.freshness > current.vmId.freshness`**; an older response
+racing a newer one is dropped silently. The clock is L0's shipped
+`ViewModelId.Freshness` (`Sources/FOSMVVM/Protocols/ViewModelId.swift:143` — `Comparable`,
+birth-moment preserved across the wire, unforgeable internal `init`).
+
+**Freshness producer — deliberately unchanged.** The north star anticipated L2 might need to
+broaden `Freshness.init` access for a server-side producer. It does not: every served VM stamps
+`freshness = .now` at construction (`ViewModelId()`) during server projection, which *is* the
+version's birth moment. L2 adds only the consumer (the gate); no access broadening, no
+`package`/`@_spi` seam — a plan author should not re-open this.
+
+**Gate scoping (new, explicit):** the gate applies only to **same-request refreshes** —
+nudge-triggered re-fetches and pushed refreshes. A `query`/`fragment` change is navigation
+(different data, incomparable freshness) and bypasses the gate; today's `onChange(of: query)`
+path stays gate-free.
+
+### 3.4 `.live` delivery — the macro and the registration set
+
+**The registration set is server-derived from the executed plan (D-L2-3).** Every served
+response executed a `RecordLoadPlan`; its resolved roots plus touched containers are precisely
+the response's staleness surface — the *same set shape* the write path computes for cache
+invalidation (`WriteRoute.swift:183-193`). The read path derives it from its **own**
+`ResolvedRecordLoadPlan` (net-new derivation mirroring that shape — `invalidateWrittenContainers`
+itself is write-path code, not directly reusable). The executor **deposits the set in
+`Request.storage`** — the same request-scoped mechanism the container-record cache already
+rides — and the centralized `buildResponse` reads it there and attaches it as a **header
+(D-L2-4)**, beside the existing version header (`SystemVersion.httpHeader = "X-FOS-Version"`,
+`Sources/FOSMVVM/Versioning/SystemVersion.swift:31`). That deposit-and-read pair is the single
+new integration point on the shared serve surface. VM `Codable` shapes and version baselines
+stay byte-identical; only the bind resolver reads the header.
+
+- Zero author code; exact by construction; immune to drift.
+- **Each refresh re-registers the latest response's set** — a screen whose plan touched new
+  containers starts listening to them automatically.
+- A rooted plan yields exact identities; an unbounded plan would yield its `ModelNamespace`
+  (see the §3.3 honesty note).
+- The header is attached to every served response (the server does not know which clients are
+  live; the set is already in hand at serve time, the cost is bytes).
+
+**`@ViewModel(options: [.live])` synthesizes a marker conformance** — `LiveViewModel` — and
+nothing else. `ViewModelOptions` extends as built
+(`Sources/FOSMacros/ViewModelMacro.swift:48`, one case today). The resolver gains a live-aware
+path when `VM: LiveViewModel`:
+
+- on each arriving response: register its header set with the dispatcher (replacing the prior
+  registration), swap through the freshness gate;
+- on disappear: the registration token dies → unregistered;
+- no channel configured / stream down: degrades to today's fetch-once-on-appear — shipping a
+  screen non-live and adding `.live` later is purely additive (north star promise).
+
+**v1 constraint:** `.live` is server-hosted binding only. `.live` + `.clientHostedFactory` on
+one VM is a **macro diagnostic error** (a client-hosted VM has no server response to derive
+registrations from). Lifting it later is additive (§9).
+
+## 4. Public surface (signature-normative)
+
+Everything not listed here is `internal`: the dispatcher, the hub, the emit middleware, SSE
+framing/parsing, the registration token.
+
+```swift
+// ── FOSMacros ───────────────────────────────────────────────────────────────
+private enum ViewModelOptions: String {
+    case clientHostedFactory
+    case live                    // NEW — synthesizes LiveViewModel conformance;
+}                                // combined with .clientHostedFactory ⇒ diagnostic error
+
+// ── FOSMVVM ─────────────────────────────────────────────────────────────────
+/// Marker adopted via `@ViewModel(options: [.live])`; the bind resolver
+/// registers/refreshes such ViewModels through the invalidation dispatcher.
+public protocol LiveViewModel: RequestableViewModel {}
+
+/// One event from the server's invalidation stream.
+public enum InvalidationEvent: Sendable {
+    case connected                        // (re)connected — the dispatcher sweeps
+    case invalidated(Set<ModelIdentity>)  // one server emit
+}
+
+/// The transport seam (DIP). `nil` on MVVMEnvironment ⇒ the default SSE channel.
+public protocol InvalidationChannel: Sendable {
+    func events() -> AsyncStream<InvalidationEvent>
+}
+
+// MVVMEnvironment additions (mirroring the resourcesBaseURL idiom):
+//   invalidationChannel: (any InvalidationChannel)? = nil
+//   URL package: invalidationBaseURL: URL? = nil   // nil ⇒ serverBaseURL
+
+// ── FOSMVVMVapor ────────────────────────────────────────────────────────────
+public extension Vapor.Application {
+    /// Enables live invalidation: mounts the SSE endpoint on `routes` (hang it on
+    /// your auth-middleware group) and registers the emit middleware for every
+    /// registered container model — past and future registrations alike.
+    func useLiveInvalidation(on routes: any RoutesBuilder) throws
+}
+
+public extension Vapor.Request {
+    /// A Fluent transaction whose committed writes still nudge live clients:
+    /// identity sets produced inside the closure flush to the hub on commit and
+    /// are discarded on rollback. The sanctioned replacement for
+    /// `db.transaction { }` in live applications.
+    func liveTransaction<T: Sendable>(
+        _ closure: @Sendable @escaping (any Database) async throws -> T
+    ) async throws -> T
+}
+// + the same wrapper on Vapor.Application (background jobs).
+```
+
+## 5. Naming
+
+| Concept | Name | Rooting / legibility |
+|---|---|---|
+| macro option | `.live` | locked by north star; joins `clientHostedFactory` |
+| marker protocol | `LiveViewModel` | `RequestableViewModel`/`ViewModelView` family; leading "Live…" shape distinct from every "ViewModel…" symbol |
+| channel protocol | `InvalidationChannel` | shipped invalidation family (`invalidateBinding`, `viewModelInvalidated`, `invalidateContainerRecords`) |
+| channel event | `InvalidationEvent` | same family |
+| env seam | `invalidationChannel` / `invalidationBaseURL` | mirrors `resourcesBaseURL ?? serverBaseURL` idiom |
+| boot call | `useLiveInvalidation(on:)` | C8 `use` family (`useAppState`, `useApexContainerResolver`) |
+| tx wrapper | `liveTransaction { }` | distinct leading shape from Fluent's `transaction` |
+
+Rejected: `LiveRequestable` (authors face VMs, not requests); `LiveChannel` (names the feature,
+not the event); `invalidatingTransaction` (long confusable middle against
+`invalidateContainerRecords`).
+
+## 6. Wire contracts (frozen pre-1.0, like L0's `fsh`)
+
+- **Registration header:** `X-FOS-Registrations` — value: the derived identity set, JSON array
+  of `ModelIdentity` (L0 frozen encoding) via `JSONEncoder.defaultEncoder`. Joins
+  `X-FOS-Version` in `buildResponse`. Consumers treat it as opaque; the resolver is the only
+  reader.
+- **SSE endpoint:** `GET <group>/invalidations`, `Content-Type: text/event-stream`; events are
+  `data:`-only (JSON array of `ModelIdentity`); comment-line heartbeats; no `id:`/`event:`
+  fields in v1.
+- **Nudge payload:** the identity set only — never VM data, never a rendered fragment.
+
+## 7. Decisions
+
+| ID | Decision |
+|---|---|
+| D-L2-1 | In-transaction emits are **suppressed** (one warning); the sanctioned `liveTransaction` wrapper collects and flushes on commit. Rejected: emit-on-operation (stale-forever race, violates north star); `Database` decorator buffering (the prior-art regret the north star forbids). |
+| D-L2-2 | Invalidation identity sets are **derived from C4 containment** — zero author code, no drift. A declared override is deferred until a consumer needs one. |
+| D-L2-3 | A `.live` screen's registration set is **server-derived from the executed plan** and re-registered on every refresh. Rejected: client-declared (author obligation + drift); hybrid (no consumer yet). |
+| D-L2-4 | The set travels as a **response header** (`X-FOS-Registrations`) beside the version header. Rejected: a field on the encoded VM (baseline churn; response-scoped metadata inside model data). |
+| scope | SwiftUI-only v1 · framework-first · single server process · one spec · SSE auth via `ClientCredentialProvider` · `.live`+`.clientHostedFactory` = diagnostic. |
+
+## 8. Test groups
+
+1. **Emit / auto-commit** — a door write emits post-save; the set matches the fixtures (Berth
+   save ⇒ {Berth, owning Dock}); delete and create emit membership changes on the container.
+2. **Emit / transactions** — in-transaction save emits nothing + warns once; `liveTransaction`
+   flushes on commit; a thrown/rolled-back `liveTransaction` emits nothing.
+3. **Derivation** — `.parent`/`.children` inversion against the Harbor graph; pivot-model saves
+   cover `.siblings`; an uncontained model emits only itself.
+4. **Hub + SSE endpoint** — connected stream receives framed events; heartbeat lines flow;
+   buffer overflow closes the stream. (Plan-level: long-lived streams may exceed
+   `app.test(...)`; mind the async-boot gotcha — `app.asyncBoot()` for lifecycle handlers.)
+5. **Registration header** — served responses carry the executed plan's set; write-door
+   refreshes carry the refreshed set; the header round-trips through
+   `defaultEncoder`/`defaultDecoder`.
+6. **Client channel** — event-stream parsing; `connected` on (re)open; credential headers
+   attach at open; reconnect back-off.
+7. **Dispatcher** — exact and namespace matching; token death unregisters; re-registration
+   replaces; reconnect sweep fires all.
+8. **Freshness gate** — older-drops / newer-swaps; navigation (`query`/`fragment` change)
+   bypasses; the redundant self-nudge after a write is absorbed.
+9. **Delivery** — `.live` expansion fixture (XCTest, macro rule);
+   `.live`+`.clientHostedFactory` diagnostic; degraded no-channel behavior = fetch-once.
+10. **Seam hardening** — first tests for the shipped `viewModelInvalidated` teardown and
+    `viewModelRefreshed` in-place swap.
+
+## 9. Deferred
+
+- **DEF-1..3** (north star §10) stand: no server-side subscription filtering; no subtree
+  matching; namespace matching only for unbounded screens.
+- **DEF-L2-4 — multi-instance fan-out.** The hub is single-process; a cross-instance
+  propagation backend (e.g. a pub/sub bridge) plugs in behind `emit`.
+- **DEF-L2-5 — browser/WASM channel.** An `EventSource` consumer for Leaf/React/WASM clients;
+  the wire contract (§6) is already sufficient.
+- **DEF-L2-6 — `.live` for client-hosted ViewModels.** Requires a client-side registration
+  source; the diagnostic keeps the door closed, lifting it is additive.
+- **DEF-L2-7 — declared identity-set override** (from D-L2-2) and **author-added
+  registrations** (from D-L2-3), each waiting on a real consumer.
+
+## 10. Build order (plan handoff)
+
+Server emit (middleware + hub + wrapper) → transport (endpoint + client channel) → dispatcher +
+gate → delivery (macro + resolver + header). Plan via the `fosmvvm-planning` gate
+(design-first / DocC-first), then `superpowers:writing-plans`; subagent-driven TDD per L1
+practice. Suite baseline entering L2: green on `main` + `client-credential-provider`.
+
+## 11. Review reconciliation (2026-07-09)
+
+Both reviewers approved on the first pass; four advisories were folded in:
+
+1. **`liveTransaction` discriminator pinned** (spec-document reviewer) — the middleware's
+   collect-vs-suppress routing is a **task-local collector** installed by the wrapper
+   (§3.1); pinned in the spec, not left to the plan, because it brushes the north star's
+   no-`Database`-attachment rule.
+2. **Freshness producer non-change made explicit** (discipline reviewer) — L2 uses
+   construction-now stamping; the anticipated access-broadening is deliberately not needed
+   (§3.3).
+3. **`buildResponse` deposit seam named** (discipline reviewer) — the executor deposits the
+   registration set in `Request.storage`; `buildResponse` reads it there. The read path derives
+   its own set from its `ResolvedRecordLoadPlan`; `invalidateWrittenContainers` is write-path
+   code, not directly reusable (§3.4).
+4. **Citation anchors corrected** — `Freshness` at `ViewModelId.swift:143`.
+
+Standing (disclosed, not defects): the credential-branch merge precondition (header block);
+the possibly-dormant namespace tier (§3.3 honesty note).
+
+## 12. Implementation reconciliation (2026-07-09)
+
+What implementation refined against the contract above. Each item is a clarification, not a
+change of decision.
+
+- **§3.1 — middleware coverage is the registered GRAPH.** `useLiveInvalidation` wires an emit
+  middleware for each registered container's whole graph — the container itself, every contained
+  type, and every `.siblings` pivot — deduped by `ObjectIdentifier` so a type reachable through
+  several descriptors gets exactly one middleware (`Application+LiveInvalidation.swift`
+  `registerInvalidationEmitMiddleware`). This is required by the Berth contract: FluentKit
+  type-filters `ModelMiddleware` per concrete model, so each covered type needs its own instance,
+  and an *erased* middleware would sever the task-local the collect-vs-suppress routing rides
+  (the T3 binding-site finding; reviewer-ruled sound).
+- **§3.1 — binding-site amendment already in-spec.** The "bind the collector inside the closure
+  `db.transaction` runs, not around the call" refinement (commit a2b008f) is folded into §3.1's
+  "Binding site" bullet — cross-reference only, no new text.
+- **§3.2 / §6 — the SSE `: open` comment preamble.** The stream opens with one SSE comment line
+  because Vapor flushes response headers only with the first body byte; the preamble forces the
+  header flush (and the client's `.connected`) at open rather than at first nudge. Ruled within
+  the frozen §6 contract — comments are not events (no `data:`, no `id:`/`event:`), so no
+  representation was pinned that a consumer could parse.
+- **§3.4 — supplemental-hook-only containers are outside v1.** The deposited registration set is
+  derived from the executed plan's tuples only; a container touched *solely* by a
+  `SupplementalRecordLoading` hook is outside the v1 registration surface (mirrors the internal
+  note at `PlanExecutor.swift` `depositRegistrationSet`). A screen depending on such a container
+  self-heals on the next `.connected` sweep; a declared override (DEF-L2-7) covers it when a
+  consumer needs it.
+- **§4 — exactly one `package` symbol.** The whole layer added a single `package` declaration:
+  `DataFetch.send(…capturingResponseHeader:)` (FOSFoundation), so FOSMVVM's live resolver can read
+  `X-FOS-Registrations` off the very fetch that produced the ViewModel — the why-required
+  statement lives at the declaration (`DataFetch.swift`). Everything else held `internal`; zero
+  `package` in FOSMVVMVapor.
+- **§3.4 — failed refreshes preserve the prior registration set.** A failed re-fetch returns
+  `(nil, [])`; the resolver's guard covers both the swap and the re-registration, so the screen
+  keeps its stale data AND keeps listening with the prior set. `[]` re-registers (deafening the
+  screen until the next sweep) only on a genuinely-empty *successful* response — never on the
+  error path (`VMServerResolverView.refreshInPlace`).
+- **§3.2 — `.connected` fires on the FIRST open, not only on re-opens after a drop.** The channel
+  emits `.connected` at the initial connection as well, deliberately: it closes the serve→subscribe
+  race window (a nudge emitted between a screen's first serve and its subscription would otherwise be
+  lost), because the initial `.connected` sweep re-fetches every current registration. The cost is one
+  extra gated fetch at first appearance, which the freshness gate absorbs as redundant.

--- a/docs/superpowers/specs/2026-07-09-live-invalidation-l2-design.md
+++ b/docs/superpowers/specs/2026-07-09-live-invalidation-l2-design.md
@@ -437,3 +437,7 @@ change of decision.
   race window (a nudge emitted between a screen's first serve and its subscription would otherwise be
   lost), because the initial `.connected` sweep re-fetches every current registration. The cost is one
   extra gated fetch at first appearance, which the freshness gate absorbs as redundant.
+- **§3.2 — the default channel is Darwin-only.** swift-corelibs FoundationNetworking provides no
+  async `URLSession.bytes`, so Linux/WASI clients get no synthesized channel and degrade to
+  fetch-once — consistent with the v1 SwiftUI-native client scope; a custom `InvalidationChannel`
+  remains the door for those platforms.


### PR DESCRIPTION
## What

One macro option keeps a bound screen current: after any committed mutation, every affected client re-fetches through the normal pipeline — no polling, no author plumbing.

```swift
@ViewModel(options: [.live])
public struct DocksViewModel: RequestableViewModel { ... }
```

Degrades to fetch-once when no live connection is configured, so adding `.live` to a shipped screen is purely additive.

## How (two commits)

**`feat(FOSMVVM)`** — the full L2 arc per the approved spec ([`2026-07-09-live-invalidation-l2-design.md`](docs/superpowers/specs/2026-07-09-live-invalidation-l2-design.md); §12 = implementation reconciliation):

- **Server:** containment-derived invalidation identity sets (zero author code) → per-type emit middleware (task-local collect / in-transaction suppress / emit) → in-memory hub → SSE endpoint. Public: `useLiveInvalidation(on:)`, `liveTransaction { }`.
- **Wire (frozen):** `X-FOS-Registrations` response header (opaque, resolver-only) carrying each response's plan-derived staleness surface; `data:`-only SSE nudges. Registration and cache invalidation share one `touchedContainers(of:)` traversal — equal by construction.
- **Client:** internal SSE channel (status-validated opens, capped backoff, credentials per open) → `@MainActor` dispatcher (weak registration tokens, reconnect sweep) → `ViewModelId.freshness` gate → in-place swap.
- **Macros:** `.live` + `LiveViewModel` conformance emission; `.live`+`.clientHostedFactory` is a diagnostic error.
- **Testing:** `withServedFluentTestApp` serve-on-port streaming harness (FOSTestingVapor).

**`fix(FOSMVVMVapor)`** — pre-existing: `X-FOS-Version` attached twice on every served response; `addSystemVersion` now `replaceOrAdd` + pin test. Separable.

## Verification

- Suite 585 → **668 tests / 118 suites green** (incl. post-rebase cold run); macro target 21 XCTest green.
- Every task dual-reviewed (spec-compliance + code-quality); final whole-branch review: **READY-with-notes, zero Criticals**, all notes closed.
- api-catalog audit exit 0; overload staleness gate clean; swiftformat/swiftlint clean.
- Catalog entries for the new surface: recorded follow-up (`fosutilities-api-catalog-update` + plugin bump).

## Note for CI

An unnamed **cold-first-run intermittent** was observed 3× during development (never on re-run, never under full capture, 40+ clean runs since; predates this branch's socket code). If this PR's cold CI run trips one test, its name is the missing datapoint — please preserve the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7gwMG1bmLjAMwpFYRzXca