### PR TITLE
docs(api-catalog): live-invalidation + FilterableDataModel entries; plugin 2.13.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/skills/fosutilities-api-catalog/SKILL.md
+++ b/.claude/skills/fosutilities-api-catalog/SKILL.md
@@ -50,6 +50,7 @@ line via the `fosutilities-api-catalog-update` skill.
 - Identifying *which* entity a model is (opaque `ModelIdentity`) — keying refresh or authorization by it → `FOSMVVM.md § Protocols`
 - Container-scoped authorization — declaring containers, grant verbs, who may touch which records → `FOSMVVM.md § Protocols`
 - Client-chosen sort or pagination on a request → `FOSMVVM.md § Protocols`
+- Live-updating screens that refresh when server data changes (`@ViewModel(options: [.live])`), or replacing the invalidation transport → `FOSMVVM.md § Protocols`, `FOSMVVMVapor.md § Live Invalidation`
 - Attaching auth headers (bearer token, API key) to every client request, rotation-safe → `FOSMVVM.md § Protocols`
 - Declaring the data a server-rendered body needs — composable factory, load requirements, rooted scopes → `FOSMVVM.md § Protocols`
 - Rendering a ViewModel in SwiftUI — app setup, view binding, previews, form views → `FOSMVVM.md § SwiftUI Support`
@@ -59,6 +60,8 @@ line via the `fosutilities-api-catalog-update` skill.
 - Projecting loaded records into a response body, or reading them through the projection context → `FOSMVVMVapor.md § Containment`, `§ Protocols`
 - Declaring Fluent containers and their relations, or mapping sort meanings to database columns → `FOSMVVMVapor.md § Containment`
 - Registering the container authorization provider, apex resolver, per-request app state, or a container migration → `FOSMVVMVapor.md § Containment`, `§ Extensions`
+- Filtering (narrowing) a large container load by the request's query → `FOSMVVMVapor.md § Containment`
+- Enabling server-pushed refresh at boot, or transactional writes that notify live clients → `FOSMVVMVapor.md § Live Invalidation`
 - The server-side write path — candidate set, field application, authorization provider → `FOSMVVMVapor.md § Protocols`
 - Projecting the database into ViewModels — resolvable requests, Fluent `DataModel` → `FOSMVVMVapor.md § Protocols`
 - Serving typed/localized errors, gating routes on client app version → `FOSMVVMVapor.md § Middleware`
@@ -66,4 +69,5 @@ line via the `fosutilities-api-catalog-update` skill.
 - Testing ViewModels — Codable round-trip, version stability, translation coverage → `FOSTesting.md § FOSTesting`
 - UI-testing SwiftUI ViewModel views (XCUITest hosting, operations, identifiers) → `FOSTesting.md § FOSTestingUI`, `FOSMVVM.md § SwiftUI Support`
 - Testing Vapor ServerRequests end to end, or Fluent-backed code against a fresh in-memory database → `FOSTesting.md § FOSTestingVapor`
+- Testing a streaming / SSE endpoint over a real socket → `FOSTesting.md § FOSTestingVapor`
 - Generating PDFs from SwiftUI views, choosing page size/orientation → `FOSReporting.md § PDF Rendering`

--- a/.claude/skills/shared/api-catalog/FOSMVVM.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVM.md
@@ -238,9 +238,10 @@ write them by hand; `ViewModelOptions` tunes `@ViewModel`'s output.
 Reach for this when: creating any View-Model — always the macro, never bare
 protocol conformance (the macro generates the `propertyNames()` localization
 bindings; hand conformance breaks OCP and silently unbinds `@LocalizedString`).
-Pass `options: [.clientHostedFactory]` to generate
-`ClientHostedViewModelFactory` support. Scaffolded by
-`fosmvvm-viewmodel-generator`.
+Tune the output through `options:`: `.clientHostedFactory` generates
+`ClientHostedViewModelFactory` support; `.live` makes the ViewModel refresh
+automatically when its server data changes (`LiveViewModel`, under Protocols).
+Scaffolded by `fosmvvm-viewmodel-generator`.
 
 ```swift
 @ViewModel
@@ -570,6 +571,44 @@ struct UserViewModel: RequestableViewModel, ModelIdentifiedViewModel {
 }
 ```
 
+### Refresh a screen when its server data changes — `LiveViewModel`
+Reach for this when: a bound screen must re-fetch automatically after another
+actor mutates the data it was served from — opt in with
+`@ViewModel(options: [.live])` (never conform `LiveViewModel` directly; the
+macro generates the conformance). Any view bound with `.bind()` then refreshes
+on each server change — no polling, no manual invalidation. Where no live
+connection is configured the ViewModel behaves exactly like a non-live one
+(fetch once on appear), so adding `.live` to a shipped screen is purely
+additive. The server half lives in `FOSMVVMVapor.md § Live Invalidation`.
+
+```swift
+@ViewModel(options: [.live])
+public struct DocksViewModel: RequestableViewModel { /* ... */ }
+```
+
+### Replace the live-invalidation transport — `InvalidationChannel` / `InvalidationEvent`
+Reach for this when: the standard live-invalidation transport won't do (a shared
+push socket, a custom connection) and you must supply your own — conform a
+`Sendable` type whose `events()` yields an `InvalidationEvent` stream and hand it
+to `MVVMEnvironment(invalidationChannel:)`. Yield `.connected` each time your
+transport (re)establishes — FOSMVVM refreshes every live screen — and
+`.invalidated` with each identity set the server pushes. Most apps never conform
+this: leave `invalidationChannel` nil and FOSMVVM synthesizes the standard
+channel over the deployment URLs.
+Don't hand-wire per-screen refresh — one channel feeds every
+`@ViewModel(options: [.live])` screen at once.
+
+```swift
+struct MyChannel: InvalidationChannel {
+    func events() -> AsyncStream<InvalidationEvent> { myStream }
+}
+let env = MVVMEnvironment(
+    appBundle: .main,
+    invalidationChannel: MyChannel(),
+    deploymentURLs: deploymentURLs
+)
+```
+
 ### Own and authorize contained records — `Container` / `AuthorityFlow`
 Reach for this when: a model owns other records (a `Dock` owns its `Berth`s) and
 those records need authorized loading and live-invalidation membership. List what it
@@ -738,7 +777,10 @@ Reach for this when: setting up the `@main` App — register an
 `MVVMEnvironment` in the SwiftUI environment with per-`Deployment` server
 URLs; it also establishes the app's SystemVersion at startup. Missing
 deployment URLs throw `MVVMEnvironmentError` when a request resolves.
-Scaffolded by `fosmvvm-swiftui-app-setup`.
+For live-updating screens, `invalidationChannel:` overrides the invalidation
+transport (see `InvalidationChannel` under Protocols) and a `URLPackage`'s
+`invalidationBaseURL` overrides where the default channel connects (defaults to
+the server base URL). Scaffolded by `fosmvvm-swiftui-app-setup`.
 
 ```swift
 WindowGroup { RootView() }

--- a/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
@@ -299,6 +299,27 @@ extension Berth: SortableDataModel {
 }
 ```
 
+### Narrow a container load by the request's query — `FilterableDataModel`
+Reach for this when: a request should load only the records matching its query (a
+search box, a filtered list) instead of the whole container — conform the Fluent
+model and translate the request's own `ServerRequestQuery` (FOSMVVM's Protocols)
+to a Fluent `WHERE`, by hand, in `apply(filter:to:)`. The framework rides that
+filter into the one query it counts, paginates, and caches, so counts and windows
+reflect the narrowed set. `Filter` is the single query type this model narrows by —
+a request whose query is a different type loads the model unfiltered. Return the
+query unchanged when there's nothing to narrow by — never a silent match-nothing.
+Don't invent a filter vocabulary or leak column names to the wire — the request's
+query *is* the filter, and your Fluent columns stay server-side.
+
+```swift
+extension Berth: FilterableDataModel {
+    static func apply(filter: BerthQuery, to query: QueryBuilder<Berth>) -> QueryBuilder<Berth> {
+        guard let name = filter.dockName else { return query }
+        return query.filter(\.$dockName == name)   // your Fluent, your columns
+    }
+}
+```
+
 ### Register per-request app state for projections — `useAppState`
 Reach for this when: a projection needs session-derived display data ("signed in
 as…") that isn't a loaded record. Register one builder per `AppState` type in
@@ -323,6 +344,49 @@ one resolver per application — a second registration throws.
 ```swift
 try app.useApexContainerResolver { req in
     try await req.auth.require(User.self).harborIdentity
+}
+```
+
+## Live Invalidation
+
+Server-push refresh for `@ViewModel(options: [.live])` screens (FOSMVVM's
+`LiveViewModel`): enable it once at boot, and every committed change to a
+registered container model nudges connected clients to re-fetch. The moving parts
+behind it — the fan-out hub, the per-model emit middleware, and the SSE stream
+route — are all internal; the two calls below are the entire author-facing surface.
+
+### Enable server-push refresh at boot — `useLiveInvalidation()`
+Reach for this when: turning on live invalidation for the server — call once in
+`configure(_:)`, passing the route group clients authenticate against. Every
+registered container model (`register(_:migration:)`, see Extensions) then nudges
+connected clients to re-fetch after each committed change; registrations made
+before or after this call are both honored. Screens refresh only after a change
+commits, and a client with no live connection degrades to fetch-once — so enabling
+it is purely additive.
+Limitation: fan-out is single-process — one server instance notifies the clients
+connected to it. Enable exactly once — a second call throws at boot.
+
+```swift
+let authed = app.grouped(MyAuthMiddleware())
+try app.useLiveInvalidation(on: authed)
+```
+
+### Writes that notify live clients — `liveTransaction`
+Reach for this when: a mutation you run yourself must refresh live screens — wrap
+the writes in `req.liveTransaction { db in … }` (route handlers) or
+`app.liveTransaction { db in … }` (background jobs, other app-level work). Every
+write inside the closure nudges live clients if — and only if — the transaction
+commits; a throw rolls back and notifies no one. With live invalidation not
+enabled the wrapper is just a plain Fluent transaction.
+Don't reach for a bare `database.transaction { }` on a live model — FOSMVVM can't
+tell whether those writes commit, so it stays silent (and warns once). The
+framework's own guarded write path (`DataModelWriter`, see Protocols) already
+notifies; `liveTransaction` is for the writes you drive by hand.
+
+```swift
+try await req.liveTransaction { db in
+    dock.status = .closed
+    try await dock.save(on: db)
 }
 ```
 

--- a/.claude/skills/shared/api-catalog/FOSTesting.md
+++ b/.claude/skills/shared/api-catalog/FOSTesting.md
@@ -228,6 +228,30 @@ let berths = try await withFluentTestApp { app in
 }
 ```
 
+### Test a streaming / SSE endpoint over a real socket — `withServedFluentTestApp()`
+Reach for this when: a test must hold open a genuine HTTP connection that
+`app.test(...)` can't — a streaming response, a live-invalidation SSE feed.
+Configure the application in `configure` (register containers, enable live
+invalidation), then use the `Application` and the base `URL` handed to `body` to
+open a real socket to it. The server binds to `127.0.0.1` on an ephemeral port;
+each call owns a private in-memory SQLite database, a bound port, and a full
+lifecycle (always shut down), so tests stay isolated and run in parallel.
+Don't reach for `app.test(...)` for a stream — it drives the request in-process
+and cannot keep a socket open.
+
+```swift
+try await withServedFluentTestApp { app in
+    try app.register(Dock.self, migration: CreateDock())
+    try app.useLiveInvalidation(on: app.routes)
+} _: { app, baseURL in
+    let url = baseURL.appending(path: "invalidations")
+    let (bytes, _) = try await URLSession(configuration: .ephemeral).bytes(from: url)
+    for try await line in bytes.lines where line.hasPrefix("data:") {
+        break   // a connected client received a pushed nudge
+    }
+}
+```
+
 ### Serve one request through a fresh server — `VaporServerRequestTest`
 Reach for this when: testing a ViewModel factory end-to-end without owning any
 application configuration — each `test(request:locale:)` boots a fresh Vapor


### PR DESCRIPTION
## What

Post-merge catalog obligation for PR #116 (`.live` live invalidation), plus one stowaway gap.

- **New `§ Live Invalidation` section** (FOSMVVMVapor.md): `useLiveInvalidation`, `liveTransaction` — with honest limitation notes (single-process fan-out; bare-transaction writes are silent + warned once). Section prose names the hub / emit middleware / SSE route as internal so nobody hunts for them.
- **FOSMVVM.md § Protocols:** `LiveViewModel`, `InvalidationChannel`/`InvalidationEvent` (transport-override seam).
- **FOSTesting.md § FOSTestingVapor:** `withServedFluentTestApp` (real-socket streaming/SSE endpoint testing).
- **FOSMVVMVapor.md § Containment:** `FilterableDataModel` — uncatalogued public API from the paginated-search arc, entry written from source.
- **Freshened:** `@ViewModel`/`ViewModelOptions` now names `.live`; `MVVMEnvironment` points at `invalidationChannel:`/`invalidationBaseURL:`.
- **Reach-for index:** 4 new lines (live-updating screens; transactional writes that notify clients; query-filtered container loads; real-socket SSE testing).
- **Plugin 2.12.0 → 2.13.0** (consumers receive catalog updates only on a bump).

Deliberately absent: `ModelIdentity.registrationsHeader` — opaque, resolver-only by owner ruling; cataloguing it would invite client reads.

## Verification

`swift scripts/api-catalog-audit.swift`: **0 non-ignored gaps, 0 stale, exit 0** (DocC worklist: 74, unchanged — separate effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7gwMG1bmLjAMwpFYRzXca