### PR TITLE
CredentialRejectedError — credential rejections cross the wire as typed errors

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -112,6 +112,7 @@ Before hand-writing a helper, check whether it already exists — the catalog in
 - Semantic version comparison/parsing → `FOSFoundation.md § Versioning`
 - Typed model identifiers (never a raw `UUID`/`String` field) → `FOSFoundation.md § Data`
 - Declaring/localizing/encoding ViewModels, factories, requests → `FOSMVVM.md § Macros`, `§ Localization`, `§ Protocols`
+- Credential rejection / typed 401 recovery → `FOSMVVM.md § Protocols`
 - Form fields and input validation → `FOSMVVM.md § Forms`, `§ Validation`
 - SwiftUI binding/app setup, property versioning, deployment URLs → `FOSMVVM.md § SwiftUI Support`, `§ Versioning`
 - Vapor boot/Leaf, routes, Fluent factories, versioned middleware → `FOSMVVMVapor.md § Extensions`, `§ Vapor Support`, `§ Protocols`, `§ Middleware`

--- a/.claude/docs/FOSMVVMArchitecture.md
+++ b/.claude/docs/FOSMVVMArchitecture.md
@@ -571,7 +571,28 @@ When a `ServerRequestController` registers routes, it automatically applies the 
 
 ### ServerRequestError - Typed Error Responses
 
-Each `ServerRequest` can define a custom `ResponseError` type for structured error handling:
+**`ResponseError` is the operation's semantic error — NOT an HTTP-status mapping.**
+
+If there were no wire, the operation would be a local function call,
+and it would `throw` a well-defined Swift error.
+`ResponseError` **is** that error.
+`ServerRequestError` exists so the throw can happen *across the wire*:
+
+1. Server-side code `throw`s the typed error
+2. It rides the response body as `Codable` (encoded by `ErrorMiddleware`)
+3. The client's `processRequest` rethrows the **same typed error** —
+   as if the call had been local
+
+The HTTP status underneath is transport dressing the framework applies.
+It carries no result semantics, and nobody should read it back to
+interpret a result.
+
+**Design starts from the throw, never from the status:**
+
+- ✅ "What would this operation `throw` if it were a local call?" —
+  that error is the `ResponseError`
+- ❌ "What should a 401 become on the client?" —
+  status-first thinking; the wrong frame entirely
 
 ```swift
 public protocol ServerRequest {
@@ -617,7 +638,22 @@ Server returns response
 └────────────────────────────────┘
 ```
 
-The key insight: if the server returns JSON that can't decode as `ResponseBody` but CAN decode as `ResponseError`, that typed error is thrown. This works even when HTTP status is 200 (some APIs return errors with success status codes).
+The key insight: this decode chain is transport *plumbing*, not semantics. If the server returns JSON that can't decode as `ResponseBody` but CAN decode as `ResponseError`, that typed error is thrown — even when the HTTP status is 200. The status check exists only to route decoding down the error path; the client branches by **catching the typed case**, never by reading a status.
+
+**Never interpret results from HTTP statuses:**
+
+```swift
+// ❌ WRONG - status sniffing. A 401 is a raw transport number;
+// ANY failure can wear it, so the client learns nothing typed.
+catch DataFetchError.badStatus(401) {
+    refreshSessionAndRetry()
+}
+
+// ✅ RIGHT - the operation's thrown vocabulary crossed the wire; catch the case
+catch let error as LoginError where error.code == .sessionExpired {
+    refreshSessionAndRetry()
+}
+```
 
 #### Why Use Custom ServerRequestError?
 
@@ -851,7 +887,8 @@ struct LocalizedError: ServerRequestError {
 
 #### When to Use EmptyError
 
-Use `EmptyError` (the default) when:
+Use `EmptyError` (the default) when the operation, as a local call, would have
+nothing well-defined to throw:
 - The operation rarely fails
 - Failures are truly exceptional (network down, server crash)
 - No structured error response is expected from the server

--- a/.claude/docs/FOSMVVMArchitecture.md
+++ b/.claude/docs/FOSMVVMArchitecture.md
@@ -655,6 +655,40 @@ catch let error as LoginError where error.code == .sessionExpired {
 }
 ```
 
+#### The Framework's Own Typed Throws
+
+The middleware stack is itself a layer that can throw
+**before the operation runs** — a credential check, a version gate.
+
+FOS declares well-known typed errors for those rejections.
+The client-visible thrown vocabulary of `processRequest` is therefore:
+
+    the request's ResponseError  ∪  the framework's own well-known errors
+
+There is currently one such error: **`CredentialRejectedError`**.
+
+- Served by `ClientCredentialMiddleware` + FOS `ErrorMiddleware`.
+- Two caller-actionable meanings: `.missing` / `.invalid`.
+- Rethrown typed by `processRequest` — always thrown
+  **past** `requestErrorHandler`, never routed to it.
+- Decoded **before** the request's own `ResponseError`, so a
+  permissive `ResponseError` (even `EmptyError`) cannot swallow it.
+- The rejection happens before the operation runs, so
+  refresh-and-retry after recovery never duplicates effects.
+
+```swift
+do {
+    try await request.processRequest(mvvmEnv: mvvmEnv)
+} catch let error as CredentialRejectedError {
+    switch error.code {
+    case .missing: break // no credential was presented — check the
+                         // MVVMEnvironment's clientCredentialProvider
+    case .invalid: break // presented but refused — refresh the credential
+                         // and retry (safe: the operation never ran)
+    }
+}
+```
+
 #### Why Use Custom ServerRequestError?
 
 **1. Errors with Associated Values (Parameterized Messages)**

--- a/.claude/skills/fosmvvm-review/checks/cross-cutting.md
+++ b/.claude/skills/fosmvvm-review/checks/cross-cutting.md
@@ -46,6 +46,17 @@ static var modelNamespace: ModelNamespace { .init(stringLiteral: "User") }      
 ```
 **Detection:** Flag: (a) a `public`/`internal` `var`/`func` on a sealed identity/namespace/token type that returns `String`/`UUID` of its private storage; (b) a raw `String`/`UUID` parameter or stored property used as an identity/route/key/token where a typed value exists; (c) constructing an identity/namespace from a string literal rather than a type. Exempt: the single owner-scoped computed that *consumes* the string to build a typed value and never returns it.
 
+## Check: status-interpreted-as-result
+**Severity:** blocker
+**What:** Client code reading an HTTP status to interpret an operation's *result*. Statuses govern transport consequences only (logging, caching, retry/backoff); result semantics ride the typed error path — the server `throw`s a `ServerRequestError` and the client catches the typed case. Branching business behavior on a status number is the stringly-typed break applied to errors: any failure can wear a 401, so the client learns nothing typed. See [Architecture Patterns → Typed Errors Are the Operation's Throw](../../shared/architecture-patterns.md).
+**Anti-pattern:**
+```swift
+catch DataFetchError.badStatus(401) {
+    refreshSessionAndRetry()          // result semantics inferred from a transport number
+}
+```
+**Detection:** In non-test source, find `catch` clauses or `if`/`switch` branches keyed on a specific HTTP status (`DataFetchError.badStatus(<code>)`, `response.status == .<case>`, raw `401`/`403`/`404` comparisons) where the branch drives business behavior (retry with new credential, navigation, user-facing state). Exempt: pure transport consequences (structured logging, cache invalidation, generic backoff without semantic branching) and test assertions of the server's transport contract.
+
 ## Check: published-representation
 **Severity:** warning
 **What:** A sealed type's internal encoded shape (JSON keys, token format, byte/column layout) stated on a **public** surface — a DocC `///` comment, `CHANGELOG`, or `README`. Publishing the representation makes it a de-facto schema consumers parse or hand-forge, defeating the opacity and freezing an implementation detail. Public docs state the *contract* (opaque; `Codable` round-trips; stable within a major version), never the shape; pin the shape in an internal `//` comment + a forward-compat test.

--- a/.claude/skills/fosmvvm-review/checks/serverrequest.md
+++ b/.claude/skills/fosmvvm-review/checks/serverrequest.md
@@ -8,4 +8,24 @@ where:
 
 # ServerRequest Checks
 
-The positive pattern lives in the `fosmvvm-serverrequest-generator` skill. No review-only checks defined yet.
+The positive pattern lives in the `fosmvvm-serverrequest-generator` skill.
+
+## Reviewer Guidance
+
+- A `ResponseError` is the operation's *semantic* error — the well-defined Swift error the operation would `throw` if it were a local function call. `ServerRequestError` exists so that throw can happen across the wire (server throws → rides the response as `Codable` → the client's `processRequest` rethrows the same typed error). It is **not** an HTTP-status mapping; HTTP statuses are transport dressing and carry no result semantics. See [Architecture Patterns → Typed Errors Are the Operation's Throw](../../shared/architecture-patterns.md).
+
+## Check: responseerror-models-the-throw
+**Severity:** blocker
+**What:** A `ResponseError` must declare the operation's failure vocabulary as typed data — what the operation would `throw` locally — not mirror the transport. Two smells: (a) error cases named after HTTP statuses or transport categories rather than operation outcomes; (b) a `ResponseError` whose only content is a free-text `reason`/`message` `String`. A reason-only shape mirrors a middleware abort body, so *any* rejection decodes into it and the client cannot distinguish cases by type.
+**Anti-pattern:**
+```swift
+struct MyError: ServerRequestError {
+    let reason: String                       // free-text only — string-puns with any abort body
+}
+
+enum ErrorCode: String, Codable, Sendable {
+    case unauthorized401                     // status-named — transport leaked into semantics
+    case badRequest
+}
+```
+**Detection:** For each type conforming to `ServerRequestError` (excluding `EmptyError` and `ValidationError`): flag if (a) its only stored data is one or more free-text `String` fields (no `ErrorCode`-style enum, no typed associated data); or (b) its enum cases are named for HTTP statuses/transport categories (`unauthorized`, `forbidden`, `badRequest`, `notFound` with no operation noun, numeric-status suffixes) rather than operation outcomes (`duplicateContent`, `quotaExceeded`, `sessionExpired`).

--- a/.claude/skills/fosmvvm-serverrequest-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-serverrequest-generator/SKILL.md
@@ -127,10 +127,40 @@ try await updateRequest.processRequest(mvvmEnv: mvvmEnv)
 | HTTP Method | Determined by `action.httpMethod` (ShowRequest=GET, CreateRequest=POST, etc.) |
 | Request Body | `RequestBody` type, automatically JSON encoded via `requestBody?.toJSONData()` |
 | Response Body | `ResponseBody` type, automatically JSON decoded into `responseBody` |
-| Error Response | `ResponseError` type, automatically decoded when response can't decode as `ResponseBody` |
+| Error Response | `ResponseError` type — the operation's *thrown* error carried across the wire; `processRequest` rethrows it client-side (see below) |
 | Validation | `RequestBody: ValidatableModel` for write operations |
 | Body Size Limits | `RequestBody.maxBodySize` for large uploads (files, images) |
 | Type Safety | Compiler enforces correct types throughout |
+
+---
+
+## ResponseError Is the Operation's Throw, Not a Status Mapping
+
+If there were no wire, the operation would be a local function call that
+`throw`s a well-defined Swift error. `ResponseError` **is** that error.
+`ServerRequestError` (`Error, Codable, Sendable`) exists so the throw can
+happen *across the wire*:
+
+- The server-side handler `throw`s the typed error
+- It rides the response as `Codable` (via `ErrorMiddleware`)
+- The client's `processRequest` rethrows the **same typed error**,
+  as if the call had been local
+
+**Design from the throw, never from the transport:**
+
+- ✅ Ask: "what would this operation `throw` if it were local?" —
+  that error (usually an enum-carrying struct) is the `ResponseError`
+- ❌ Never ask: "what should a 401 / an HTTP status become?" —
+  statuses are transport dressing; they carry no result semantics
+- Clients branch by **catching the typed case** —
+  never by reading an HTTP status back
+
+**Why this protects encapsulation:** an HTTP status is a raw,
+publicly-mintable number — any failure can wear a 401, so routing result
+semantics on one is the stringly-typed encapsulation break (see SOLID /
+encapsulation in `CLAUDE.md`). The typed error IS the contract; the moment a
+client sniffs a status, the error vocabulary you declared stops being the
+only door.
 
 ---
 
@@ -229,9 +259,12 @@ From requirements already in context:
 
 From requirements already in context:
 - **ResponseBody type** (often a ViewModel, sometimes just an ID)
-- **ResponseError type** (custom error structure or EmptyError)
+- **ResponseError type** — ask "what would this operation `throw` if it were
+  a local call?"; that error is the `ResponseError` (`EmptyError` if nothing
+  well-defined). Never derive it from HTTP statuses.
 - **Success scenarios** (what indicates successful operation)
-- **Error scenarios** (known failure modes requiring structured errors)
+- **Error scenarios** (known failure modes the client must branch on —
+  each becomes a typed case the client catches)
 
 ### Client Detection
 

--- a/.claude/skills/fosmvvm-serverrequest-generator/reference.md
+++ b/.claude/skills/fosmvvm-serverrequest-generator/reference.md
@@ -388,6 +388,19 @@ Available size units:
 - `.mb(_ count: UInt)` - Megabytes (× 1,048,576)
 - `.gb(_ count: UInt)` - Gigabytes (× 1,073,741,824)
 
+### Custom ResponseError — Design From the Throw
+
+`ResponseError` is the operation's *semantic* error — the well-defined Swift
+error the operation would `throw` if it were a local function call.
+`ServerRequestError` (`Error, Codable, Sendable`) makes that throw
+wire-capable: the controller throws it, `ErrorMiddleware` encodes it into the
+response, and the client's `processRequest` rethrows the same typed error.
+
+It is **NOT an HTTP-status mapping**:
+- never design an error case from a status ("what should a 401 become?")
+- never have a client read a status to interpret a result —
+  clients branch by catching the typed case
+
 ### Custom ResponseError - Pattern 1: Associated Values
 
 For errors with dynamic data in messages, use `LocalizableSubstitutions`:
@@ -539,7 +552,7 @@ do {
 - [ ] Extends correct protocol (ShowRequest, CreateRequest, UpdateRequest, DeleteRequest)
 - [ ] RequestBody has all fields client needs to send
 - [ ] ResponseBody contains what client needs back (often a ViewModel)
-- [ ] ResponseError defined if operation has known failure modes (use EmptyError otherwise)
+- [ ] ResponseError answers "what would this operation throw locally?" (EmptyError if nothing well-defined) — never derived from an HTTP status
 - [ ] Stubbable conformance for testing
 - [ ] ValidatableModel on RequestBody (for write operations)
 - [ ] `maxBodySize` set on RequestBody if handling large uploads (files, images, etc.)
@@ -557,7 +570,7 @@ do {
 - [ ] MVVMEnvironment configured once at app/tool startup
 - [ ] Uses `request.processRequest(mvvmEnv:)` - NO baseURL/headers per-call
 - [ ] Handles response via `request.responseBody`
-- [ ] Catches custom `ResponseError` type if defined
+- [ ] Catches custom `ResponseError` type if defined (branches on the typed case, never on an HTTP status)
 - [ ] Generic error fallback for unexpected errors
 
 ### WebApp Bridge (if needed)

--- a/.claude/skills/fosmvvm-serverrequest-test-generator/SKILL.md
+++ b/.claude/skills/fosmvvm-serverrequest-test-generator/SKILL.md
@@ -102,11 +102,12 @@ for locale in [en, es] {
     }
 }
 
-// ✅ RIGHT - Test error responses
+// ✅ RIGHT - Test error responses: assert the TYPED error (the operation's
+// thrown vocabulary), not just a status — statuses are transport, not results
 let badRequest = MyShowRequest(query: .init(userId: invalidId))
 try await app.testing().test(badRequest, locale: en) { response in
-    #expect(response.status == .notFound)
-    #expect(response.error != nil)
+    #expect(response.status == .notFound)          // transport contract
+    #expect(response.error?.code == .userNotFound) // the semantics
 }
 ```
 

--- a/.claude/skills/shared/api-catalog/FOSMVVM.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVM.md
@@ -340,7 +340,11 @@ Reach for this when: defining any client↔server interaction — every client
 by URL string. The pieces map onto HTTP: `action` (`.show`/`.create`/`.update`/
 `.replace`/`.delete`/`.destroy` → GET/POST/PATCH/PUT/DELETE), `Query`,
 `Fragment`, `RequestBody`, `ResponseBody`; a unique path is derived from the
-type names automatically. Typed server failures decode into `ResponseError`.
+type names automatically. `ResponseError` carries the operation's *thrown*
+error across the wire — the error the operation would throw as a local call;
+the server throws it and `processRequest` rethrows the same `Codable` error
+client-side. It is not an HTTP-status mapping: branch by catching the typed
+case, never by reading a status.
 Don't hand-build URLs or raw URLSession calls — that is the stringly-typed
 encapsulation break this hierarchy exists to prevent.
 

--- a/.claude/skills/shared/api-catalog/FOSMVVM.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVM.md
@@ -359,6 +359,22 @@ final class UserViewModelRequest: ViewModelRequest, @unchecked Sendable {
 }
 ```
 
+### Catch a credential rejection typed — `CredentialRejectedError`
+Reach for this when: a request to a protected route may be rejected before the
+operation runs — catch the typed error (`.missing` = no credential configured;
+`.invalid` = presented and refused → refresh and retry, safe because the
+operation never ran); never branch on an HTTP status. It always throws to the
+caller (never `requestErrorHandler`).
+
+```swift
+} catch let error as CredentialRejectedError {
+    switch error.code {
+    case .missing: ... // check the MVVMEnvironment's clientCredentialProvider
+    case .invalid: ... // refresh the credential and retry
+    }
+}
+```
+
 ### Placeholders for unused pieces — `EmptyQuery` / `EmptyFragment` / `EmptyBody` / `EmptyError`
 Reach for this when: a request has no query, fragment, body, or well-defined
 error — typealias the slot to the Empty type and the protocol's default

--- a/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
@@ -195,7 +195,9 @@ errors (ValidationError, a request's ResponseError) are encoded through the
 request's localizing encoder and returned as the response body, so the client
 decodes them back into the ServerRequest's typed `ResponseError` and throws
 them in context (form validation, for example); other errors degrade to
-status + reason, hiding details in release builds.
+status + reason, hiding details in release builds. An error that is both
+`Encodable` and `AbortError` is served with its typed body and its own status
+and headers (e.g. `CredentialRejectedError` → 401 + `WWW-Authenticate`).
 Don't keep Vapor's stock ErrorMiddleware — it flattens typed ResponseErrors
 into plain-text reasons the client cannot decode.
 
@@ -221,13 +223,11 @@ it). Supply the rule as a `ServerCredentialVerifier` (throw to reject, return
 to admit); the stock `BearerCredentialVerifier` extracts `Authorization:
 Bearer` and asks your `isValid` closure (compare digests or constant-time —
 never `==` on raw secrets). Missing or invalid → 401 with `WWW-Authenticate`.
-Limitation: a rejection reaches a FOSMVVM client as a transport-level
-bad-status error (401), not the request's typed `ResponseError` — a known gap
-in the errors-are-data model (a `ResponseError` is the operation's *thrown*
-error crossing the wire; statuses carry no result semantics), so never build
-client branching on the 401 itself. Also, a `ResponseError` that decodes from
-any JSON body (e.g. `EmptyError`) swallows the 401 entirely; give protected
-requests an error type with a required field absent from rejection bodies.
+A rejection reaches a FOSMVVM client as the typed `CredentialRejectedError`
+(requires FOS `ErrorMiddleware.default`, the documented configuration) — catch
+it, never branch on the 401. Verifiers throw it directly (code + challenge);
+any other verifier throw is wrapped as `.invalid`; a thrown `CancellationError`
+propagates unchanged, never as `.invalid`.
 
 ```swift
 let protected = app.grouped(ClientCredentialMiddleware(

--- a/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
@@ -222,10 +222,12 @@ to admit); the stock `BearerCredentialVerifier` extracts `Authorization:
 Bearer` and asks your `isValid` closure (compare digests or constant-time —
 never `==` on raw secrets). Missing or invalid → 401 with `WWW-Authenticate`.
 Limitation: a rejection reaches a FOSMVVM client as a transport-level
-bad-status error (401), not the request's typed `ResponseError` — and a
-`ResponseError` that decodes from any JSON body (e.g. `EmptyError`) swallows
-the 401 entirely; give protected requests an error type with a required field
-absent from rejection bodies.
+bad-status error (401), not the request's typed `ResponseError` — a known gap
+in the errors-are-data model (a `ResponseError` is the operation's *thrown*
+error crossing the wire; statuses carry no result semantics), so never build
+client branching on the 401 itself. Also, a `ResponseError` that decodes from
+any JSON body (e.g. `EmptyError`) swallows the 401 entirely; give protected
+requests an error type with a required field absent from rejection bodies.
 
 ```swift
 let protected = app.grouped(ClientCredentialMiddleware(

--- a/.claude/skills/shared/api-catalog/FOSTesting.md
+++ b/.claude/skills/shared/api-catalog/FOSTesting.md
@@ -196,7 +196,9 @@ Reach for this when: verifying a route serves a typed ServerRequest —
 `app.testing().test(request, locale:)` derives the path, HTTP method, query
 string, and version/locale headers from the request type, and hands the
 callback a `TestingServerRequestResponse` carrying the status, headers, decoded
-`ResponseBody`, and decoded `ResponseError`. Scaffolded by
+`ResponseBody`, and decoded `ResponseError`. It also carries a typed
+`credentialRejection` — assert credential rejections on it, never on the status
+alone; `error` is nil when a rejection decoded. Scaffolded by
 `fosmvvm-serverrequest-test-generator`.
 Don't hand-build paths with `app.test(.GET, "/my_request?...")` — that is the
 stringly-typed break the ServerRequest hierarchy exists to prevent.

--- a/.claude/skills/shared/architecture-patterns.md
+++ b/.claude/skills/shared/architecture-patterns.md
@@ -171,6 +171,40 @@ Each error scenario is a **UX design decision**, not a type system problem:
 
 ---
 
+## Typed Errors Are the Operation's Throw, Not a Status Mapping
+
+If there were no wire, the operation would be a local function call that
+`throw`s a well-defined Swift error. A request's `ResponseError` **is** that
+error — `ServerRequestError` (`Error, Codable, Sendable`) exists so the throw
+can happen *across the wire*: the server throws it, it rides the response as
+`Codable`, and the client's `processRequest` rethrows the same typed error,
+as if the call had been local.
+
+The HTTP status underneath is transport dressing.
+It carries no result semantics — nobody reads it back.
+
+**Wrong (status brain):**
+```swift
+// A 401 is a raw transport number — ANY failure can wear it.
+// Status sniffing is the stringly-typed break applied to errors.
+catch DataFetchError.badStatus(401) {
+    refreshSessionAndRetry()
+}
+```
+
+**Right (throw brain):**
+```swift
+// The vocabulary was declared where it belongs — on the operation's error
+catch let error as LoginRequest.ResponseError where error.code == .sessionExpired {
+    refreshSessionAndRetry()
+}
+```
+
+**Design test:** never ask "what should a 401 decode into?" —
+ask "what would this operation throw if it were local?"
+
+---
+
 ## Type Safety Means You Already Know
 
 In Swift, you know the types at compile time. Don't write code that "discovers" types at runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`CredentialRejectedError`** (FOSMVVM / FOSMVVMVapor). A credential rejection from
+  `ClientCredentialMiddleware` now crosses the wire as a typed, `Codable` error and is
+  rethrown by `processRequest(mvvmEnv:)` — catch it to recover (`.missing` /
+  `.invalid`); it always throws to the caller (never `requestErrorHandler`). Requires
+  FOS `ErrorMiddleware.default` (already the documented configuration). Retires the
+  `DataFetchError.badStatus(401)` client contract and the documented `EmptyError`
+  rejection-swallow. `TestingServerRequestResponse` gains `credentialRejection`.
+
+### Changed
+
+- **`ErrorMiddleware`**: an error conforming to both `Encodable` and `AbortError` is
+  now served with **both** its typed body and its own status/headers (previously such errors
+  were served `400 Bad Request`). Plain `Encodable` errors are unchanged.
 
 ## [0.6.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ErrorMiddleware`**: an error conforming to both `Encodable` and `AbortError` is
   now served with **both** its typed body and its own status/headers (previously such errors
   were served `400 Bad Request`). Plain `Encodable` errors are unchanged.
+- **`ClientCredentialMiddleware`**: any verifier throw that is not a
+  `CredentialRejectedError` is now wrapped as one (`.invalid`) — a custom
+  verifier that previously threw an `Abort` with its own status/reason now
+  rejects as `401` with the typed body. Throw `CredentialRejectedError`
+  directly to carry intent; `CancellationError` propagates unchanged.
 
 ## [0.6.0] - 2026-07-09
 

--- a/Sources/FOSMVVM/Protocols/CredentialRejectedError.swift
+++ b/Sources/FOSMVVM/Protocols/CredentialRejectedError.swift
@@ -1,0 +1,108 @@
+// CredentialRejectedError.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// The error thrown when a protected route rejects the request's credential
+///
+/// Routes grouped behind `ClientCredentialMiddleware` verify the presented
+/// credential before the operation runs. When verification rejects the
+/// request, this error crosses the wire and is rethrown by
+/// ``ServerRequest/processRequest(mvvmEnv:)`` — catch it to recover:
+///
+/// ```swift
+/// do {
+///     try await request.processRequest(mvvmEnv: mvvmEnv)
+/// } catch let error as CredentialRejectedError {
+///     switch error.code {
+///     case .missing: break // no credential was presented — check the
+///                          // MVVMEnvironment's clientCredentialProvider
+///     case .invalid: break // presented but refused — refresh the credential
+///                          // and retry (safe: the operation never ran)
+///     }
+/// }
+/// ```
+///
+/// The rejection happens **before** the operation runs, so retrying after
+/// recovery never duplicates the operation's effects.
+///
+/// This error always throws to the call site — it is never routed to
+/// ``MVVMEnvironment/requestErrorHandler``.
+public struct CredentialRejectedError: ServerRequestError {
+    /// Why the credential seam rejected the request
+    ///
+    /// `.missing` — no credential accompanied the request; typically the client
+    /// has no `ClientCredentialProvider` configured (or it returned no headers).
+    /// `.invalid` — a credential was presented and the server's verifier refused
+    /// it; refresh the credential and retry.
+    public enum Code: String, Codable, Sendable {
+        case missing
+        case invalid
+    }
+
+    /// Why the request was rejected
+    public let code: Code
+
+    /// The authentication challenge the verifier answers with (for example
+    /// `"Bearer"`), used server-side to dress the response's
+    /// `WWW-Authenticate` header. Never crosses the wire — always `nil` on
+    /// a decoded value.
+    public let challenge: String?
+
+    /// Creates the rejection thrown by a `ServerCredentialVerifier`
+    ///
+    /// - Parameters:
+    ///   - code: Why the request was rejected
+    ///   - challenge: The scheme for the response's `WWW-Authenticate`
+    ///     header (default: none)
+    public init(code: Code, challenge: String? = nil) {
+        self.code = code
+        self.challenge = challenge
+    }
+
+    // swiftformat:disable docComments
+    // Wire envelope — INTERNAL detail; never publish in DocC/CHANGELOG/README.
+    // The discriminator key + fixed value make the decode strict: init(from:)
+    // fails unless both match, so nothing puns into (or out of) this type.
+    // Shape pinned by CredentialRejectedErrorTests.forwardCompat.
+    private enum CodingKeys: String, CodingKey {
+        case discriminator = "__fosServerError"
+        case code
+    }
+
+    // swiftformat:enable docComments
+
+    private static let discriminatorValue = "credentialRejected"
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard try container.decode(String.self, forKey: .discriminator) == Self.discriminatorValue else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .discriminator,
+                in: container,
+                debugDescription: "Not a credential rejection"
+            )
+        }
+        self.code = try container.decode(Code.self, forKey: .code)
+        self.challenge = nil
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Self.discriminatorValue, forKey: .discriminator)
+        try container.encode(code, forKey: .code)
+    }
+}

--- a/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
+++ b/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
@@ -110,38 +110,47 @@ public extension ServerRequest {
         }
 
         let headerValue: String?
-        if ResponseBody.self == EmptyBody.self {
-            // An `EmptyBody` response carries no meaningful content, so its media type is irrelevant.
-            // Fetch it as `String` (the one decode path that accepts ANY 2xx body) with the
-            // received-MIME check disabled, discard the body, and synthesize the empty response. This
-            // round-trips against a server that answers `application/json` `{}` (`buildResponse`) AND
-            // one that answers `text/plain`/empty (a plain REST API) — neither type is
-            // enforced, because there is nothing to type. A non-2xx still decodes the typed
-            // `ResponseError` via `errorType`, unchanged.
-            let (_, captured): (String, String?) = try await dataFetch.send(
-                data: requestData,
-                to: requestURL(baseURL: baseURL),
-                httpMethod: action.httpMethod,
-                headers: requestHeaders,
-                locale: Locale.current,
-                checkReceivedMimeType: false,
-                errorType: Self.ResponseError.self,
-                capturingResponseHeader: ModelIdentity.registrationsHeader
-            )
-            responseBody = EmptyBody() as? ResponseBody
-            headerValue = captured
-        } else {
-            let (body, captured): (ResponseBody, String?) = try await dataFetch.send(
-                data: requestData,
-                to: requestURL(baseURL: baseURL),
-                httpMethod: action.httpMethod,
-                headers: requestHeaders,
-                locale: Locale.current,
-                errorType: Self.ResponseError.self,
-                capturingResponseHeader: ModelIdentity.registrationsHeader
-            )
-            responseBody = body
-            headerValue = captured
+        // WireError is decode plumbing — unwrap so callers catch the payload
+        // (the surface rejection or the request's typed ResponseError).
+        do {
+            if ResponseBody.self == EmptyBody.self {
+                // An `EmptyBody` response carries no meaningful content, so its media type is irrelevant.
+                // Fetch it as `String` (the one decode path that accepts ANY 2xx body) with the
+                // received-MIME check disabled, discard the body, and synthesize the empty response. This
+                // round-trips against a server that answers `application/json` `{}` (`buildResponse`) AND
+                // one that answers `text/plain`/empty (a plain REST API) — neither type is
+                // enforced, because there is nothing to type. A non-2xx still decodes the typed
+                // `ResponseError` via `errorType`, unchanged.
+                let (_, captured): (String, String?) = try await dataFetch.send(
+                    data: requestData,
+                    to: requestURL(baseURL: baseURL),
+                    httpMethod: action.httpMethod,
+                    headers: requestHeaders,
+                    locale: Locale.current,
+                    checkReceivedMimeType: false,
+                    errorType: WireError<Self.ResponseError>.self,
+                    capturingResponseHeader: ModelIdentity.registrationsHeader
+                )
+                responseBody = EmptyBody() as? ResponseBody
+                headerValue = captured
+            } else {
+                let (body, captured): (ResponseBody, String?) = try await dataFetch.send(
+                    data: requestData,
+                    to: requestURL(baseURL: baseURL),
+                    httpMethod: action.httpMethod,
+                    headers: requestHeaders,
+                    locale: Locale.current,
+                    errorType: WireError<Self.ResponseError>.self,
+                    capturingResponseHeader: ModelIdentity.registrationsHeader
+                )
+                responseBody = body
+                headerValue = captured
+            }
+        } catch let wire as WireError<Self.ResponseError> {
+            switch wire {
+            case .surface(let rejection): throw rejection
+            case .response(let error): throw error
+            }
         }
 
         return (responseBody, LiveRegistrations.decode(headerValue))
@@ -189,6 +198,10 @@ public extension ServerRequest {
                 headers: headers,
                 session: mvvmEnv.session
             ).registrations
+        } catch let rejection as CredentialRejectedError {
+            // A surface rejection always reaches the caller — recovery
+            // (refresh credential, retry) is a call-site decision.
+            throw rejection
         } catch let error as ServerRequestError {
             if let errorHandler = mvvmEnv.requestErrorHandler {
                 errorHandler(self, error)

--- a/Sources/FOSMVVM/Protocols/ServerRequest.swift
+++ b/Sources/FOSMVVM/Protocols/ServerRequest.swift
@@ -422,12 +422,17 @@ public enum ServerRequestBodySize: Equatable, Hashable, Sendable {
     }
 }
 
-/// A custom *Error* implementation that the server will send in the event of an error
+/// The error your operation throws, carried across the wire
 ///
-/// If the server encounters an error, it can return JSON in the response body.  If
-/// the response body cannot be converted into ``ServerRequest/responseBody->ResponseBody?``,
-/// then an attempt will be made to convert it to ``ServerRequest/ResponseError``.  The resulting
-/// error will be thrown by the requesting api.
+/// If there were no wire, your operation would be a local function call that
+/// `throw`s a well-defined Swift error. A ``ServerRequestError`` *is* that
+/// error — conforming makes the throw wire-capable: server-side code throws
+/// it, and the client's ``ServerRequest/processRequest(mvvmEnv:)`` rethrows
+/// the same typed error, as if the call had been local.
+///
+/// Design the type by asking "what would this operation throw?" — never from
+/// the transport ("what should a 401 become?"). HTTP statuses carry no result
+/// semantics; clients branch by catching the typed case.
 ///
 /// ## Simple Errors
 ///
@@ -514,7 +519,12 @@ public enum ServerRequestBodySize: Equatable, Hashable, Sendable {
 ///     // ...
 /// }
 ///
-/// // Type-safe error handling
+/// // Server side: throw it like any local error
+/// guard operationSucceeded else {
+///     throw MyError(code: .applicationFailed)
+/// }
+///
+/// // Client side: catch the same typed error
 /// do {
 ///     try await request.processRequest(mvvmEnv: mvvmEnv)
 /// } catch let error as MyError {

--- a/Sources/FOSMVVM/Protocols/WireError.swift
+++ b/Sources/FOSMVVM/Protocols/WireError.swift
@@ -1,0 +1,40 @@
+// WireError.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// swiftformat:disable docComments
+// The client-side decode order for a ServerRequest error body: the well-known
+// surface errors (closed, FOS-owned list — CredentialRejectedError today) are
+// tried STRICTLY before the request's own ResponseError. Passed to DataFetch
+// as the ONE existing `errorType:` — FOSFoundation stays untouched; add a
+// future surface error HERE, nowhere else.
+// `package`: the decode chain is defined once here and consumed by both the
+// client fetch path (FOSMVVM) and the test harness (FOSTestingVapor) — spec §3.4.
+package enum WireError<E: ServerRequestError>: Error, Decodable {
+    case surface(CredentialRejectedError)
+    case response(E)
+
+    // swiftformat:enable docComments
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let rejection = try? container.decode(CredentialRejectedError.self) {
+            self = .surface(rejection)
+        } else {
+            self = try .response(container.decode(E.self))
+        }
+    }
+}

--- a/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift
@@ -115,6 +115,9 @@ public final class MVVMEnvironment: @unchecked Sendable {
     public let invalidationChannel: (any InvalidationChannel)?
 
     /// A function that is called when there is an error processing a ``ServerRequest``
+    ///
+    /// Surface rejections (``CredentialRejectedError``) are never routed here — they
+    /// always throw to the caller.
     public let requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)?
 
     /// A custom ``URLSession``
@@ -226,7 +229,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///     only to replace the standard transport — see ``InvalidationChannel`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
-    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
+    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil). Surface rejections
+    ///      (``CredentialRejectedError``) are never routed here — they always throw to the caller.
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - loadingView: A function that produces a View that will be displayed while the ``ViewModel``
     ///     is being retrieved (default: [ProgressView](https://developer.apple.com/documentation/swiftui/progressview))
@@ -280,7 +284,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///     only to replace the standard transport — see ``InvalidationChannel`` (default: nil)
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
-    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
+    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil). Surface rejections
+    ///      (``CredentialRejectedError``) are never routed here — they always throw to the caller.
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - loadingView: A function that produces a View that will be displayed while the ``ViewModel``
     ///     is being retrieved (default: [ProgressView](https://developer.apple.com/documentation/swiftui/progressview))
@@ -363,7 +368,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
-    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
+    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil). Surface rejections
+    ///      (``CredentialRejectedError``) are never routed here — they always throw to the caller.
     public init(
         currentVersion: SystemVersion? = nil,
         appBundle: Bundle,
@@ -429,7 +435,8 @@ public final class MVVMEnvironment: @unchecked Sendable {
     ///   - deploymentURLs: The base URLs of the web service for the given ``Deployment``s
     ///   - session: An optional *URLSession* to use to process the request (default: *DataFetch.urlSessionConfiguration()*)
     ///   - requestErrorHandler: A function that can take action when an error occurs when resolving
-    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil)
+    ///      ``ViewModel`` via a ``ViewModelRequest`` (default: nil). Surface rejections
+    ///      (``CredentialRejectedError``) are never routed here — they always throw to the caller.
     public convenience init(
         currentVersion: SystemVersion? = nil,
         appBundle: Bundle,

--- a/Sources/FOSMVVM/SwiftUI Support/TabContent+Testing.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/TabContent+Testing.swift
@@ -17,10 +17,12 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
+// swiftformat:disable docComments
 // The wildcard in an @available list claims every UNLISTED platform at the
 // package floor — TabContent itself is tvOS 18 / watchOS 11 / visionOS 2, so
 // omitting those platforms is a floor-level lie that only an honest
 // device-platform compile exposes.
+// swiftformat:enable docComments
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public extension TabContent {
     /// Adds an identifier that can be used to identify the element in an XCUITest

--- a/Sources/FOSMVVMVapor/Extensions/CredentialRejectedError+Vapor.swift
+++ b/Sources/FOSMVVMVapor/Extensions/CredentialRejectedError+Vapor.swift
@@ -1,0 +1,39 @@
+// CredentialRejectedError+Vapor.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSMVVM
+import Vapor
+
+/// Dresses the rejection for the transport: `401 Unauthorized` with the
+/// verifier's authentication challenge (for example `WWW-Authenticate:
+/// Bearer`). The response *body* remains the typed error — FOSMVVM clients
+/// decode and rethrow it; the status exists for proxies, logs, and RFC 7235
+/// conformance, never for client branching.
+extension CredentialRejectedError: AbortError {
+    public var status: HTTPResponseStatus {
+        .unauthorized
+    }
+
+    public var headers: HTTPHeaders {
+        guard let challenge else { return [:] }
+        return ["WWW-Authenticate": challenge]
+    }
+
+    public var reason: String {
+        // Constant — a rejection reason must never echo the presented credential
+        "Credential rejected"
+    }
+}

--- a/Sources/FOSMVVMVapor/Middleware/ClientCredentialMiddleware.swift
+++ b/Sources/FOSMVVMVapor/Middleware/ClientCredentialMiddleware.swift
@@ -14,13 +14,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import FOSMVVM
 import Vapor
 
 /// Decides whether a request's presented credential admits it
 ///
 /// A ``ServerCredentialVerifier`` is the validity rule that ``ClientCredentialMiddleware``
 /// runs before each route in a protected group: return to admit the request, throw to
-/// reject it — typically `Abort(.unauthorized)`. Rejection reasons must **never** echo
+/// reject it — throw ``CredentialRejectedError`` (carrying its code + challenge) to
+/// reject; any other thrown error is wrapped by the middleware into
+/// `CredentialRejectedError(code: .invalid)`. Rejection reasons must **never** echo
 /// the presented credential back to the caller.
 ///
 /// The verifier is consulted **per request**, so a credential revoked or rotated on the
@@ -35,7 +38,9 @@ public protocol ServerCredentialVerifier: Sendable {
     /// Called once per request before the route runs.
     ///
     /// - Parameter headers: The HTTP headers the request presented
-    /// - Throws: To reject the request — typically `Abort(.unauthorized)`; the
+    /// - Throws: To reject the request — throw ``CredentialRejectedError``
+    ///     (carrying code + challenge); any other thrown error is wrapped by
+    ///     the middleware into `CredentialRejectedError(code: .invalid)`. The
     ///     rejection reason must not contain the presented credential
     func verify(headers: HTTPHeaders) async throws
 }
@@ -51,21 +56,10 @@ public protocol ServerCredentialVerifier: Sendable {
 ///
 /// ## Client-Side Contract
 ///
-/// On a FOSMVVM client, a rejection surfaces from `processRequest(mvvmEnv:)` as
-/// FOSFoundation's `DataFetchError.badStatus(httpStatusCode: 401)` — not as the
-/// request's typed `ResponseError` — so `MVVMEnvironment.requestErrorHandler` is
-/// bypassed and the error propagates directly to the caller. This contract requires
-/// an installed error serializer that forwards the `Abort`'s status and headers;
-/// FOS ``ErrorMiddleware`` (`.default(environment:)`) does.
-///
-/// Known limitation: a request whose `ResponseError` decodes from the rejection body
-/// swallows the 401 into a typed error instead. `EmptyError` **always** does — an
-/// empty struct's synthesized decode is a no-op, so it decodes from ANY valid-JSON
-/// rejection body (FOS ``ErrorMiddleware``'s JSON string and Vapor's stock JSON
-/// object alike). A pre-existing `DataFetch` property, noted here because this
-/// middleware is the first consumer depending on 401 visibility: a request that must
-/// observe the 401 needs a `ResponseError` with at least one required field absent
-/// from rejection bodies.
+/// On a FOSMVVM client, a rejection surfaces from
+/// `processRequest(mvvmEnv:)` as `CredentialRejectedError` — the same typed
+/// error whether the request's own `ResponseError` is `EmptyError` or a
+/// custom type. Catch it to recover; see ``CredentialRejectedError``.
 ///
 /// ## Example
 ///
@@ -88,7 +82,20 @@ public struct ClientCredentialMiddleware: AsyncMiddleware {
 
     public func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
         // Ensure that the presented credential admits the request
-        try await verifier.verify(headers: request.headers)
+        do {
+            try await verifier.verify(headers: request.headers)
+        } catch let rejection as CredentialRejectedError {
+            throw rejection
+        } catch is CancellationError {
+            // Cancellation is a control-flow signal, not a domain rejection —
+            // the "throw to reject" contract covers domain failures.
+            throw CancellationError()
+        } catch {
+            // The verifier contract is "throw to reject" — any throw is a
+            // rejection; custom verifiers throw CredentialRejectedError
+            // directly to carry richer intent (code, challenge).
+            throw CredentialRejectedError(code: .invalid)
+        }
 
         return try await next.respond(to: request)
     }
@@ -125,25 +132,19 @@ public struct ClientCredentialMiddleware: AsyncMiddleware {
 /// }
 /// ```
 public struct BearerCredentialVerifier: ServerCredentialVerifier {
+    private static let challenge = "Bearer"
+
     private let isValid: @Sendable (String) async -> Bool
 
     // MARK: ServerCredentialVerifier Protocol
 
     public func verify(headers: HTTPHeaders) async throws {
         guard let token = headers.bearerAuthorization?.token else {
-            throw Abort(
-                .unauthorized,
-                headers: ["WWW-Authenticate": "Bearer"],
-                reason: "Missing bearer credential"
-            )
+            throw CredentialRejectedError(code: .missing, challenge: Self.challenge)
         }
 
         guard await isValid(token) else {
-            throw Abort(
-                .unauthorized,
-                headers: ["WWW-Authenticate": "Bearer"],
-                reason: "Invalid bearer credential"
-            )
+            throw CredentialRejectedError(code: .invalid, challenge: Self.challenge)
         }
     }
 

--- a/Sources/FOSMVVMVapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/FOSMVVMVapor/Middleware/ErrorMiddleware.swift
@@ -29,6 +29,10 @@ import Vapor
 /// values will be localized before sending them  back to the client.  The client will then
 /// convert the response back to the *ServerRequest*'s *ResponseError* type and
 /// throw it for the client application to use.
+///
+/// An error that is both `Encodable` and `AbortError` is served with its typed body
+/// (localized through the request's encoder) AND its own status and headers. A plain
+/// `Encodable` error keeps the typed body with `400 Bad Request`.
 public final class ErrorMiddleware: AsyncMiddleware {
     /// Error-handling closure.
     private let closure: @Sendable (Request, any Error) -> (Response)
@@ -70,6 +74,27 @@ public extension ErrorMiddleware {
 
             // Inspect the error type and extract what data we can.
             switch error {
+            case let encodableAbort as any (Encodable & AbortError):
+                do {
+                    let encoder = try req.localizingEncoder
+
+                    (reason, errorData, status, headers, source) = try (
+                        "",
+                        encodableAbort.toJSONData(encoder: encoder),
+                        encodableAbort.status,
+                        encodableAbort.headers,
+                        .capture()
+                    )
+                } catch {
+                    (reason, errorData, status, headers, source) = (
+                        encodableAbort.reason,
+                        nil,
+                        encodableAbort.status,
+                        encodableAbort.headers,
+                        .capture()
+                    )
+                }
+
             case let encodable as any Encodable:
                 do {
                     let encoder = try req.localizingEncoder
@@ -152,7 +177,7 @@ public extension ErrorMiddleware {
                 var byteBuffer = req.byteBufferAllocator.buffer(capacity: 0)
                 if let errorData {
                     byteBuffer.writeBytes(errorData)
-                    headers.add(
+                    headers.replaceOrAdd(
                         name: HTTPHeaders.Name.contentType,
                         value: "application/json; charset=utf-8"
                     )

--- a/Sources/FOSTestingVapor/TestingServerRequestResponse.swift
+++ b/Sources/FOSTestingVapor/TestingServerRequestResponse.swift
@@ -30,6 +30,11 @@ public struct TestingServerRequestResponse<R: ServerRequest> {
     /// The received *ServerRequest/ResponseBody*, if any
     public let body: R.ResponseBody?
 
+    /// The received *CredentialRejectedError*, if the protected route rejected the
+    /// request's credential — assert rejections on this typed value, never on
+    /// `status` alone
+    public let credentialRejection: CredentialRejectedError?
+
     /// The received *ServerRequest/ResponseError*, if any
     public let error: R.ResponseError?
 
@@ -37,7 +42,21 @@ public struct TestingServerRequestResponse<R: ServerRequest> {
         self.status = response.status
         self.headers = response.headers
         self.body = try? response.body.fromJSON()
-        self.error = try? response.body.fromJSON()
+        // One decode chain, defined by WireError (FOSMVVM): the surface
+        // rejection is claimed first so a permissive ResponseError
+        // (EmptyError) can't swallow it.
+        let wire: WireError<R.ResponseError>? = try? response.body.fromJSON()
+        switch wire {
+        case .surface(let rejection):
+            self.credentialRejection = rejection
+            self.error = nil
+        case .response(let error):
+            self.credentialRejection = nil
+            self.error = error
+        case nil:
+            self.credentialRejection = nil
+            self.error = nil
+        }
     }
 }
 

--- a/Tests/FOSMVVMTests/Protocols/CredentialRejectedErrorTests.swift
+++ b/Tests/FOSMVVMTests/Protocols/CredentialRejectedErrorTests.swift
@@ -1,0 +1,73 @@
+// CredentialRejectedErrorTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+import Testing
+
+@Suite("CredentialRejectedError contract")
+struct CredentialRejectedErrorTests {
+    @Test("Round-trips through JSON: code preserved, challenge transient")
+    func roundTrip() throws {
+        let original = CredentialRejectedError(code: .invalid, challenge: "Bearer")
+        let decoded: CredentialRejectedError = try original.toJSON().fromJSON()
+
+        #expect(decoded.code == .invalid)
+        #expect(decoded.challenge == nil) // transient: never crosses the wire
+    }
+
+    @Test("Both codes round-trip")
+    func bothCodes() throws {
+        for code in [CredentialRejectedError.Code.missing, .invalid] {
+            let decoded: CredentialRejectedError =
+                try CredentialRejectedError(code: code).toJSON().fromJSON()
+            #expect(decoded.code == code)
+        }
+    }
+
+    @Test("Does NOT decode from bodies lacking the envelope")
+    func strictDecode() {
+        // Vapor's stock abort body, a plain reason string, an empty object,
+        // and a wrong discriminator VALUE must all fail — nothing puns into
+        // the rejection.
+        for body in [
+            #"{"error":true,"reason":"Unauthorized"}"#,
+            #""Invalid bearer credential""#,
+            "{}",
+            #"{"__fosServerError":"someOtherError","code":"invalid"}"#
+        ] {
+            let decoded: CredentialRejectedError? = try? body.fromJSON()
+            #expect(decoded == nil, "must not decode from: \(body)")
+        }
+    }
+
+    @Test("Unknown code value is rejected")
+    func unknownCode() {
+        let body = #"{"__fosServerError":"credentialRejected","code":"bogus"}"#
+        let decoded: CredentialRejectedError? = try? body.fromJSON()
+        #expect(decoded == nil)
+    }
+
+    @Test("Forward-compat: the committed wire form still decodes")
+    func forwardCompat() throws {
+        // INTERNAL representation pin (golden blob). The ONE place the envelope
+        // shape is asserted — see the maintainer comment beside CodingKeys.
+        let committedWireForm = #"{"__fosServerError":"credentialRejected","code":"invalid"}"#
+        let decoded: CredentialRejectedError = try committedWireForm.fromJSON()
+        #expect(decoded.code == .invalid)
+    }
+}

--- a/Tests/FOSMVVMTests/Protocols/WireErrorTests.swift
+++ b/Tests/FOSMVVMTests/Protocols/WireErrorTests.swift
@@ -1,0 +1,60 @@
+// WireErrorTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+@testable import FOSMVVM
+import Foundation
+import Testing
+
+private struct StrictError: ServerRequestError {
+    let errorCode: Int
+}
+
+@Suite("WireError decode precedence")
+struct WireErrorTests {
+    @Test("A rejection body decodes .surface — even when E is EmptyError")
+    func rejectionBeatsEmptyError() throws {
+        let rejection = try CredentialRejectedError(code: .invalid).toJSON()
+
+        let strict: WireError<StrictError> = try rejection.fromJSON()
+        guard case .surface(let error) = strict else {
+            Issue.record("Expected .surface, got \(strict)"); return
+        }
+        #expect(error.code == .invalid)
+
+        // EmptyError decodes from ANYTHING — the wrapper must claim the
+        // rejection FIRST (this retires the documented swallow).
+        let permissive: WireError<EmptyError> = try rejection.fromJSON()
+        guard case .surface = permissive else {
+            Issue.record("EmptyError swallowed the rejection"); return
+        }
+    }
+
+    @Test("A request-error body decodes .response")
+    func responseErrorPassesThrough() throws {
+        let wire: WireError<StrictError> = try #"{"errorCode":42}"#.fromJSON()
+        guard case .response(let error) = wire else {
+            Issue.record("Expected .response, got \(wire)"); return
+        }
+        #expect(error.errorCode == 42)
+    }
+
+    @Test("A body matching neither type fails to decode")
+    func neitherFallsThrough() {
+        let wire: WireError<StrictError>? = try? #"{"unrelated":true}"#.fromJSON()
+        #expect(wire == nil)
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift
+++ b/Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift
@@ -29,11 +29,19 @@
 //   • the Authorization parse edges are pinned: a lowercase `bearer` scheme admits;
 //     an empty token (`Bearer `) rejects,
 //   • the CLIENT-SIDE contract: through the REAL client (`processRequest(mvvmEnv:)`)
-//     with FOS `ErrorMiddleware.default` installed, a rejection surfaces as
-//     `DataFetchError.badStatus(httpStatusCode: 401)` — requestErrorHandler bypassed —
-//     PROVIDED the request's `ResponseError` does not decode from the rejection body;
-//     `EmptyError` always decodes (no-op synthesized decode), swallowing the 401 into
-//     a contentless typed error — the known limitation, pinned by its own test.
+//     with FOS `ErrorMiddleware.default` installed, a rejection surfaces TYPED as
+//     `CredentialRejectedError` (`.invalid`) — the wrapper claims the rejection body
+//     before the request's own `ResponseError` decode runs, so:
+//       - an `EmptyError` `ResponseError` no longer swallows the 401 (the retired
+//         gotcha) — the typed rejection wins,
+//       - a permissive custom `ResponseError` (an all-optional shape that decodes
+//         from any JSON object) likewise cannot swallow it,
+//   • the rejection THROWS PAST `requestErrorHandler` — recovery (refresh, retry) is a
+//     call-site decision — while an operation's own `ResponseError` still routes to the
+//     handler (the positive half),
+//   • skew fallback: a plain 401 WITHOUT the self-identifying envelope (an old server,
+//     Vapor's stock middleware) still surfaces as `DataFetchError.badStatus(401)`,
+//     unchanged.
 
 import FOSFoundation
 import FOSMVVM
@@ -125,8 +133,8 @@ struct ClientCredentialMiddlewareTests {
         }
     }
 
-    @Test("On a FOSMVVM client, a rejection surfaces as DataFetchError.badStatus(401)")
-    func rejectionSurfacesAsBadStatus401ToTheClient() async throws {
+    @Test("On a FOSMVVM client, a rejection surfaces as the typed CredentialRejectedError")
+    func rejectionSurfacesTypedToTheClient() async throws {
         try await withRunningServer { app in
             try Self.registerRejectingClientContractRoutes(app)
         } _: { base in
@@ -138,21 +146,38 @@ struct ClientCredentialMiddlewareTests {
             let request = ShowStrictErrorReplyRequest()
             do {
                 try await request.processRequest(mvvmEnv: env)
-                Issue.record("Expected DataFetchError.badStatus(401), but the request succeeded")
-            } catch DataFetchError.badStatus(httpStatusCode: let code) {
-                // NOT a ServerRequestError — requestErrorHandler is bypassed; this is
-                // the error downstream consumers branch on.
-                #expect(code == 401)
+                Issue.record("Expected CredentialRejectedError, but the request succeeded")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .invalid)
             } catch {
-                Issue.record("Expected DataFetchError.badStatus(401), got \(error)")
+                Issue.record("Expected CredentialRejectedError, got \(error)")
             }
 
             #expect(request.responseBody == nil)
         }
     }
 
-    @Test("Known limitation: an EmptyError ResponseError swallows the 401 into a contentless typed error")
-    func emptyErrorResponseSwallowsThe401() async throws {
+    @Test("With no credential provider configured, a rejection surfaces typed as .missing")
+    func missingCredentialSurfacesTypedToTheClient() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app)
+        } _: { base in
+            let env = Self.environment(base: base) // no clientCredentialProvider
+
+            let request = ShowStrictErrorReplyRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected CredentialRejectedError")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .missing)
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+        }
+    }
+
+    @Test("EmptyError no longer swallows a rejection — the typed error wins")
+    func emptyErrorNoLongerSwallowsRejections() async throws {
         try await withRunningServer { app in
             try Self.registerRejectingClientContractRoutes(app)
         } _: { base in
@@ -161,20 +186,130 @@ struct ClientCredentialMiddlewareTests {
                 provider: BearerCredentialProvider { "revoked-token" }
             )
 
-            // EmptyError's synthesized decode is a no-op, so it decodes from ANY
-            // valid-JSON rejection body — the 401 never reaches the caller. Pinned
-            // here so a DataFetch behavior change surfaces as a test delta.
-            let request = ShowGrantedReplyRequest()
+            let request = ShowGrantedReplyRequest() // ResponseError == EmptyError
             do {
                 try await request.processRequest(mvvmEnv: env)
-                Issue.record("Expected EmptyError, but the request succeeded")
-            } catch is EmptyError {
-                // The documented swallow — a contentless typed error, no status visible
+                Issue.record("Expected CredentialRejectedError, but the request succeeded")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .invalid)
             } catch {
-                Issue.record("Expected EmptyError, got \(error)")
+                Issue.record("Expected CredentialRejectedError, got \(error) — the swallow is back")
             }
+        }
+    }
 
-            #expect(request.responseBody == nil)
+    @Test("A rejection bypasses requestErrorHandler; operation errors still route to it")
+    func rejectionBypassesRequestErrorHandler() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app)
+            // ADMITTED route whose controller throws an operation error — the
+            // positive half: ordinary ResponseErrors still route to the handler.
+            try Self.registerAdmittedThrowingRoute(app)
+        } _: { base in
+            let handled = ErrorSink() // synchronous, lock-guarded — see support code
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" },
+                requestErrorHandler: { _, error in handled.record(error) }
+            )
+
+            // (a) A rejection THROWS to the caller — never reaches the handler
+            let rejected = ShowStrictErrorReplyRequest()
+            do {
+                try await rejected.processRequest(mvvmEnv: env)
+                Issue.record("Expected CredentialRejectedError")
+            } catch is CredentialRejectedError {
+                // thrown to the caller — NOT swallowed into the handler
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+            #expect(handled.count == 0)
+
+            // (b) An operation's own ResponseError still routes to the handler
+            // (handler swallows: no throw, responseBody stays nil)
+            let admittedEnv = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "valid-token" },
+                requestErrorHandler: { _, error in handled.record(error) }
+            )
+            let failing = ShowOperationFailureRequest()
+            try await failing.processRequest(mvvmEnv: admittedEnv)
+            #expect(handled.count == 1)
+            #expect(handled.last is StrictContractError)
+            #expect(failing.responseBody == nil)
+        }
+    }
+
+    @Test("Precedence: a permissive custom ResponseError does not swallow a rejection")
+    func permissiveCustomResponseErrorDoesNotSwallow() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app) // also registers the permissive fixture
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            let request = ShowPermissiveErrorReplyRequest() // ResponseError decodes loose JSON
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected CredentialRejectedError")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .invalid)
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+        }
+    }
+
+    @Test("Skew fallback: a plain 401 without the envelope behaves as today")
+    func plain401WithoutEnvelopeFallsBack() async throws {
+        try await withRunningServer { app in
+            // Vapor's STOCK middleware — the old-server wire shape (no envelope)
+            let protected = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { _ in false })
+            )
+            try protected.register(collection: RoundTripController<ShowStrictErrorReplyRequest>(actions: [
+                .show: { _, _ in GrantedReply(message: "granted") }
+            ]))
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            let request = ShowStrictErrorReplyRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected a failure")
+            } catch DataFetchError.badStatus(httpStatusCode: let code) {
+                #expect(code == 401) // pre-envelope fallback, unchanged
+            } catch {
+                Issue.record("Expected badStatus(401) fallback, got \(error)")
+            }
+        }
+    }
+
+    @Test("Under FOS ErrorMiddleware, a rejection body IS the typed CredentialRejectedError")
+    func rejectionBodyIsTypedUnderFOSErrorMiddleware() async throws {
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+            Self.registerProtectedRoute(app, isValid: { _ in false })
+        } _: { base in
+            let rejected = try await Self.send(
+                to: base,
+                headers: ["Authorization": "Bearer nope"]
+            )
+
+            #expect(rejected.status == 401) // transport dressing
+            #expect(rejected.wwwAuthenticate == "Bearer") // RFC 7235 preserved
+            let typed: CredentialRejectedError = try rejected.body.fromJSON()
+            #expect(typed.code == .invalid) // the semantics
+
+            let missing = try await Self.send(to: base, headers: [:])
+            let missingTyped: CredentialRejectedError = try missing.body.fromJSON()
+            #expect(missingTyped.code == .missing)
         }
     }
 
@@ -221,12 +356,14 @@ struct ClientCredentialMiddlewareTests {
             #expect(afterRevocation.status == 401)
         }
     }
+}
 
-    // MARK: - Fixtures
+// MARK: - Fixtures
 
+private extension ClientCredentialMiddlewareTests {
     /// Registers `GET /protected` behind a ``ClientCredentialMiddleware`` running the stock
     /// bearer verifier over `isValid`.
-    private static func registerProtectedRoute(
+    static func registerProtectedRoute(
         _ app: Application,
         isValid: @Sendable @escaping (String) async -> Bool
     ) {
@@ -239,7 +376,7 @@ struct ClientCredentialMiddlewareTests {
     /// Registers both client-contract fixtures behind an always-rejecting bearer verifier,
     /// with FOS `ErrorMiddleware.default` replacing Vapor's stock error serializer — the
     /// configuration the DocC's Client-Side Contract describes.
-    private static func registerRejectingClientContractRoutes(_ app: Application) throws {
+    static func registerRejectingClientContractRoutes(_ app: Application) throws {
         app.middleware = .init()
         app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
 
@@ -252,12 +389,30 @@ struct ClientCredentialMiddlewareTests {
         try protected.register(collection: RoundTripController<ShowGrantedReplyRequest>(actions: [
             .show: { _, _ in GrantedReply(message: "granted") }
         ]))
+        try protected.register(collection: RoundTripController<ShowPermissiveErrorReplyRequest>(actions: [
+            .show: { _, _ in GrantedReply(message: "granted") }
+        ]))
+    }
+
+    /// Adds a SECOND protected group (admitting `"valid-token"`) whose `.show`
+    /// controller throws `StrictContractError` — an operation's own
+    /// `ResponseError`, which must still route to `requestErrorHandler`. Assumes
+    /// FOS `ErrorMiddleware.default` is already installed by
+    /// ``registerRejectingClientContractRoutes(_:)`` (called first in the same
+    /// fixture).
+    static func registerAdmittedThrowingRoute(_ app: Application) throws {
+        let admitted = app.grouped(
+            ClientCredentialMiddleware(verifier: BearerCredentialVerifier { $0 == "valid-token" })
+        )
+        try admitted.register(collection: RoundTripController<ShowOperationFailureRequest>(actions: [
+            .show: { _, _ in throw StrictContractError(errorCode: 99) }
+        ]))
     }
 
     /// Performs `GET <base>/protected` with the given headers and yields the raw
     /// status + body + challenge header the server sent — no client-side error
     /// mapping in the way.
-    private static func send(
+    static func send(
         to base: URL,
         headers: [String: String]
     ) async throws -> (status: Int, body: String, wwwAuthenticate: String?) {
@@ -290,9 +445,10 @@ struct ClientCredentialMiddlewareTests {
     /// holds regardless of how the test process resolves `Deployment.current`. The explicit
     /// `session:`-before-`requestErrorHandler:` label order selects the non-SwiftUI
     /// initializer (no bundle-version compatibility gate).
-    private static func environment(
+    static func environment(
         base: URL,
-        provider: any ClientCredentialProvider
+        provider: (any ClientCredentialProvider)? = nil,
+        requestErrorHandler: (@Sendable (any ServerRequest, any ServerRequestError) -> Void)? = nil
     ) -> MVVMEnvironment {
         MVVMEnvironment(
             currentVersion: SystemVersion.current,
@@ -305,7 +461,7 @@ struct ClientCredentialMiddlewareTests {
                 .test: base
             ],
             session: nil,
-            requestErrorHandler: nil
+            requestErrorHandler: requestErrorHandler
         )
     }
 }
@@ -343,28 +499,16 @@ private actor TokenRegistry {
     }
 }
 
-/// The response body a protected route grants — the client-contract test never
-/// receives one (the middleware rejects first).
-private struct GrantedReply: ServerRequestBody {
-    let message: String
-}
-
-/// A typed error with a required field — it does NOT decode from a rejection body,
-/// so the middleware's 401 stays visible to the caller as `DataFetchError.badStatus`.
-private struct StrictContractError: ServerRequestError {
-    let errorCode: Int
-}
-
-/// `.show` fixture behind the protected group — drives the REAL client
-/// (`processRequest(mvvmEnv:)`) against the middleware. Its `EmptyError`
-/// `ResponseError` is the known-limitation fixture: it decodes from any
-/// valid-JSON rejection body, swallowing the 401.
-private final class ShowGrantedReplyRequest: ServerRequest, @unchecked Sendable {
+/// Same `.show` shape; its `ResponseError` cannot decode from a rejection body,
+/// so under stock (non-FOS) middleware the raw 401 surfaces
+/// (`plain401WithoutEnvelopeFallsBack`), and under FOS `ErrorMiddleware` the
+/// typed rejection wins.
+private final class ShowStrictErrorReplyRequest: ServerRequest, @unchecked Sendable {
     typealias Query = EmptyQuery
     typealias Fragment = EmptyFragment
     typealias RequestBody = EmptyBody
     typealias ResponseBody = GrantedReply
-    typealias ResponseError = EmptyError
+    typealias ResponseError = StrictContractError
 
     var action: ServerRequestAction {
         .show
@@ -378,14 +522,39 @@ private final class ShowGrantedReplyRequest: ServerRequest, @unchecked Sendable 
     }
 }
 
-/// The 401-visibility fixture: same `.show` shape, but its `ResponseError` cannot
-/// decode from a rejection body, so `DataFetchError.badStatus(401)` surfaces.
-private final class ShowStrictErrorReplyRequest: ServerRequest, @unchecked Sendable {
+/// Synchronous, lock-guarded error sink — the handler is a plain @Sendable
+/// closure; an actor + Task would make the count assertion racy on the
+/// failure path this test exists to catch.
+private final class ErrorSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [any Error] = []
+
+    func record(_ error: any Error) {
+        lock.withLock { errors.append(error) }
+    }
+
+    var count: Int {
+        lock.withLock { errors.count }
+    }
+
+    var last: (any Error)? {
+        lock.withLock { errors.last }
+    }
+}
+
+/// A permissive error — its single optional field decodes from ANY JSON
+/// object, like EmptyError but user-defined (spec §6 test 7).
+private struct PermissiveContractError: ServerRequestError {
+    let note: String?
+}
+
+/// Same .show shape as the other fixtures; ResponseError is permissive.
+private final class ShowPermissiveErrorReplyRequest: ServerRequest, @unchecked Sendable {
     typealias Query = EmptyQuery
     typealias Fragment = EmptyFragment
     typealias RequestBody = EmptyBody
     typealias ResponseBody = GrantedReply
-    typealias ResponseError = StrictContractError
+    typealias ResponseError = PermissiveContractError
 
     var action: ServerRequestAction {
         .show

--- a/Tests/FOSMVVMVaporTests/Middleware/ErrorMiddlewareDressingTests.swift
+++ b/Tests/FOSMVVMVaporTests/Middleware/ErrorMiddlewareDressingTests.swift
@@ -1,0 +1,132 @@
+// ErrorMiddlewareDressingTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ErrorMiddleware transport-dressing contract: an error that is BOTH Encodable
+// and AbortError is served with its typed body AND its own status/headers; a
+// plain Encodable error keeps the typed body with 400 (unchanged).
+
+import FOSFoundation
+import FOSMVVM
+import FOSMVVMVapor
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+import Vapor
+
+private struct DressedError: ServerRequestError, AbortError {
+    let errorCode: Int
+    var status: HTTPResponseStatus {
+        .conflict
+    } // 409 — distinctive
+    var headers: HTTPHeaders {
+        ["X-Dressed": "yes"]
+    }
+
+    var reason: String {
+        "dressed"
+    }
+}
+
+private struct PlainEncodableError: ServerRequestError {
+    let errorCode: Int
+}
+
+@Suite("ErrorMiddleware dressing (running server)", .serialized)
+struct ErrorMiddlewareDressingTests {
+    @Test("Encodable & AbortError: typed body + its own status and headers")
+    func dressedErrorKeepsStatusAndBody() async throws {
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+            app.get("boom") { _ -> String in throw DressedError(errorCode: 7) }
+        } _: { base in
+            let (status, body, headers) = try await rawGet(
+                base.appendingPathComponent("boom"),
+                readHeaders: ["X-Dressed", "Content-Type"]
+            )
+            #expect(status == 409)
+            #expect(headers["X-Dressed"] == "yes")
+            // A single Content-Type on the wire — a duplicate would surface here
+            // comma-joined by value(forHTTPHeaderField:)
+            #expect(headers["Content-Type"] == "application/json; charset=utf-8")
+            let decoded: DressedError = try body.fromJSON()
+            #expect(decoded.errorCode == 7)
+        }
+    }
+
+    @Test("Plain Encodable: typed body + 400 (existing contract unchanged)")
+    func plainEncodableKeeps400() async throws {
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+            app.get("boom") { _ -> String in throw PlainEncodableError(errorCode: 9) }
+        } _: { base in
+            let (status, body, headers) = try await rawGet(
+                base.appendingPathComponent("boom"),
+                readHeaders: ["Content-Type"]
+            )
+            #expect(status == 400)
+            // A single Content-Type on the wire — a duplicate would surface here
+            // comma-joined by value(forHTTPHeaderField:)
+            #expect(headers["Content-Type"] == "application/json; charset=utf-8")
+            let decoded: PlainEncodableError = try body.fromJSON()
+            #expect(decoded.errorCode == 9)
+        }
+    }
+}
+
+/// Performs `GET <url>` and yields the raw status + body + the requested
+/// response headers the server sent — no client-side error mapping in the way.
+/// Each name in `readHeaders` is resolved via `http.value(forHTTPHeaderField:)`
+/// (case-insensitive) rather than by indexing `allHeaderFields`, whose key
+/// capitalization differs across Darwin / FoundationNetworking.
+private func rawGet(
+    _ url: URL,
+    readHeaders: [String]
+) async throws -> (status: Int, body: String, headers: [String: String]) {
+    let urlRequest = URLRequest(url: url)
+
+    return try await withCheckedThrowingContinuation { continuation in
+        URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+            if let error {
+                continuation.resume(throwing: error)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                continuation.resume(throwing: NonHTTPResponseFailure())
+                return
+            }
+
+            var resolved: [String: String] = [:]
+            for name in readHeaders {
+                if let value = http.value(forHTTPHeaderField: name) {
+                    resolved[name] = value
+                }
+            }
+
+            continuation.resume(returning: (
+                status: http.statusCode,
+                body: String(data: data ?? Data(), encoding: .utf8) ?? "",
+                headers: resolved
+            ))
+        }.resume()
+    }
+}
+
+/// The server replied with something other than HTTP — never expected against the harness.
+private struct NonHTTPResponseFailure: Error {}

--- a/Tests/FOSMVVMVaporTests/Protocols/CredentialSeamFixtures.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/CredentialSeamFixtures.swift
@@ -1,0 +1,80 @@
+// CredentialSeamFixtures.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared credential-seam fixtures used by both the round-trip and in-process suites.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+
+/// The response body a protected route grants — the client-contract test never
+/// receives one (the middleware rejects first).
+struct GrantedReply: ServerRequestBody {
+    let message: String
+}
+
+/// A typed error with a required field — it does NOT decode from a rejection body,
+/// so under stock (non-FOS) middleware the raw 401 surfaces
+/// (`plain401WithoutEnvelopeFallsBack`), and under FOS `ErrorMiddleware` the
+/// typed rejection wins.
+struct StrictContractError: ServerRequestError {
+    let errorCode: Int
+}
+
+/// `.show` fixture behind the protected group — drives the REAL client
+/// (`processRequest(mvvmEnv:)`) against the middleware. Its `EmptyError`
+/// `ResponseError` decodes from any valid-JSON body; the WireError chain now
+/// claims rejections first, so this fixture PROVES the swallow is retired
+/// (`emptyErrorNoLongerSwallowsRejections`).
+final class ShowGrantedReplyRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = GrantedReply
+    typealias ResponseError = EmptyError
+
+    var action: ServerRequestAction {
+        .show
+    }
+
+    var responseBody: GrantedReply?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: GrantedReply? = nil) {
+        self.responseBody = responseBody
+    }
+}
+
+/// Same .show shape; the CONTROLLER throws StrictContractError after
+/// admission — drives the handler-routing positive half.
+final class ShowOperationFailureRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = GrantedReply
+    typealias ResponseError = StrictContractError
+
+    var action: ServerRequestAction {
+        .show
+    }
+
+    var responseBody: GrantedReply?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: GrantedReply? = nil) {
+        self.responseBody = responseBody
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Protocols/RoundTripHarness.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/RoundTripHarness.swift
@@ -62,7 +62,7 @@ func withRunningServer(
 
 /// A no-op `LocalizationStore` so `req.localizingEncoder` resolves on the live server; every key
 /// falls back to its `default`.
-private struct RoundTripLocalizationStore: LocalizationStore {
+struct RoundTripLocalizationStore: LocalizationStore {
     func value(_ key: String, locale: Locale, default defaultValue: Any?, index: Int?) -> Any? {
         defaultValue
     }

--- a/Tests/FOSMVVMVaporTests/TestingServerRequestResponseTests.swift
+++ b/Tests/FOSMVVMVaporTests/TestingServerRequestResponseTests.swift
@@ -1,0 +1,97 @@
+// TestingServerRequestResponseTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `TestingServerRequestResponse` gives server tests the SAME typed visibility the
+// real client has: a rejection surfaces as `credentialRejection` (decoded FIRST,
+// same order as the client), gating `error` so a permissive `ResponseError` can't
+// swallow the 401 — while an operation's own `ResponseError` still populates `error`.
+
+import FOSFoundation
+import FOSMVVM
+import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite("TestingServerRequestResponse credential rejection", .serialized)
+struct TestingServerRequestResponseTests {
+    @Test("A rejection populates credentialRejection; error stays nil")
+    func rejectionIsTyped() async throws {
+        try await withTestingApp { app in
+            let protected = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { _ in false })
+            )
+            try protected.register(collection: RoundTripController<ShowGrantedReplyRequest>(actions: [
+                .show: { _, _ in GrantedReply(message: "granted") }
+            ]))
+        } _: { app in
+            // An invalid bearer token is present, so the verifier rejects with `.invalid`
+            // (a missing header would be `.missing`).
+            try await app.testing().test(
+                ShowGrantedReplyRequest(),
+                headers: ["Authorization": "Bearer nope"]
+            ) { response in
+                #expect(response.status == .unauthorized) // transport contract
+                #expect(response.credentialRejection?.code == .invalid) // the semantics
+                #expect(response.error == nil) // EmptyError does NOT swallow
+                #expect(response.body == nil)
+            }
+        }
+    }
+
+    @Test("An operation error populates error; credentialRejection stays nil")
+    func operationErrorIsTyped() async throws {
+        try await withTestingApp { app in
+            // No credential middleware — the operation runs, then throws its own
+            // `ResponseError` (a required-field type the rejection envelope can't pun into).
+            try app.register(collection: RoundTripController<ShowOperationFailureRequest>(actions: [
+                .show: { _, _ in throw StrictContractError(errorCode: 99) }
+            ]))
+        } _: { app in
+            try await app.testing().test(ShowOperationFailureRequest()) { response in
+                #expect(response.credentialRejection == nil) // the rejection gate is closed
+                #expect(response.error?.errorCode == 99) // the operation error still lands
+                #expect(response.body == nil)
+            }
+        }
+    }
+}
+
+/// Boots an in-process `.testing` Application with the localization store and FOS
+/// `ErrorMiddleware.default` installed, runs `configure` then `body`, and shuts the
+/// app down on both the success and failure paths.
+private func withTestingApp(
+    configure: (Application) throws -> Void,
+    _ body: (Application) async throws -> Void
+) async throws {
+    let app = try await Application.make(.testing)
+    do {
+        app.localizationStore = RoundTripLocalizationStore()
+        app.middleware = .init()
+        app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+        try configure(app)
+        try await body(app)
+    } catch {
+        try await app.asyncShutdown()
+        throw error
+    }
+    try await app.asyncShutdown()
+}

--- a/docs/superpowers/plans/2026-07-13-credential-rejected-error.md
+++ b/docs/superpowers/plans/2026-07-13-credential-rejected-error.md
@@ -1,0 +1,869 @@
+# CredentialRejectedError Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A credential rejection from `ClientCredentialMiddleware` crosses the wire as the typed `CredentialRejectedError` and is rethrown by `processRequest(mvvmEnv:)` — retiring the `DataFetchError.badStatus(401)` client contract.
+
+**Architecture:** Per `docs/superpowers/specs/2026-07-13-credential-rejection-typed-error-design.md` (READ IT FIRST — it is the source of truth). Server: verifier throws the typed error; a new general `Encodable & AbortError` case in FOS `ErrorMiddleware` serves the typed body WITH the error's own status/headers. Client: an internal `WireError<E>` wrapper rides the ONE existing `errorType:` slot — `DataFetch`/FOSFoundation are untouched. The error self-identifies via a strict, internal discriminator.
+
+**Tech Stack:** Swift 6 / Swift Testing (`.serialized` where suites share servers), Vapor, existing `withRunningServer` harness (`Tests/FOSMVVMVaporTests/Protocols/RoundTripHarness.swift`).
+
+**Ground rules for every task:**
+- TDD: failing test first, minimal code, green, commit. Granular local commits are fine (squash before PR).
+- `swiftformat .` before each commit (auto-adds the license header to new files).
+- NEVER publish the envelope shape (discriminator key/value) in DocC, CHANGELOG, or README — it is pinned ONLY by the `//` maintainer comment and internal tests.
+- The working tree already carries UNRELATED uncommitted doc edits (errors-are-data doc sweep + this spec). Create the feature branch first; commit only files this plan touches; leave the rest untouched.
+
+---
+
+### Task 0: Branch + baseline
+
+- [ ] **Step 1:** `git checkout -b feature/credential-rejected-error`
+- [ ] **Step 2:** Run `swift test` — record the baseline is green before any change. Expected: all tests pass (≈1200+).
+
+---
+
+### Task 1: `CredentialRejectedError` (FOSMVVM)
+
+**Files:**
+- Create: `Sources/FOSMVVM/Protocols/CredentialRejectedError.swift`
+- Test: `Tests/FOSMVVMTests/Protocols/CredentialRejectedErrorTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// CredentialRejectedErrorTests.swift
+import FOSFoundation
+import FOSMVVM
+import Foundation
+import Testing
+
+@Suite("CredentialRejectedError contract")
+struct CredentialRejectedErrorTests {
+    @Test("Round-trips through JSON: code preserved, challenge transient")
+    func roundTrip() throws {
+        let original = CredentialRejectedError(code: .invalid, challenge: "Bearer")
+        let decoded: CredentialRejectedError = try original.toJSON().fromJSON()
+
+        #expect(decoded.code == .invalid)
+        #expect(decoded.challenge == nil) // transient: never crosses the wire
+    }
+
+    @Test("Both codes round-trip")
+    func bothCodes() throws {
+        for code in [CredentialRejectedError.Code.missing, .invalid] {
+            let decoded: CredentialRejectedError =
+                try CredentialRejectedError(code: code).toJSON().fromJSON()
+            #expect(decoded.code == code)
+        }
+    }
+
+    @Test("Does NOT decode from bodies lacking the envelope")
+    func strictDecode() {
+        // Vapor's stock abort body, a plain reason string, and an empty object
+        // must all fail — nothing puns into the rejection.
+        for body in [
+            #"{"error":true,"reason":"Unauthorized"}"#,
+            #""Invalid bearer credential""#,
+            "{}"
+        ] {
+            let decoded: CredentialRejectedError? = try? body.fromJSON()
+            #expect(decoded == nil, "must not decode from: \(body)")
+        }
+    }
+
+    @Test("Forward-compat: the committed wire form still decodes")
+    func forwardCompat() throws {
+        // INTERNAL representation pin (golden blob). The ONE place the envelope
+        // shape is asserted — see the maintainer comment beside CodingKeys.
+        let committedWireForm = #"{"__fosServerError":"credentialRejected","code":"invalid"}"#
+        let decoded: CredentialRejectedError = try committedWireForm.fromJSON()
+        #expect(decoded.code == .invalid)
+    }
+}
+```
+
+- [ ] **Step 2:** Run `swift test --filter CredentialRejectedErrorTests` — Expected: FAIL (type does not exist).
+
+- [ ] **Step 3: Implement**
+
+```swift
+// CredentialRejectedError.swift
+import Foundation
+
+/// The error thrown when a protected route rejects the request's credential
+///
+/// Routes grouped behind `ClientCredentialMiddleware` verify the presented
+/// credential before the operation runs. When verification rejects the
+/// request, this error crosses the wire and is rethrown by
+/// ``ServerRequest/processRequest(mvvmEnv:)`` — catch it to recover:
+///
+/// ```swift
+/// do {
+///     try await request.processRequest(mvvmEnv: mvvmEnv)
+/// } catch let error as CredentialRejectedError {
+///     switch error.code {
+///     case .missing: break // no credential was presented — check the
+///                          // MVVMEnvironment's clientCredentialProvider
+///     case .invalid: break // presented but refused — refresh the credential
+///                          // and retry (safe: the operation never ran)
+///     }
+/// }
+/// ```
+///
+/// The rejection happens **before** the operation runs, so retrying after
+/// recovery never duplicates the operation's effects.
+///
+/// This error always throws to the call site — it is never routed to
+/// ``MVVMEnvironment/requestErrorHandler``.
+public struct CredentialRejectedError: ServerRequestError {
+    /// Why the credential seam rejected the request
+    ///
+    /// `.missing` — no credential accompanied the request; typically the client
+    /// has no `ClientCredentialProvider` configured (or it returned no headers).
+    /// `.invalid` — a credential was presented and the server's verifier refused
+    /// it; refresh the credential and retry.
+    public enum Code: String, Codable, Sendable {
+        case missing
+        case invalid
+    }
+
+    /// Why the request was rejected
+    public let code: Code
+
+    /// The authentication challenge the verifier answers with (for example
+    /// `"Bearer"`), used server-side to dress the response's
+    /// `WWW-Authenticate` header. Never crosses the wire — always `nil` on
+    /// a decoded value.
+    public let challenge: String?
+
+    /// Creates the rejection thrown by a `ServerCredentialVerifier`
+    ///
+    /// - Parameters:
+    ///   - code: Why the request was rejected
+    ///   - challenge: The scheme for the response's `WWW-Authenticate`
+    ///     header (default: none)
+    public init(code: Code, challenge: String? = nil) {
+        self.code = code
+        self.challenge = challenge
+    }
+
+    // Wire envelope — INTERNAL detail; never publish in DocC/CHANGELOG/README.
+    // The discriminator key + fixed value make the decode strict: init(from:)
+    // fails unless both match, so nothing puns into (or out of) this type.
+    // Shape pinned by CredentialRejectedErrorTests.forwardCompat.
+    private enum CodingKeys: String, CodingKey {
+        case discriminator = "__fosServerError"
+        case code
+    }
+
+    private static let discriminatorValue = "credentialRejected"
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard try container.decode(String.self, forKey: .discriminator) == Self.discriminatorValue else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .discriminator,
+                in: container,
+                debugDescription: "Not a credential rejection"
+            )
+        }
+        self.code = try container.decode(Code.self, forKey: .code)
+        self.challenge = nil
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Self.discriminatorValue, forKey: .discriminator)
+        try container.encode(code, forKey: .code)
+    }
+}
+```
+
+- [ ] **Step 4:** Run `swift test --filter CredentialRejectedErrorTests` — Expected: PASS.
+- [ ] **Step 5:** `swiftformat . && git add Sources/FOSMVVM/Protocols/CredentialRejectedError.swift Tests/FOSMVVMTests/Protocols/CredentialRejectedErrorTests.swift && git commit -m "feat(FOSMVVM): CredentialRejectedError — the credential seam's typed rejection"`
+
+---
+
+### Task 2: `WireError<E>` internal decode wrapper (FOSMVVM)
+
+**Files:**
+- Create: `Sources/FOSMVVM/Protocols/WireError.swift`
+- Test: `Tests/FOSMVVMTests/Protocols/WireErrorTests.swift`
+
+- [ ] **Step 1: Write the failing tests** (internal type → `@testable import`; this is coverage of internal plumbing, not the public contract)
+
+```swift
+// WireErrorTests.swift
+import FOSFoundation
+@testable import FOSMVVM
+import Foundation
+import Testing
+
+private struct StrictError: ServerRequestError {
+    let errorCode: Int
+}
+
+@Suite("WireError decode precedence")
+struct WireErrorTests {
+    @Test("A rejection body decodes .surface — even when E is EmptyError")
+    func rejectionBeatsEmptyError() throws {
+        let rejection = try CredentialRejectedError(code: .invalid).toJSON()
+
+        let strict: WireError<StrictError> = try rejection.fromJSON()
+        guard case .surface(let error) = strict else {
+            Issue.record("Expected .surface, got \(strict)"); return
+        }
+        #expect(error.code == .invalid)
+
+        // EmptyError decodes from ANYTHING — the wrapper must claim the
+        // rejection FIRST (this retires the documented swallow).
+        let permissive: WireError<EmptyError> = try rejection.fromJSON()
+        guard case .surface = permissive else {
+            Issue.record("EmptyError swallowed the rejection"); return
+        }
+    }
+
+    @Test("A request-error body decodes .response")
+    func responseErrorPassesThrough() throws {
+        let wire: WireError<StrictError> = try #"{"errorCode":42}"#.fromJSON()
+        guard case .response(let error) = wire else {
+            Issue.record("Expected .response, got \(wire)"); return
+        }
+        #expect(error.errorCode == 42)
+    }
+
+    @Test("A body matching neither type fails to decode")
+    func neitherFallsThrough() {
+        let wire: WireError<StrictError>? = try? #"{"unrelated":true}"#.fromJSON()
+        #expect(wire == nil)
+    }
+}
+```
+
+- [ ] **Step 2:** Run `swift test --filter WireErrorTests` — Expected: FAIL (type does not exist).
+
+- [ ] **Step 3: Implement**
+
+```swift
+// WireError.swift
+import Foundation
+
+// The client-side decode order for a ServerRequest error body: the well-known
+// surface errors (closed, FOS-owned list — CredentialRejectedError today) are
+// tried STRICTLY before the request's own ResponseError. Passed to DataFetch
+// as the ONE existing `errorType:` — FOSFoundation stays untouched; add a
+// future surface error HERE, nowhere else.
+enum WireError<E: ServerRequestError>: Error, Decodable {
+    case surface(CredentialRejectedError)
+    case response(E)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let rejection = try? container.decode(CredentialRejectedError.self) {
+            self = .surface(rejection)
+        } else {
+            self = try .response(container.decode(E.self))
+        }
+    }
+}
+```
+
+- [ ] **Step 4:** Run `swift test --filter WireErrorTests` — Expected: PASS.
+- [ ] **Step 5:** `swiftformat . && git add Sources/FOSMVVM/Protocols/WireError.swift Tests/FOSMVVMTests/Protocols/WireErrorTests.swift && git commit -m "feat(FOSMVVM): WireError — surface-before-response error decode order"`
+
+---
+
+### Task 3: Transport dressing — `ErrorMiddleware` `Encodable & AbortError` case + `AbortError` conformance (FOSMVVMVapor)
+
+**Files:**
+- Create: `Sources/FOSMVVMVapor/CredentialRejectedError+Vapor.swift`
+- Modify: `Sources/FOSMVVMVapor/Middleware/ErrorMiddleware.swift:72` (new first case) and its type DocC
+- Test: `Tests/FOSMVVMVaporTests/Middleware/ErrorMiddlewareDressingTests.swift`
+
+- [ ] **Step 1: Write the failing test** — model on `ClientCredentialMiddlewareTests`' `withRunningServer` usage (real socket; `.serialized` if the harness requires it — mirror the existing suite's traits)
+
+```swift
+// ErrorMiddlewareDressingTests.swift
+//
+// ErrorMiddleware transport-dressing contract: an error that is BOTH Encodable
+// and AbortError is served with its typed body AND its own status/headers; a
+// plain Encodable error keeps the typed body with 400 (unchanged).
+
+import FOSFoundation
+import FOSMVVM
+import FOSMVVMVapor
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+import Vapor
+
+private struct DressedError: ServerRequestError, AbortError {
+    let errorCode: Int
+    var status: HTTPResponseStatus { .conflict }          // 409 — distinctive
+    var headers: HTTPHeaders { ["X-Dressed": "yes"] }
+    var reason: String { "dressed" }
+}
+
+private struct PlainEncodableError: ServerRequestError {
+    let errorCode: Int
+}
+
+@Suite("ErrorMiddleware dressing (running server)", .serialized)
+struct ErrorMiddlewareDressingTests {
+    @Test("Encodable & AbortError: typed body + its own status and headers")
+    func dressedErrorKeepsStatusAndBody() async throws {
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+            app.get("boom") { _ -> String in throw DressedError(errorCode: 7) }
+        } _: { base in
+            let (status, body, headers) = try await rawGet(base.appendingPathComponent("boom"))
+            #expect(status == 409)
+            #expect(headers["X-Dressed"] == "yes")
+            let decoded: DressedError? = try? body.fromJSON()
+            #expect(decoded?.errorCode == 7)
+        }
+    }
+
+    @Test("Plain Encodable: typed body + 400 (existing contract unchanged)")
+    func plainEncodableKeeps400() async throws {
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+            app.get("boom") { _ -> String in throw PlainEncodableError(errorCode: 9) }
+        } _: { base in
+            let (status, body, _) = try await rawGet(base.appendingPathComponent("boom"))
+            #expect(status == 400)
+            let decoded: PlainEncodableError? = try? body.fromJSON()
+            #expect(decoded?.errorCode == 9)
+        }
+    }
+}
+```
+
+Write a file-private helper `rawGet(_ url: URL, headers: [String: String] = [:], readHeaders: [String]) async throws -> (status: Int, body: String, headers: [String: String])` using the same URLSession-continuation shape as `ClientCredentialMiddlewareTests.send` (`ClientCredentialMiddlewareTests.swift:260-287`) — do NOT try to reuse `send` itself: it is `private static`, hard-codes the `/protected` path, and returns only the `WWW-Authenticate` header. This helper takes a full URL; resolve each returned header with `http.value(forHTTPHeaderField:)` (case-insensitive) rather than indexing `allHeaderFields` — key capitalization differs between Darwin and FoundationNetworking (a Linux-only flake otherwise).
+
+> **Encoder note:** `req.localizingEncoder` throws unless
+> `app.localizationStore` is set (`Request+FOS.swift:169-176`). The
+> `withRunningServer` harness sets it (`RoundTripHarness.swift:42`), so these
+> tests are covered — but any fixture built WITHOUT `withRunningServer` must
+> set the store itself (see Task 6).
+
+- [ ] **Step 2:** Run `swift test --filter ErrorMiddlewareDressingTests` — Expected: `dressedErrorKeepsStatusAndBody` FAILS (status is 400 today, headers lost); `plainEncodableKeeps400` PASSES (pins the unchanged contract).
+
+- [ ] **Step 3: Implement** — in `ErrorMiddleware.swift`, insert the new case as the FIRST case *inside* the `switch error {` (which opens at line 72 — the case goes at line 73, before `case let encodable as any Encodable:`); mirror the existing Encodable branch exactly, differing only in status/headers:
+
+```swift
+            case let encodableAbort as any (Encodable & AbortError):
+                do {
+                    let encoder = try req.localizingEncoder
+
+                    var abortHeaders = encodableAbort.headers
+                    abortHeaders.replaceOrAdd(
+                        name: HTTPHeaders.Name.contentType.description,
+                        value: "application/json;charset=utf-8"
+                    )
+                    (reason, errorData, status, headers, source) = try (
+                        "",
+                        encodableAbort.toJSONData(encoder: encoder),
+                        encodableAbort.status,
+                        abortHeaders,
+                        .capture()
+                    )
+                } catch {
+                    (reason, errorData, status, headers, source) = (
+                        encodableAbort.reason,
+                        nil,
+                        encodableAbort.status,
+                        encodableAbort.headers,
+                        .capture()
+                    )
+                }
+```
+
+Update `ErrorMiddleware`'s type DocC with the contract sentence from the spec §5. Then create the conformance:
+
+```swift
+// CredentialRejectedError+Vapor.swift
+import FOSMVVM
+import Vapor
+
+/// Dresses the rejection for the transport: `401 Unauthorized` with the
+/// verifier's authentication challenge (for example `WWW-Authenticate:
+/// Bearer`). The response *body* remains the typed error — FOSMVVM clients
+/// decode and rethrow it; the status exists for proxies, logs, and RFC 7235
+/// conformance, never for client branching.
+extension CredentialRejectedError: AbortError {
+    public var status: HTTPResponseStatus { .unauthorized }
+
+    public var headers: HTTPHeaders {
+        guard let challenge else { return [:] }
+        return ["WWW-Authenticate": challenge]
+    }
+
+    public var reason: String {
+        // Constant — a rejection reason must never echo the presented credential
+        "Credential rejected"
+    }
+}
+```
+
+- [ ] **Step 4:** Run `swift test --filter ErrorMiddlewareDressingTests` — Expected: PASS (both).
+- [ ] **Step 5:** Run `swift test --filter ClientCredentialMiddlewareTests` — Expected: PASS (nothing server-side has changed yet; this guards ordering).
+- [ ] **Step 6:** `swiftformat . && git add -A Sources/FOSMVVMVapor Tests/FOSMVVMVaporTests && git commit -m "feat(FOSMVVMVapor): Encodable & AbortError dressing case; CredentialRejectedError 401 conformance"`
+
+---
+
+### Task 4: Server rejection path — verifier throws typed, middleware wraps (FOSMVVMVapor)
+
+**Files:**
+- Modify: `Sources/FOSMVVMVapor/Middleware/ClientCredentialMiddleware.swift:89-94` (respond), `:132-147` (BearerCredentialVerifier.verify), and the type DocC (spec §5/§9)
+- Test: extend `Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift`
+
+- [ ] **Step 1: Write the failing wire-level test** (add to the existing suite)
+
+```swift
+    @Test("Under FOS ErrorMiddleware, a rejection body IS the typed CredentialRejectedError")
+    func rejectionBodyIsTypedUnderFOSErrorMiddleware() async throws {
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+            Self.registerProtectedRoute(app, isValid: { _ in false })
+        } _: { base in
+            let rejected = try await Self.send(
+                to: base,
+                headers: ["Authorization": "Bearer nope"]
+            )
+
+            #expect(rejected.status == 401)                       // transport dressing
+            #expect(rejected.wwwAuthenticate == "Bearer")          // RFC 7235 preserved
+            let typed: CredentialRejectedError? = try? rejected.body.fromJSON()
+            #expect(typed?.code == .invalid)                       // the semantics
+
+            let missing = try await Self.send(to: base, headers: [:])
+            let missingTyped: CredentialRejectedError? = try? missing.body.fromJSON()
+            #expect(missingTyped?.code == .missing)
+        }
+    }
+```
+
+- [ ] **Step 2:** Run `swift test --filter ClientCredentialMiddlewareTests/rejectionBodyIsTypedUnderFOSErrorMiddleware` — Expected: FAIL (body is Vapor/FOS reason text today; typed decode nil).
+
+- [ ] **Step 3: Implement.** In `BearerCredentialVerifier.verify`, replace each `Abort` 1:1 — same guards, same branch semantics:
+
+```swift
+    public func verify(headers: HTTPHeaders) async throws {
+        guard let token = headers.bearerAuthorization?.token else {
+            throw CredentialRejectedError(code: .missing, challenge: "Bearer")
+        }
+
+        guard await isValid(token) else {
+            throw CredentialRejectedError(code: .invalid, challenge: "Bearer")
+        }
+    }
+```
+
+In `ClientCredentialMiddleware.respond`, wrap any non-typed verifier throw (the shipped verifier contract is "throw to reject"):
+
+```swift
+    public func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        // Ensure that the presented credential admits the request
+        do {
+            try await verifier.verify(headers: request.headers)
+        } catch let rejection as CredentialRejectedError {
+            throw rejection
+        } catch {
+            // The verifier contract is "throw to reject" — any throw is a
+            // rejection; custom verifiers throw CredentialRejectedError
+            // directly to carry richer intent (code, challenge).
+            throw CredentialRejectedError(code: .invalid)
+        }
+
+        return try await next.respond(to: request)
+    }
+```
+
+Rewrite the type DocC's "Client-Side Contract" + "Known limitation" sections per spec §5, and update `ServerCredentialVerifier`'s DocC ("typically `Abort(.unauthorized)`" → throw `CredentialRejectedError`; wrapping otherwise).
+
+- [ ] **Step 4:** Run `swift test --filter ClientCredentialMiddlewareTests` — Expected: the new test PASSES; wire-level tests (401, no-echo, WWW-Authenticate, per-request, custom-verifier, parse edges) PASS; the two client-contract tests (`rejectionSurfacesAsBadStatus401ToTheClient`, `emptyErrorResponseSwallowsThe401`) still PASS (client not yet wired — the envelope doesn't decode into `StrictContractError`, and `EmptyError` still decodes anything).
+  - **Watch:** the wire tests run Vapor's STOCK middleware — a thrown `CredentialRejectedError` must still produce 401 + `WWW-Authenticate` there via its `AbortError` conformance. If `wwwAuthenticate` assertions fail, the conformance headers aren't reaching the stock serializer — fix the conformance, not the tests.
+- [ ] **Step 5:** `swiftformat . && git add Sources/FOSMVVMVapor/Middleware/ClientCredentialMiddleware.swift Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift && git commit -m "feat(FOSMVVMVapor): credential rejections are served as typed CredentialRejectedError"`
+  - **Staging rule (applies to EVERY commit in this plan):** the working tree carries pre-existing UNRELATED edits (`Sources/FOSMVVM/Protocols/ServerRequest.swift` DocC sweep, `.claude-plugin/plugin.json`, several `.claude/` docs). NEVER use bare `git add -A` / `git add .` — stage only the exact paths each step lists.
+
+---
+
+### Task 5: Client decode path + handler bypass (FOSMVVM) — reshapes the client contract
+
+**Files:**
+- Modify: `Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift:120-147` (errorType + unwrap), `:192` (bypass), `MVVMEnvironment.swift` (requestErrorHandler DocC — 5 sites, see Step 3d)
+- Test: reshape the two client-contract tests in `ClientCredentialMiddlewareTests.swift`; add bypass + precedence + skew tests there
+
+- [ ] **Step 1: Reshape/write the failing tests.** Replace `rejectionSurfacesAsBadStatus401ToTheClient` and `emptyErrorResponseSwallowsThe401` (same fixtures, new contract), and add three tests:
+
+```swift
+    @Test("On a FOSMVVM client, a rejection surfaces as the typed CredentialRejectedError")
+    func rejectionSurfacesTypedToTheClient() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app)
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            let request = ShowStrictErrorReplyRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected CredentialRejectedError, but the request succeeded")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .invalid)
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+
+            #expect(request.responseBody == nil)
+        }
+    }
+
+    @Test("EmptyError no longer swallows a rejection — the typed error wins")
+    func emptyErrorNoLongerSwallowsRejections() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app)
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            let request = ShowGrantedReplyRequest() // ResponseError == EmptyError
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected CredentialRejectedError, but the request succeeded")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .invalid)
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error) — the swallow is back")
+            }
+        }
+    }
+
+    @Test("A rejection bypasses requestErrorHandler; operation errors still route to it")
+    func rejectionBypassesRequestErrorHandler() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app)
+            // ADMITTED route whose controller throws an operation error — the
+            // positive half: ordinary ResponseErrors still route to the handler.
+            try Self.registerAdmittedThrowingRoute(app)
+        } _: { base in
+            let handled = ErrorSink() // synchronous, lock-guarded — see support code
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" },
+                requestErrorHandler: { _, error in handled.record(error) }
+            )
+
+            // (a) A rejection THROWS to the caller — never reaches the handler
+            let rejected = ShowStrictErrorReplyRequest()
+            do {
+                try await rejected.processRequest(mvvmEnv: env)
+                Issue.record("Expected CredentialRejectedError")
+            } catch is CredentialRejectedError {
+                // thrown to the caller — NOT swallowed into the handler
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+            #expect(handled.count == 0)
+
+            // (b) An operation's own ResponseError still routes to the handler
+            // (handler swallows: no throw, responseBody stays nil)
+            let admittedEnv = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "valid-token" },
+                requestErrorHandler: { _, error in handled.record(error) }
+            )
+            let failing = ShowOperationFailureRequest()
+            try await failing.processRequest(mvvmEnv: admittedEnv)
+            #expect(handled.count == 1)
+            #expect(handled.last is StrictContractError)
+            #expect(failing.responseBody == nil)
+        }
+    }
+
+    @Test("Precedence: a permissive custom ResponseError does not swallow a rejection")
+    func permissiveCustomResponseErrorDoesNotSwallow() async throws {
+        try await withRunningServer { app in
+            try Self.registerRejectingClientContractRoutes(app) // also registers the permissive fixture
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            let request = ShowPermissiveErrorReplyRequest() // ResponseError decodes loose JSON
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected CredentialRejectedError")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .invalid)
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+        }
+    }
+
+    @Test("Skew fallback: a plain 401 without the envelope behaves as today")
+    func plain401WithoutEnvelopeFallsBack() async throws {
+        try await withRunningServer { app in
+            // Vapor's STOCK middleware — the old-server wire shape (no envelope)
+            let protected = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { _ in false })
+            )
+            try protected.register(collection: RoundTripController<ShowStrictErrorReplyRequest>(actions: [
+                .show: { _, _ in GrantedReply(message: "granted") }
+            ]))
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: BearerCredentialProvider { "revoked-token" }
+            )
+
+            let request = ShowStrictErrorReplyRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected a failure")
+            } catch DataFetchError.badStatus(httpStatusCode: let code) {
+                #expect(code == 401) // pre-envelope fallback, unchanged
+            } catch {
+                Issue.record("Expected badStatus(401) fallback, got \(error)")
+            }
+        }
+    }
+```
+
+Support code to add to the suite's fixtures:
+
+```swift
+/// Synchronous, lock-guarded error sink — the handler is a plain @Sendable
+/// closure; an actor + Task would make the count assertion racy on the
+/// failure path this test exists to catch.
+private final class ErrorSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [any Error] = []
+
+    func record(_ error: any Error) {
+        lock.withLock { errors.append(error) }
+    }
+
+    var count: Int { lock.withLock { errors.count } }
+    var last: (any Error)? { lock.withLock { errors.last } }
+}
+
+/// A permissive error — its single optional field decodes from ANY JSON
+/// object, like EmptyError but user-defined (spec §6 test 7).
+private struct PermissiveContractError: ServerRequestError {
+    let note: String?
+}
+
+/// Same .show shape as the other fixtures; ResponseError is permissive.
+private final class ShowPermissiveErrorReplyRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = GrantedReply
+    typealias ResponseError = PermissiveContractError
+
+    var action: ServerRequestAction { .show }
+    var responseBody: GrantedReply?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: GrantedReply? = nil) {
+        self.responseBody = responseBody
+    }
+}
+
+/// Same .show shape; the CONTROLLER throws StrictContractError after
+/// admission — drives the handler-routing positive half.
+private final class ShowOperationFailureRequest: ServerRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias Fragment = EmptyFragment
+    typealias RequestBody = EmptyBody
+    typealias ResponseBody = GrantedReply
+    typealias ResponseError = StrictContractError
+
+    var action: ServerRequestAction { .show }
+    var responseBody: GrantedReply?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil,
+         requestBody: EmptyBody? = nil, responseBody: GrantedReply? = nil) {
+        self.responseBody = responseBody
+    }
+}
+```
+
+And two fixture registrations:
+- extend `registerRejectingClientContractRoutes(_:)` to also register
+  `RoundTripController<ShowPermissiveErrorReplyRequest>`;
+- add `registerAdmittedThrowingRoute(_:)`: assumes FOS `ErrorMiddleware.default`
+  is already installed globally by `registerRejectingClientContractRoutes`
+  (called first in the same fixture) — registers ONLY a new protected group
+  with a `ClientCredentialMiddleware` admitting `"valid-token"`, containing
+  `RoundTripController<ShowOperationFailureRequest>` whose `.show` action
+  `throw`s `StrictContractError(errorCode: 99)`.
+- extend `Self.environment(base:provider:)` with an optional
+  `requestErrorHandler:` parameter (default nil), passed through to
+  `MVVMEnvironment`.
+
+Note the stock-middleware fixture: `plain401WithoutEnvelopeFallsBack` must NOT install FOS ErrorMiddleware — after Task 4 the middleware throws `CredentialRejectedError` and Vapor's stock serializer emits `{"error":true,"reason":"Credential rejected"}` — no envelope, by construction.
+
+Also update the suite's header comment block (lines 17–36) to describe the NEW contract.
+
+- [ ] **Step 2:** Run `swift test --filter ClientCredentialMiddlewareTests` — Expected: the reshaped/new tests FAIL (client still throws `badStatus`/`EmptyError`); `plain401WithoutEnvelopeFallsBack` PASSES (pins the fallback).
+
+- [ ] **Step 3: Implement.** In `ServerRequest+Fetch.swift`:
+
+(a) Both `send` calls (`:128` and `:140`): `errorType: WireError<Self.ResponseError>.self`.
+
+(b) Wrap the body of `processRequestCapturingRegistrations(baseURL:headers:session:)` so wrapper values unwrap to their payload before propagating — add around the existing `dataFetch.send` calls (both branches):
+
+```swift
+        // WireError is decode plumbing — unwrap so callers catch the payload
+        // (the surface rejection or the request's typed ResponseError).
+        do {
+            ... existing sends ...
+        } catch let wire as WireError<Self.ResponseError> {
+            switch wire {
+            case .surface(let rejection): throw rejection
+            case .response(let error): throw error
+            }
+        }
+```
+
+(c) In `processRequestCapturingRegistrations(mvvmEnv:)` (`:192`), add BEFORE the `ServerRequestError` catch:
+
+```swift
+        } catch let rejection as CredentialRejectedError {
+            // A surface rejection always reaches the caller — recovery
+            // (refresh credential, retry) is a call-site decision.
+            throw rejection
+        } catch let error as ServerRequestError {
+```
+
+(d) `MVVMEnvironment.swift` — append the bypass note to the `requestErrorHandler` DocC at EVERY occurrence: the property (`:118`) AND all four initializers' parameter docs (`:228`, `:282`, `:365`, `:431` — grep `requestErrorHandler:` to be sure none is missed): surface rejections (``CredentialRejectedError``) are never routed here — they always throw to the caller.
+
+- [ ] **Step 4:** Run `swift test --filter ClientCredentialMiddlewareTests` — Expected: ALL PASS.
+- [ ] **Step 5:** Run `swift test` (full suite) — Expected: green; any request-flow test that previously relied on rejection swallowing surfaces here.
+- [ ] **Step 6:** `swiftformat . && git add Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift "Sources/FOSMVVM/SwiftUI Support/MVVMEnvironment.swift" Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift && git commit -m "feat(FOSMVVM): rejections decode typed and throw past requestErrorHandler"` (staging rule: exact paths only — the tree carries unrelated edits)
+
+---
+
+### Task 6: Test-harness surface — `TestingServerRequestResponse.credentialRejection` (FOSTestingVapor)
+
+**Files:**
+- Modify: `Sources/FOSTestingVapor/TestingServerRequestResponse.swift:23-42`
+- Test: `Tests/FOSMVVMVaporTests/TestingServerRequestResponseTests.swift` (this target already exercises the harness; keep the new suite beside the middleware tests if a better home doesn't exist)
+
+- [ ] **Step 1a: Promote the localization stub.** `RoundTripLocalizationStore` in `Tests/FOSMVVMVaporTests/Protocols/RoundTripHarness.swift` is `private`; change it to `internal` (target-visible) so this suite can reuse it. **This is load-bearing:** `req.localizingEncoder` throws unless `app.localizationStore` is set (`Request+FOS.swift:169-176`) — without it, the dressing case falls back to a plaintext body and `credentialRejection` never decodes.
+
+- [ ] **Step 1b: Write the failing test** — an `app.testing().test(request…)` run against a protected route:
+
+```swift
+@Suite("TestingServerRequestResponse credential rejection")
+struct TestingServerRequestResponseTests {
+    @Test("A rejection populates credentialRejection; error stays nil")
+    func rejectionIsTyped() async throws {
+        let app = try await Application.make(.testing)
+        do {
+            app.localizationStore = RoundTripLocalizationStore() // REQUIRED — see Step 1a
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+            let protected = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { _ in false })
+            )
+            try protected.register(collection: RoundTripController<ShowGrantedReplyRequest>(actions: [
+                .show: { _, _ in GrantedReply(message: "granted") }
+            ]))
+
+            try await app.testing().test(ShowGrantedReplyRequest()) { response in
+                #expect(response.status == .unauthorized)          // transport contract
+                #expect(response.credentialRejection?.code == .invalid) // the semantics
+                #expect(response.error == nil)                     // EmptyError does NOT swallow
+                #expect(response.body == nil)
+            }
+        } catch {
+            try await app.asyncShutdown(); throw error
+        }
+        try await app.asyncShutdown()
+    }
+}
+```
+
+(Adjust `app.localizationStore` spelling to however `RoundTripHarness.swift:42` sets it — copy that line verbatim. Fixtures `ShowGrantedReplyRequest`/`GrantedReply`/`RoundTripController` may need `fileprivate` → target-visibility moves; if so, move them into the existing shared fixture file used by `RoundTripHarness.swift` rather than duplicating.)
+
+- [ ] **Step 2:** Run `swift test --filter TestingServerRequestResponseTests` — Expected: FAIL (`credentialRejection` does not exist).
+
+- [ ] **Step 3: Implement** in `TestingServerRequestResponse`:
+
+```swift
+    /// The received ``CredentialRejectedError``, if the protected route
+    /// rejected the request's credential — assert rejections on this typed
+    /// value, never on `status` alone
+    public let credentialRejection: CredentialRejectedError?
+
+    init(response: TestingHTTPResponse) throws {
+        self.status = response.status
+        self.headers = response.headers
+        self.body = try? response.body.fromJSON()
+        // Same decode order as the client: the surface rejection is claimed
+        // first so a permissive ResponseError (EmptyError) can't swallow it.
+        let rejection: CredentialRejectedError? = try? response.body.fromJSON()
+        self.credentialRejection = rejection
+        self.error = rejection == nil ? (try? response.body.fromJSON()) : nil
+    }
+```
+
+- [ ] **Step 4:** Run `swift test --filter TestingServerRequestResponseTests` — Expected: PASS.
+- [ ] **Step 5:** `swiftformat . && git add Sources/FOSTestingVapor/TestingServerRequestResponse.swift Tests/FOSMVVMVaporTests/TestingServerRequestResponseTests.swift Tests/FOSMVVMVaporTests/Protocols/RoundTripHarness.swift && git commit -m "feat(FOSTestingVapor): typed credentialRejection on TestingServerRequestResponse"` (add any fixture file moved in Step 1b; exact paths only)
+
+---
+
+### Task 7: Documentation sweep
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased), `.claude/docs/FOSMVVMArchitecture.md` (§ ServerRequestError — add the surface-error paragraph), `.claude/skills/shared/api-catalog/FOSMVVM.md` (new `CredentialRejectedError` entry), `.claude/skills/shared/api-catalog/FOSMVVMVapor.md` (replace the ClientCredentialMiddleware "Limitation" paragraph and the ErrorMiddleware entry's contract), `.claude/skills/shared/api-catalog/FOSTesting.md` (harness entry gains `credentialRejection`)
+
+- [ ] **Step 1:** CHANGELOG under `## [Unreleased]` — contract statements ONLY, never the envelope shape:
+
+```markdown
+### Added
+
+- **`CredentialRejectedError`** (FOSMVVM / FOSMVVMVapor). A credential rejection from
+  `ClientCredentialMiddleware` now crosses the wire as a typed, `Codable` error and is
+  rethrown by `processRequest(mvvmEnv:)` — catch it to recover (`.missing` /
+  `.invalid`); it always throws to the caller (never `requestErrorHandler`). Requires
+  FOS `ErrorMiddleware.default` (already the documented configuration). Retires the
+  `DataFetchError.badStatus(401)` client contract and the documented `EmptyError`
+  rejection-swallow. `TestingServerRequestResponse` gains `credentialRejection`.
+
+### Changed
+
+- **`ErrorMiddleware`**: an error conforming to both `Encodable` and `AbortError` is
+  now served with its typed body AND its own status/headers (previously such errors
+  were served `400 Bad Request`). Plain `Encodable` errors are unchanged.
+```
+
+- [ ] **Step 2:** Apply the catalog/architecture edits (follow `fosutilities-api-catalog` entry style; the reach-for index line in the repo `CLAUDE.md` API-catalog section may need a "credential rejection / typed 401" pointer). Run the catalog audit if CI expects it (`fosutilities-api-catalog-update` skill describes it) — plugin version is ALREADY bumped to 2.14.0 uncommitted in this working tree; do not bump again for this same unreleased batch.
+- [ ] **Step 3: Stage CAREFULLY — three of these files already carry unrelated hunks.** `.claude/docs/FOSMVVMArchitecture.md`, `.claude/skills/shared/api-catalog/FOSMVVM.md`, and `.claude/skills/shared/api-catalog/FOSMVVMVapor.md` hold the pre-existing errors-are-data sweep: use `git add -p <file>` on those three and stage ONLY the hunks this task wrote (CredentialRejectedError content). The clean files stage whole: `git add CHANGELOG.md .claude/skills/shared/api-catalog/FOSTesting.md CLAUDE.md` (drop any of these not actually touched). Then `git commit -m "docs: CredentialRejectedError contract across CHANGELOG, catalog, architecture doc"`.
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1:** `swift test` — full suite green.
+- [ ] **Step 2:** `swiftformat . --lint` → 0 files require formatting; `swiftlint` → no new violations.
+- [ ] **Step 3:** Grep the diff for envelope leakage — two checks, both must come back empty:
+  - `git diff main -- '*.md' 'Sources/**/*.docc/**' | grep -n "__fosServerError"` (published prose)
+  - `git diff main -- 'Sources/**/*.swift' | grep -nE '^\+\s*///.*__fosServerError'` (DocC lines inside source — `///` is published; the `//` maintainer pin and the test fixtures are the ONLY legitimate occurrences)
+- [ ] **Step 4:** Review `git log --oneline main..HEAD`; squash to a few logical commits per repo convention BEFORE any PR. **Do NOT open a PR — David reviews first (hard gate).**

--- a/docs/superpowers/specs/2026-07-13-credential-rejection-typed-error-design.md
+++ b/docs/superpowers/specs/2026-07-13-credential-rejection-typed-error-design.md
@@ -1,0 +1,411 @@
+# Credential Rejection as a Typed Error — Design Spec
+
+**Date:** 2026-07-13
+**Status:** RATIFIED (David, 2026-07-13) — structural decisions (§2) and names.
+**Names:** `CredentialRejectedError`, cases `.missing` / `.invalid`, transient
+`challenge` property KEPT, no `message` field. Internal wrapper name
+(`WireError`) and test-harness property (`credentialRejection`) are
+implementation-level defaults, cheap to rename in review.
+**Version target:** 0.7.0 (additive, minor).
+
+> **READ FIRST.** This spec is the source of truth for the design; the
+> deferral history lives in the consumer project's ledger. Everything here
+> was gated through `fosmvvm-planning` (surface → DocC → contract tests →
+> rationale). Section 9 lists what this design *retires*.
+
+---
+
+## 1. Problem
+
+A credential rejection is a *middleware* failure that precedes every operation
+on a protected route group. Today it surfaces client-side as
+`DataFetchError.badStatus(httpStatusCode: 401)` — a transport number, not
+typed data — because:
+
+- `DataFetch` decodes exactly ONE error type per request
+  (`errorType: Self.ResponseError.self`, `ServerRequest+Fetch.swift:128,140`),
+  and the rejection belongs to no single request's vocabulary.
+- `ClientCredentialMiddleware`'s verifier throws a bare
+  `Abort(.unauthorized, reason:)` (`ClientCredentialMiddleware.swift:134,142`),
+  which FOS `ErrorMiddleware` serves as a reason-string body.
+
+Under the errors-are-data ruling (2026-07-10): statuses carry no result
+semantics; a failure the client branches on must be a typed `Codable` error
+riding the ServerRequest error path. The credential seam is the layer that
+failed — its throw must cross the wire typed, like any other.
+
+**The local-call model.** A local call through a credential layer can throw
+from *that layer* — a domain distinct from the operation's own — and the
+caller catches both without the operation declaring the credential error.
+The client-visible thrown vocabulary of `processRequest` is therefore:
+
+    the request's ResponseError  ∪  the surface's own well-known errors
+
+This design adds the first well-known surface error.
+
+---
+
+## 2. Ratified decisions (David, 2026-07-13)
+
+**Per-seam error types.** One well-known FOS type per framework seam
+(credential rejection now; a version-rejection type later *if and when a
+consumer needs it* — defer-API-until-client-exists). The internal decode
+wrapper tries a closed, FOS-owned list in order. Each seam owns its meaning,
+payload, and transport dressing.
+
+**Throw past `requestErrorHandler`.** The well-known surface error always
+throws to the call site. `requestErrorHandler` (`MVVMEnvironment.swift:118`)
+keeps its documented job — operation errors from a request's own
+`ResponseError`. No swallow-into-nil for rejections; callers doing recovery
+(refresh credential, retry) see the trigger.
+
+**Transport dressing: `ErrorMiddleware` gains a general
+`Encodable & AbortError` case, ordered first.** Typed body via the localizing
+encoder AND the error's own status/headers. `CredentialRejectedError`
+conforms to `AbortError` via extension in FOSMVVMVapor. Behavior change for
+any existing `Encodable & AbortError` app error: today body+400, after
+body+own-status — the fix, not a regression.
+
+**Names.** `CredentialRejectedError` (event-framed, rooted in the seam's
+shipped *Credential* stem and *reject* verb); `Code` cases `.missing`
+(nothing presented — client config bug) / `.invalid` (presented and refused —
+rooted in the shipped `isValid`); `challenge` KEPT (transient, preserves
+RFC 7235 dressing); **no `message` field** (code-only; the client app owns
+UX wording — see §8).
+
+---
+
+## 3. Mechanics
+
+### 3.1 Server: serving the rejection
+
+```
+verifier.verify(headers:) throws
+        │
+        ▼
+ClientCredentialMiddleware catches:
+  - already CredentialRejectedError?  → rethrow as-is
+  - CancellationError?                → rethrow as cancellation
+  - anything else                     → wrap: .init(code: .invalid)
+        │
+        ▼                     (verifier contract is "throw to reject", §8;
+                               cancellation is a control-flow signal,
+                               not a domain rejection — it propagates)
+FOS ErrorMiddleware:
+  case any (Encodable & AbortError)   ← NEW, ordered first
+        │
+        ▼
+Response: the error's status (.unauthorized) + its headers (challenge)
+          + body = localizingEncoder(error)   ← self-identifying envelope
+```
+
+- `BearerCredentialVerifier` switches from `Abort` to throwing
+  `CredentialRejectedError(code: .missing)` / `(code: .invalid)` with
+  `challenge: "Bearer"`.
+- Custom verifiers may throw `CredentialRejectedError` directly (richer
+  intent) or keep throwing anything — the middleware wraps.
+- The "never echo the presented credential" constraint is unchanged and now
+  structurally easier: the error has no free-text field to echo into.
+
+### 3.2 Client: decoding the rejection — FOSFoundation UNTOUCHED
+
+The decode-order lives in an **internal** FOSMVVM wrapper passed as the ONE
+existing `errorType:` parameter — `DataFetch` keeps its single-error contract:
+
+```swift
+// INTERNAL — FOSMVVM plumbing, not public API
+enum WireError<E: ServerRequestError>: Error, Decodable {
+    case surface(CredentialRejectedError)   // strict: requires the envelope
+    case response(E)
+
+    init(from decoder: Decoder) throws {
+        // 1. Try CredentialRejectedError STRICTLY: required discriminator
+        //    key must be present with its exact expected value — else fall
+        //    through.
+        // 2. Try E (the request's ResponseError).
+        // 3. Else throw (DataFetch falls back to DataFetchError as today).
+    }
+}
+```
+
+`ServerRequest+Fetch.swift` passes `errorType: WireError<Self.ResponseError>.self`
+and unwraps in `processRequestCapturingRegistrations(baseURL:)`:
+`.surface` → throw the `CredentialRejectedError`; `.response` → throw the
+typed `ResponseError`. The `catch let error as ServerRequestError` block
+(`ServerRequest+Fetch.swift:192`) adds one pre-check implementing the
+routing decision (§2): `CredentialRejectedError` rethrows past the handler.
+
+### 3.3 The self-identifying envelope
+
+`CredentialRejectedError`'s `Codable` form carries a required discriminator
+key with a fixed expected value; `init(from:)` **fails** unless both match
+exactly.
+
+- The concrete key/value are an INTERNAL detail: pinned by a `//` maintainer
+  comment beside `CodingKeys` + an internal representation test + a committed
+  golden-blob forward-compat fixture. **Never published in DocC/CHANGELOG/README**
+  (the `published-representation` rule). Public docs state the contract only:
+  opaque, `Codable` round-trips, stable within a major version.
+- Strictness kills both puncture directions:
+  - nothing puns INTO `CredentialRejectedError` (a request's `ResponseError`,
+    Vapor's stock `{"error":true,"reason":…}`, and plain reason-strings all
+    lack the discriminator);
+  - `EmptyError` can no longer swallow rejections — the wrapper claims the
+    rejection body at step 1, before `EmptyError`'s decode-from-anything
+    runs. This retires the documented `DataFetch` 401-visibility gotcha
+    (`ClientCredentialMiddleware.swift:61–68`) for rejections.
+
+### 3.4 Test harness (hidden consumer)
+
+`FOSTestingVapor`'s `TestingServerRequestResponse` decodes `R.ResponseError`
+today. It composes the SAME wrapper (one decode-chain definition, reused) and
+exposes the rejection typed:
+
+- `error: R.ResponseError?` — unchanged semantics.
+- `credentialRejection: CredentialRejectedError?` — NEW, so server tests
+  assert rejections as typed data, not status-only. (Per-seam types mean a
+  future seam error adds its own property; no generic slot.)
+
+---
+
+## 4. Public surface (planning-gate applied)
+
+### FOSMVVM
+
+| Symbol | Justification (caller need) |
+|---|---|
+| `struct CredentialRejectedError: ServerRequestError` | The typed rejection callers catch; the credential seam's throw crossing the wire. |
+| `CredentialRejectedError.Code` enum: `.missing`, `.invalid` | The two caller-actionable meanings: nothing presented (client config bug) vs presented-and-refused (refresh/re-pull). Rooted in shipped verifier semantics (`isValid`). |
+| `CredentialRejectedError.init(code:challenge:)` | Constructed by the middleware, custom verifiers, and tests. |
+| `CredentialRejectedError.challenge: String?` — **transient, NOT encoded** | Carries the RFC 7235 challenge value ("Bearer") from verifier to transport dressing without Vapor types in FOSMVVM. Nil client-side. RATIFIED kept. |
+
+Gate notes:
+- **No `message` property (RATIFIED).** Deliberate deviation from the
+  `code + message` worked shape in `ServerRequestError`'s DocC: FOS ships no
+  localized strings today (all `Localizable` content is app-supplied), and
+  rejection UX is a client-hosted-ViewModel decision (Error UI Is Not
+  Special). A message adds localization machinery for marginal value.
+- **No stringly-typing:** no free-text reason field anywhere on the type.
+- **One serialization:** the envelope IS the type's only `Codable` form.
+- Boundaries hold: FOSFoundation untouched; Vapor conformance lives in
+  FOSMVVMVapor.
+
+### FOSMVVMVapor
+
+| Symbol | Justification |
+|---|---|
+| `extension CredentialRejectedError: AbortError` | Supplies `.unauthorized` + challenge header to the dressing case (§2). |
+| `ErrorMiddleware.default` — new first case `any (Encodable & AbortError)` | General mechanism (§2); no new public symbol, a documented behavior refinement. |
+| `ClientCredentialMiddleware` respond path | No signature change; rejection wrapping is internal behavior. DocC contract rewritten (§9). |
+| `BearerCredentialVerifier` | No signature change; throws `CredentialRejectedError` instead of `Abort`. |
+
+### FOSTestingVapor
+
+| Symbol | Justification |
+|---|---|
+| `TestingServerRequestResponse.credentialRejection` | Server tests must assert rejections as typed data. |
+
+### Explicitly NOT in scope
+
+- `ClientCredentialProvider` rejection hook / auto-refresh-retry — future,
+  additive. The enabling property is recorded in §8 (pre-operation ⇒
+  retry-safe) so the future pass doesn't re-derive it.
+- A version-rejection well-known error — deferred until a consumer exists;
+  the wrapper's closed-list shape already accommodates it.
+- `RequireVersionedAppMiddleware`, `DataFetch`, `DataFetchError` — untouched.
+
+---
+
+## 5. Customer-facing DocC (drafted FIRST)
+
+### `CredentialRejectedError`
+
+```swift
+/// The error thrown when a protected route rejects the request's credential
+///
+/// Routes grouped behind `ClientCredentialMiddleware` verify the presented
+/// credential before the operation runs. When verification rejects the
+/// request, this error crosses the wire and is rethrown by
+/// ``ServerRequest/processRequest(mvvmEnv:)`` — catch it to recover:
+///
+/// ```swift
+/// do {
+///     try await request.processRequest(mvvmEnv: mvvmEnv)
+/// } catch let error as CredentialRejectedError {
+///     switch error.code {
+///     case .missing: … // no credential was presented — check the
+///                      // MVVMEnvironment's clientCredentialProvider
+///     case .invalid: … // presented but refused — refresh the credential
+///                      // and retry (safe: the operation never ran)
+///     }
+/// }
+/// ```
+///
+/// The rejection happens **before** the operation runs, so retrying after
+/// recovery never duplicates the operation's effects.
+///
+/// This error always throws to the call site — it is never routed to
+/// ``MVVMEnvironment/requestErrorHandler``.
+```
+
+### `CredentialRejectedError.Code`
+
+```swift
+/// Why the credential seam rejected the request
+///
+/// `.missing` — no credential accompanied the request; typically the client
+/// has no `ClientCredentialProvider` configured (or it returned no headers).
+/// `.invalid` — a credential was presented and the server's verifier refused
+/// it; refresh the credential and retry.
+```
+
+### `AbortError` conformance (FOSMVVMVapor)
+
+```swift
+/// Dresses the rejection for the transport: `401 Unauthorized` with the
+/// verifier's authentication challenge (for example `WWW-Authenticate:
+/// Bearer`). The response *body* remains the typed error — FOSMVVM clients
+/// decode and rethrow it; the status exists for proxies, logs, and RFC 7235
+/// conformance, never for client branching.
+```
+
+### `ErrorMiddleware` (type DocC contract addition)
+
+```swift
+/// An error that is both `Encodable` and `AbortError` is served with its
+/// typed body (localized through the request's encoder) AND its own status
+/// and headers. A plain `Encodable` error keeps the typed body with
+/// `400 Bad Request`.
+```
+
+### `ClientCredentialMiddleware` — "Client-Side Contract" section REPLACED
+
+```swift
+/// ## Client-Side Contract
+///
+/// On a FOSMVVM client, a rejection surfaces from
+/// `processRequest(mvvmEnv:)` as `CredentialRejectedError` — the same typed
+/// error whether the request's own `ResponseError` is `EmptyError` or a
+/// custom type. Catch it to recover; see ``CredentialRejectedError``.
+```
+
+### `MVVMEnvironment.requestErrorHandler` (parameter DocC addition)
+
+```swift
+///   - requestErrorHandler: … Surface rejections
+///     (``CredentialRejectedError``) are never routed here — they always
+///     throw to the caller.
+```
+
+---
+
+## 6. Contract tests (public contract only; no `@testable` for contract)
+
+**FOSMVVM (unit):**
+1. `CredentialRejectedError` round-trips via `try value.toJSON().fromJSON()`
+   — code preserved, equality holds, `challenge` does NOT survive
+   (transient).
+2. Forward-compat: committed golden-blob rejection body decodes into
+   `CredentialRejectedError` (INTERNAL test — the one place the envelope
+   shape is pinned, beside the `//` maintainer note).
+3. Wrapper precedence (internal test): rejection body → `.surface`; a
+   request-error body → `.response`; Vapor stock abort JSON and a plain
+   reason-string → neither (falls through).
+
+**FOSMVVMVapor (E2E over the real middleware stack — remember
+`app.asyncBoot()` for async lifecycle handlers):**
+4. Protected route, no credential → client-side `processRequest` throws
+   `CredentialRejectedError` with `.missing`; transport shows 401 +
+   challenge header (transport assertions verify the *server's* dressing
+   contract — the client never branches on them).
+5. Protected route, bad credential → `.invalid`.
+6. **EmptyError retirement:** protected request whose `ResponseError ==
+   EmptyError` → rejection throws `CredentialRejectedError`, NOT a
+   silently-decoded `EmptyError`.
+7. **Precedence:** request with a permissive custom `ResponseError` →
+   rejection still surfaces as `CredentialRejectedError` (wrapper claims it
+   first).
+8. **Skew fallback:** a plain 401 without the envelope (old-server shape) →
+   today's behavior (`DataFetchError.badStatus` for required-field
+   `ResponseError`s) — no regression.
+9. **Handler bypass:** `MVVMEnvironment` with `requestErrorHandler` set →
+   rejection still throws; handler NOT called; a request's own
+   `ResponseError` still routes to the handler.
+10. **Dressing:** an `Encodable & AbortError` test error → own status +
+    typed body; a plain `Encodable` error → 400 + typed body (unchanged).
+11. Existing `ClientCredentialMiddlewareTests` pinning the old 401-visibility
+    contract are RESHAPED to the new contract (not deleted — same scenarios,
+    new assertions).
+
+**FOSTestingVapor:**
+12. `TestingServerRequestResponse.credentialRejection` populated on
+    rejection; `error` remains nil; and vice versa for operation errors.
+
+---
+
+## 7. Compatibility & versioning
+
+- **0.7.0, additive.** No wire shape removed; the rejection body *changes*
+  from a localized reason-string to the typed envelope.
+- New client ↔ old server: envelope decode fails → falls through to
+  `ResponseError` / `badStatus` exactly as today (test 8).
+- Old client ↔ new server: required-field `ResponseError`s fail to decode the
+  envelope → `badStatus(401)` as today. `EmptyError` requests: the old
+  client's `EmptyError` still decodes-anything and swallows — the documented
+  pre-existing hazard, unchanged for old clients, retired for new ones.
+- The `ErrorMiddleware` dressing change is called out in the CHANGELOG
+  (contract statement only — no envelope shape).
+
+## 8. Rationale & rejected alternatives (implementer prose — NOT for DocC)
+
+- **Per-request `admissionRejected` cases (the consumer's fallback option):**
+  rejected on *siting*, not just ceremony — a rejection is
+  1-per-protected-surface, not 1-per-request; embedding it in every request's
+  vocabulary mis-sites a 1:many responsibility at the 1:1 level (the
+  RefreshRequest lesson) and drifts (×12 in the consumer).
+- **Threading a second `errorType` through `DataFetch`:** rejected — touches
+  many public FOSFoundation overloads for an FOSMVVM concern. The internal
+  wrapper composes onto the shipped single-error mechanism with zero
+  FOSFoundation change and keeps the decode-order in ONE place.
+- **Carrying HTTP status on `DataFetchError` typed errors:** dead — the
+  status-first frame the errors-are-data ruling killed.
+- **One shared surface-error type:** rejected (§2) — a single shape must
+  absorb every seam's payload and its per-case transport dressing; per-seam
+  types keep SRP and crisper catches.
+- **`message: LocalizableString`:** cut (RATIFIED) — FOS ships no localized
+  strings today; rejection UX is a client-hosted-ViewModel decision. Cheap to
+  add later; expensive to remove.
+- **Middleware wraps ANY verifier throw as `.invalid`:** follows the shipped
+  verifier contract ("throw to reject" — `ClientCredentialMiddleware.swift:38`).
+  A verifier with genuine infra failures (DB down) can throw
+  `CredentialRejectedError` itself or — better — that distinction is a future
+  verifier-contract refinement, not this pass.
+- **Pre-operation ⇒ retry-safe (record for the future hook):**
+  `ClientCredentialMiddleware.respond` rejects BEFORE `next.respond`
+  (`ClientCredentialMiddleware.swift:89–93`) — the operation never ran, so
+  refresh-and-retry after a rejection can never duplicate a non-idempotent
+  operation. This is the property that legitimizes a future
+  `ClientCredentialProvider` auto-refresh seam.
+
+## 9. What this design retires
+
+- `ClientCredentialMiddleware` DocC "Client-Side Contract" +
+  "Known limitation" sections (`ClientCredentialMiddleware.swift:52–68`) —
+  replaced (§5).
+- The tests pinning the badStatus(401) client contract — reshaped (test 11).
+- API catalog `FOSMVVMVapor.md § ClientCredentialMiddleware` "Limitation"
+  paragraph — replaced with the typed contract.
+- Architecture doc / catalog gain the surface-error description; the
+  `status-interpreted-as-result` review check's anti-pattern example becomes
+  fixable-by-framework instead of merely-detectable.
+- Consumer-side (not this repo): the `badStatus(401)` interim catch and the
+  rotation deferral's prong-1 dependency.
+
+## 10. Decision record (all resolved 2026-07-13)
+
+1. Type name `CredentialRejectedError`; cases `.missing` / `.invalid` —
+   RATIFIED.
+2. Transient `challenge` property — RATIFIED kept.
+3. No `message` field — RATIFIED.
+4. Internal wrapper `WireError` and harness property `credentialRejection` —
+   implementation defaults, renameable in review.


### PR DESCRIPTION
## What

A credential rejection from `ClientCredentialMiddleware` is now the operation-layer's typed throw, end to end — the client catches `CredentialRejectedError` (`.missing` / `.invalid`) instead of sniffing `DataFetchError.badStatus(401)`.

Design spec (ratified 2026-07-13): `docs/superpowers/specs/2026-07-13-credential-rejection-typed-error-design.md` — this PR implements it exactly, including the three ratified decisions (per-seam error types, throw-past-`requestErrorHandler`, general `Encodable & AbortError` dressing).

## The contract

- **`CredentialRejectedError: ServerRequestError`** (FOSMVVM) — the credential seam's throw crossing the wire; strict self-identifying envelope (shape pinned internally, never published); transient `challenge`; no free-text fields.
- **Server**: `BearerCredentialVerifier` throws it typed; the middleware wraps any other verifier throw as `.invalid`; `CancellationError` propagates as cancellation. FOS `ErrorMiddleware` gains a general `Encodable & AbortError` case — typed body **with** the error's own status/headers, so `401` + `WWW-Authenticate` survive.
- **Client**: `processRequest(mvvmEnv:)` rethrows the same typed error — always past `requestErrorHandler` (recovery is a call-site decision). The rejection happens **before** the operation runs, so refresh-and-retry never duplicates effects.
- **`WireError` (`package`)** — one decode chain: the surface rejection is tried strictly before the request's own `ResponseError`. Retires the documented `EmptyError` rejection-swallow. Consumed by the client fetch path and `FOSTestingVapor`.
- **Harness**: `TestingServerRequestResponse.credentialRejection` — assert rejections typed, never on status.

## Compatibility (0.7.0, additive)

- FOSFoundation untouched; no public signature changed or removed.
- Old-server skew: a plain 401 without the envelope falls back to today's `badStatus(401)` (tested).
- Wire-visible behavior changes called out in CHANGELOG: `Encodable & AbortError` errors now serve their own status (was 400); custom-verifier throws are wrapped; a latent duplicate `Content-Type` on Encodable error responses is root-fixed.

## Verification

- 685 tests / 122 suites green; swiftformat + swiftlint clean.
- Every task ran TDD with spec + quality reviews; a final whole-system review traced one rejection from `verify(headers:)` through the wire into the caller's `catch`.
- Envelope-leak gate: the discriminator appears only in the source maintainer comment + internal tests — zero occurrences in DocC/CHANGELOG/catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZBhnyXr6TYPcrYBGwPWuX