### PR TITLE
feat: live-invalidation emit promotion — invalidateProjections(of:) + registerDependency(on:)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -116,6 +116,7 @@ Before hand-writing a helper, check whether it already exists — the catalog in
 - Form fields and input validation → `FOSMVVM.md § Forms`, `§ Validation`
 - SwiftUI binding/app setup, property versioning, deployment URLs → `FOSMVVM.md § SwiftUI Support`, `§ Versioning`
 - Vapor boot/Leaf, routes, Fluent factories, versioned middleware → `FOSMVVMVapor.md § Extensions`, `§ Vapor Support`, `§ Protocols`, `§ Middleware`
+- Live ViewModel refresh (server push), incl. nudging live clients from non-Fluent/hybrid sources → `FOSMVVMVapor.md § Live Invalidation`
 - Testing ViewModels / UI / ServerRequests → `FOSTesting.md § FOSTesting`, `§ FOSTestingUI`, `§ FOSTestingVapor`
 - PDF generation from SwiftUI views → `FOSReporting.md § PDF Rendering`
 

--- a/.claude/docs/FOSMVVMArchitecture.md
+++ b/.claude/docs/FOSMVVMArchitecture.md
@@ -1174,6 +1174,27 @@ A complete form specification consists of:
 
 ---
 
+## Live Invalidation
+
+A ViewModel opted into live refresh with `@ViewModel(options: [.live])` re-fetches whenever the server signals that the data it was served from has changed. Most of this is automatic: a Fluent-persisted model nudges live clients on every committed save, and plan-loaded records register their dependency with no code.
+
+Two cases fall outside that automatic path — a response reads state the record-load plan can't see (an `Application`-hosted actor's snapshot, a computed aggregate), and a non-Fluent source mutates that state. A paired public contract closes them.
+
+### The register / invalidate pair (non-Fluent sources)
+
+**Register a dependency on what you read; invalidate projections of what you changed.**
+
+- **`ProjectionContext.registerDependency(on:)`** (read side) — the factory declares that its response depends on a model the plan didn't load. The registered identity rides to the client with the response.
+- **`Application.invalidateProjections(of:)`** / **`Request.invalidateProjections(of:)`** (write side) — the non-Fluent source nudges live clients when its state changes. Inside `liveTransaction(_:)` the nudge reaches clients only if the transaction commits; where live invalidation is not enabled it is a no-op.
+
+**Both are required, and they must name the same entity.** Emit without a matching registration nudges nobody; registration without a matching emit refreshes never. That pairing *is* the live contract.
+
+**Fluent-persisted models never need either call** — their saves already notify live clients. Reach for the pair only for state Fluent doesn't own.
+
+**v1 scope:** the write side emits the changed model's *own* identity only — no containment derivation for non-Fluent sources. A screen that must refresh on a container's change registers a dependency on that container directly.
+
+---
+
 ## Key Macros
 
 | Macro | Purpose |

--- a/.claude/skills/fosutilities-api-catalog/SKILL.md
+++ b/.claude/skills/fosutilities-api-catalog/SKILL.md
@@ -62,6 +62,7 @@ line via the `fosutilities-api-catalog-update` skill.
 - Registering the container authorization provider, apex resolver, per-request app state, or a container migration → `FOSMVVMVapor.md § Containment`, `§ Extensions`
 - Filtering (narrowing) a large container load by the request's query → `FOSMVVMVapor.md § Containment`
 - Enabling server-pushed refresh at boot, or transactional writes that notify live clients → `FOSMVVMVapor.md § Live Invalidation`
+- Refreshing live screens whose data isn't Fluent-persisted — nudging from an `Application`-hosted actor or computed aggregate, or registering a dependency the load plan can't see → `FOSMVVMVapor.md § Live Invalidation`
 - The server-side write path — candidate set, field application, authorization provider → `FOSMVVMVapor.md § Protocols`
 - Projecting the database into ViewModels — resolvable requests, Fluent `DataModel` → `FOSMVVMVapor.md § Protocols`
 - Serving typed/localized errors, gating routes on client app version → `FOSMVVMVapor.md § Middleware`

--- a/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
@@ -355,7 +355,11 @@ Server-push refresh for `@ViewModel(options: [.live])` screens (FOSMVVM's
 `LiveViewModel`): enable it once at boot, and every committed change to a
 registered container model nudges connected clients to re-fetch. The moving parts
 behind it — the fan-out hub, the per-model emit middleware, and the SSE stream
-route — are all internal; the two calls below are the entire author-facing surface.
+route — are all internal; the calls below are the entire author-facing surface.
+Fluent-persisted container models refresh automatically (their saves notify, see
+`register(_:migration:)` under Extensions). The `registerDependency()` /
+`invalidateProjections()` pair covers what Fluent doesn't own — state an
+`Application`-hosted actor or a computed aggregate holds.
 
 ### Enable server-push refresh at boot — `useLiveInvalidation()`
 Reach for this when: turning on live invalidation for the server — call once in
@@ -390,6 +394,41 @@ try await req.liveTransaction { db in
     dock.status = .closed
     try await dock.save(on: db)
 }
+```
+
+### Nudge live clients from a non-Fluent source — `invalidateProjections()`
+Reach for this when: state a live screen shows lives outside Fluent and just changed — an
+`Application`-hosted actor mutating its own data, a computed aggregate going stale — and you
+must refresh the projections built from it. Call `req.invalidateProjections(of: model)` in a
+route handler, or `app.invalidateProjections(of: model)` from an actor or background job. It
+composes with `liveTransaction`: called inside one, the nudge reaches clients only if the
+transaction commits. With live invalidation not enabled it is a no-op. Pair it with
+`registerDependency()` on the read side — a nudge refreshes only the projections that
+registered a dependency on the same model. v1 emits the changed model's own identity only; a
+screen that must refresh on a container's change registers a dependency on that container.
+Don't reach for it for Fluent-persisted models — their saves already notify live clients.
+
+```swift
+// actor mutates its own state, then nudges the screens built from it
+activeSessions += 1
+try await app.invalidateProjections(of: snapshot())
+```
+
+### Register a live dependency the plan can't see — `registerDependency()`
+Reach for this when: a `body(context:)` projection reads state the load plan can't see — an
+`appState` snapshot of an `Application`-hosted actor, a computed value — and its screen is
+`@ViewModel(options: [.live])`. Plan-loaded records register automatically (that is what
+`records(_:)` reads); call `context.registerDependency(on: model)` for the rest. The
+registered identity rides to the client with the response, so a later
+`invalidateProjections()` for the same model refreshes the screen. Register a dependency on
+what you read; invalidate projections of what you changed — the two must name the same
+entity, and that pairing *is* the live contract.
+Don't reach for it for records the plan already loaded, or for Fluent saves the framework
+already notifies.
+
+```swift
+let status = context.appState.status
+try context.registerDependency(on: status)
 ```
 
 ## Protocols

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`Application.invalidateProjections(of:)`** / **`Request.invalidateProjections(of:)`**
+  (FOSMVVMVapor) — non-Fluent server-side sources (an `Application`-hosted actor, a
+  computed aggregate) nudge live clients to refresh when their state changes. Composes
+  with `liveTransaction` — inside it the nudge reaches clients only if the transaction
+  commits; where live invalidation is not enabled it is a no-op. Fluent-persisted models
+  never need it — their saves already notify live clients.
+- **`ProjectionContext.registerDependency(on:)`** (FOSMVVMVapor) — a factory registers
+  response data the record-load plan can't see (e.g. an `appState` actor snapshot) so
+  live clients refresh it when the model changes. Register a dependency on what you read;
+  invalidate projections of what you changed.
 
 ## [0.7.0] - 2026-07-14
 

--- a/Sources/FOSFoundation/Async/Task.swift
+++ b/Sources/FOSFoundation/Async/Task.swift
@@ -62,7 +62,9 @@ public extension Task where Failure == Error {
         }
 
         semaphore.wait()
-        if let error = box.value { throw error }
+        if let error = box.value {
+            throw error
+        }
     }
 }
 

--- a/Sources/FOSMVVM/Forms/FormField.swift
+++ b/Sources/FOSMVVM/Forms/FormField.swift
@@ -236,7 +236,9 @@ private extension FormField {
         if case FormFieldType.text(let inputType) = type,
            inputType == .date || inputType == .datetimeLocal,
            options.count(where: {
-               if case FormInputOption.size = $0 { return true }
+               if case FormInputOption.size = $0 {
+                   return true
+               }
                return false
            }) == 0 {
             options.append(FormInputOption<Value>.size(value: inputType == .date

--- a/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
+++ b/Sources/FOSMVVM/Localization/YamlLocalizationStore.swift
@@ -165,14 +165,30 @@ private struct YamlValue {
     let boolArray: [Bool]?
 
     var value: Any? {
-        if let string { return string }
-        if let int { return int }
-        if let double { return double }
-        if let bool { return bool }
-        if let stringArray { return stringArray }
-        if let intArray { return intArray }
-        if let doubleArray { return doubleArray }
-        if let boolArray { return boolArray }
+        if let string {
+            return string
+        }
+        if let int {
+            return int
+        }
+        if let double {
+            return double
+        }
+        if let bool {
+            return bool
+        }
+        if let stringArray {
+            return stringArray
+        }
+        if let intArray {
+            return intArray
+        }
+        if let doubleArray {
+            return doubleArray
+        }
+        if let boolArray {
+            return boolArray
+        }
 
         return nil
     }

--- a/Sources/FOSMVVM/Protocols/ProjectionContext.swift
+++ b/Sources/FOSMVVM/Protocols/ProjectionContext.swift
@@ -33,7 +33,9 @@ public struct ProjectionContext<Request: ServerRequest, AppState: Sendable>: @un
     // @unchecked Sendable: the records vended by `recordsByTuple` are live model class instances
     // (not statically Sendable), captured here as a value snapshot of the request's loaded records.
     // The snapshot is only ever READ, and only within the request's handler task (the context must
-    // not escape the projection). No reader mutates the shared instances.
+    // not escape the projection). No reader mutates the shared instances. The `dependencySink`
+    // closure is likewise invoke-only on that same handler task (see its field doc) — never stored,
+    // never called off-task.
 
     /// The typed request — query, sort, pagination, selectors.
     public let vmRequest: Request

--- a/Sources/FOSMVVM/Protocols/ProjectionContext.swift
+++ b/Sources/FOSMVVM/Protocols/ProjectionContext.swift
@@ -52,28 +52,39 @@ public struct ProjectionContext<Request: ServerRequest, AppState: Sendable>: @un
     /// FOSMVVMVapor's `totalCount(for:)`, never as raw storage.
     package let countsByTuple: [RecordLoadPlan.Tuple: Int]
 
+    /// Deposits one registered dependency identity into the serving request's
+    /// registration set. Installed at construction — required, never defaulted: a
+    /// silently-dropping sink would be a misconfiguration's invisible mode. Invoked
+    /// only within the projection, on the request's handler task (the same
+    /// no-escape contract the record snapshot already relies on).
+    package let dependencySink: (ModelIdentity) -> Void
+
     package init(
         vmRequest: Request,
         appState: AppState,
         plan: RecordLoadPlan,
         recordsByTuple: [RecordLoadPlan.Tuple: [any Model]],
-        countsByTuple: [RecordLoadPlan.Tuple: Int] = [:]
+        countsByTuple: [RecordLoadPlan.Tuple: Int] = [:],
+        dependencySink: @escaping (ModelIdentity) -> Void
     ) {
         self.vmRequest = vmRequest
         self.appState = appState
         self.plan = plan
         self.recordsByTuple = recordsByTuple
         self.countsByTuple = countsByTuple
+        self.dependencySink = dependencySink
     }
 
     package init(
         vmRequest: Request,
-        appState: AppState
+        appState: AppState,
+        dependencySink: @escaping (ModelIdentity) -> Void
     ) {
         self.vmRequest = vmRequest
         self.appState = appState
         self.plan = nil
         self.recordsByTuple = [:]
         self.countsByTuple = [:]
+        self.dependencySink = dependencySink
     }
 }

--- a/Sources/FOSMVVM/Protocols/ValidatableModel.swift
+++ b/Sources/FOSMVVM/Protocols/ValidatableModel.swift
@@ -121,8 +121,12 @@ public extension ValidationResult.Status {
 
         forLoop: for valResponse in validations {
             switch valResponse.status {
-            case .info: if status < .info { status = .info }
-            case .warning: if status < .warning { status = .warning }
+            case .info: if status < .info {
+                    status = .info
+                }
+            case .warning: if status < .warning {
+                    status = .warning
+                }
             case .error: status = .error; break forLoop
             }
         }

--- a/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
@@ -101,7 +101,9 @@ struct SSEInvalidationChannel: InvalidationChannel {
             } catch {
                 // Any open/stream failure is a drop → reconnect after back-off.
             }
-            if Task.isCancelled { break }
+            if Task.isCancelled {
+                break
+            }
             await sleep(backoff)
             backoff = min(backoff * 2, maxBackoff)
         }

--- a/Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift
@@ -46,11 +46,12 @@ public extension Vapor.Application {
     ///
     /// Clients refresh the ViewModels whose factory called
     /// ``FOSMVVM/ProjectionContext/registerDependency(on:)`` for this model.
-    /// Fluent-persisted models never need this call — their saves already
-    /// notify live clients. When the change ships together with Fluent writes,
-    /// make the call inside ``liveTransaction(_:)`` and it reaches clients
-    /// only if the transaction commits. With live invalidation not enabled
-    /// (no `useLiveInvalidation(on:)` at boot) it is a no-op.
+    ///
+    /// > **Fluent-persisted models never need this call** — their saves already
+    /// > notify live clients. When the change ships together with Fluent writes,
+    /// > make the call inside ``liveTransaction(_:)`` and it reaches clients
+    /// > only if the transaction commits. With live invalidation not enabled
+    /// > (no `useLiveInvalidation(on:)` at boot) it is a no-op.
     ///
     /// - Throws: `ModelError.missingId` when `model.id` is `nil`.
     func invalidateProjections(of model: some FOSMVVM.Model) async throws {

--- a/Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift
@@ -1,0 +1,92 @@
+// InvalidateProjections.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSMVVM
+import Foundation
+import Vapor
+
+public extension Vapor.Application {
+    /// Nudges live clients to refresh every projection built from `model`
+    ///
+    /// Call it at each point a non-Fluent source commits a change — an
+    /// `Application`-hosted actor mutating its state, a computed aggregate
+    /// going stale:
+    ///
+    /// ```swift
+    /// actor StatusMonitor {
+    ///     // Minted once — the identity of "the status" for this process's
+    ///     // lifetime. A restart is covered: reconnecting clients refresh
+    ///     // every live screen.
+    ///     private let statusId = ModelIdType()
+    ///     private var activeSessions = 0
+    ///
+    ///     func sessionOpened(app: Application) async throws {
+    ///         activeSessions += 1
+    ///         try await app.invalidateProjections(of: snapshot())
+    ///     }
+    ///
+    ///     func snapshot() -> StatusSnapshot {
+    ///         .init(id: statusId, activeSessions: activeSessions)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Clients refresh the ViewModels whose factory called
+    /// ``FOSMVVM/ProjectionContext/registerDependency(on:)`` for this model.
+    /// Fluent-persisted models never need this call — their saves already
+    /// notify live clients. When the change ships together with Fluent writes,
+    /// make the call inside ``liveTransaction(_:)`` and it reaches clients
+    /// only if the transaction commits. With live invalidation not enabled
+    /// (no `useLiveInvalidation(on:)` at boot) it is a no-op.
+    ///
+    /// - Throws: `ModelError.missingId` when `model.id` is `nil`.
+    func invalidateProjections(of model: some FOSMVVM.Model) async throws {
+        try await routeProjectionInvalidation(of: model, hub: invalidationHub)
+    }
+}
+
+public extension Vapor.Request {
+    /// Nudges live clients to refresh every projection built from `model`
+    ///
+    /// The request-scoped spelling of
+    /// ``Vapor/Application/invalidateProjections(of:)`` — same behavior, for
+    /// call sites inside a route handler:
+    ///
+    /// ```swift
+    /// try await req.invalidateProjections(of: status)
+    /// ```
+    func invalidateProjections(of model: some FOSMVVM.Model) async throws {
+        try await application.invalidateProjections(of: model)
+    }
+}
+
+/// The shared routing core, mirroring the middleware's pinned order
+/// (InvalidationEmitMiddleware.route): task-local collector present → COLLECT
+/// (its liveTransaction flushes on commit); else hub present → EMIT; else live
+/// invalidation is not enabled → no-op. A collector is only ever installed by
+/// liveTransaction, which requires a hub — so collector-first never strands a nudge.
+private func routeProjectionInvalidation(
+    of model: some FOSMVVM.Model,
+    hub: InvalidationHub?
+) async throws {
+    let identity = try model.modelIdentity
+
+    if let collector = LiveTransactionState.collector {
+        await collector.collect([identity])
+    } else if let hub {
+        await hub.emit([identity])
+    }
+}

--- a/Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift
@@ -73,7 +73,7 @@ public extension Vapor.Request {
     }
 }
 
-/// The shared routing core, mirroring the middleware's pinned order
+/// The shared routing core, following the middleware's collector-first precedence
 /// (InvalidationEmitMiddleware.route): task-local collector present → COLLECT
 /// (its liveTransaction flushes on commit); else hub present → EMIT; else live
 /// invalidation is not enabled → no-op. A collector is only ever installed by

--- a/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationHub.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/InvalidationHub.swift
@@ -39,8 +39,8 @@ actor InvalidationHub {
         let (stream, continuation) = AsyncStream<Set<ModelIdentity>>.makeStream(
             bufferingPolicy: .bufferingOldest(Self.subscriberBufferLimit)
         )
-        continuation.onTermination = { _ in
-            Task { [weak self] in
+        continuation.onTermination = { [weak self] _ in
+            Task {
                 await self?.removeSubscriber(id)
             }
         }

--- a/Sources/FOSMVVMVapor/LiveInvalidation/ProjectionContext+Dependencies.swift
+++ b/Sources/FOSMVVMVapor/LiveInvalidation/ProjectionContext+Dependencies.swift
@@ -1,0 +1,58 @@
+// ProjectionContext+Dependencies.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FOSFoundation
+import FOSMVVM
+import Foundation
+
+// swiftformat:disable docComments
+// The registration deposit is a server capability — the sink writes into the serving Request's
+// registration set (FOSMVVMVapor's ServeRequest installs it). So the public method lives at this
+// layer even though `dependencySink` is FOSMVVM's field, the same siting rationale as `records(_:)`.
+// swiftformat:enable docComments
+public extension ProjectionContext {
+    /// Declares that this response depends on `model`, so live clients refresh
+    /// its projections when the model changes
+    ///
+    /// Plan-loaded records are registered automatically. Call this from your
+    /// factory for data the plan can't see — state your `appState` builder
+    /// snapshotted from an `Application`-hosted actor:
+    ///
+    /// ```swift
+    /// // boot: the builder snapshots the actor (async, before the factory runs)
+    /// try app.useAppState(DashboardState.self) { req in
+    ///     DashboardState(status: await req.application.statusMonitor.snapshot())
+    /// }
+    ///
+    /// // factory: read the value, register the dependency
+    /// static func body<R: ServerRequest>(context: ProjectionContext<R, DashboardState>) throws -> Self
+    ///     where R.ResponseBody == Self {
+    ///     let status = context.appState.status
+    ///     try context.registerDependency(on: status)
+    ///     return .init(activeSessions: status.activeSessions)
+    /// }
+    /// ```
+    ///
+    /// The registered identity rides to the client with the response; a later
+    /// ``Vapor/Application/invalidateProjections(of:)`` for the same model triggers the refresh.
+    /// Register and invalidate must name the same entity — that pairing IS the
+    /// live contract.
+    ///
+    /// - Throws: `ModelError.missingId` when `model.id` is `nil`.
+    func registerDependency(on model: some FOSMVVM.Model) throws {
+        try dependencySink(model.modelIdentity)
+    }
+}

--- a/Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift
@@ -35,11 +35,15 @@ package extension Vapor.Request {
         try await executeRecordLoadPlan(for: vmRequest)
 
         let appState = try await resolveAppState(SR.ResponseBody.AppState.self, request: SR.self)
+        // The factory's dependency deposit: INSERTS into the set executeRecordLoadPlan
+        // already assigned — factory-registered identities merge with the plan's, and
+        // buildResponse attaches the union as X-FOS-Registrations.
+        let dependencySink: (ModelIdentity) -> Void = { self.registrationSet.insert($0) }
         // A zero-data body has no derived plan; it constructs a context that carries no records.
         let context: ProjectionContext<SR, SR.ResponseBody.AppState> = if let plan = application.recordLoadPlan(for: SR.self) {
-            .init(vmRequest: vmRequest, appState: appState, plan: plan, recordsByTuple: recordsByTuple(), countsByTuple: countsByTuple())
+            .init(vmRequest: vmRequest, appState: appState, plan: plan, recordsByTuple: recordsByTuple(), countsByTuple: countsByTuple(), dependencySink: dependencySink)
         } else {
-            .init(vmRequest: vmRequest, appState: appState)
+            .init(vmRequest: vmRequest, appState: appState, dependencySink: dependencySink)
         }
         return try SR.ResponseBody.body(context: context)
     }

--- a/Sources/FOSTestingVapor/ServedFluentTestHarness.swift
+++ b/Sources/FOSTestingVapor/ServedFluentTestHarness.swift
@@ -67,7 +67,7 @@ public func withServedFluentTestApp<R: Sendable>(
         // asyncBoot (not startup()): async lifecycle handlers only run under async boot, and
         // startup()'s console parser chokes on test-runner arguments (see FluentTestHarness).
         try await app.asyncBoot()
-        try await app.server.start()
+        try app.server.start()
         serverStarted = true
 
         guard let port = app.http.server.shared.localAddress?.port,

--- a/Sources/FOSTestingVapor/VaporServerTestCase.swift
+++ b/Sources/FOSTestingVapor/VaporServerTestCase.swift
@@ -25,7 +25,7 @@ public final class VaporServerRequestTest<Request: ServerRequest>: Sendable
     where Request.ResponseBody: VaporResponseBodyFactory {
     // `Bundle` is an immutable resource handle; it is only ever read (never
     // mutated) here, so treat it as safe to hold in this `Sendable` harness.
-    private nonisolated(unsafe) let bundle: Bundle
+    private let bundle: Bundle
     private let resourceDirectoryName: String
 
     public init(for request: Request.Type, bundle: Bundle, resourceDirectoryName: String = "Resources") async throws {

--- a/Tests/FOSMVVMTests/Protocols/InvalidationChannelTests.swift
+++ b/Tests/FOSMVVMTests/Protocols/InvalidationChannelTests.swift
@@ -82,7 +82,9 @@ struct InvalidationChannelTests {
 
         var sawConnected = false
         for await event in stored.events() {
-            if case .connected = event { sawConnected = true }
+            if case .connected = event {
+                sawConnected = true
+            }
         }
         #expect(sawConnected)
     }

--- a/Tests/FOSMVVMTests/SwiftUI Support/InvalidationDispatcherTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/InvalidationDispatcherTests.swift
@@ -283,7 +283,9 @@ private extension InvalidationDispatcherTests {
 
     func waitUntil(_ predicate: @MainActor () -> Bool) async {
         for _ in 0..<200 {
-            if predicate() { return }
+            if predicate() {
+                return
+            }
             await Task.yield()
             try? await Task.sleep(nanoseconds: 500000)
         }

--- a/Tests/FOSMVVMTests/SwiftUI Support/LiveRegistrationCoordinatorTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/LiveRegistrationCoordinatorTests.swift
@@ -147,7 +147,9 @@ private extension LiveRegistrationCoordinatorTests {
 
     func waitUntil(_ predicate: @MainActor () -> Bool) async {
         for _ in 0..<200 {
-            if predicate() { return }
+            if predicate() {
+                return
+            }
             await Task.yield()
             try? await Task.sleep(nanoseconds: 500000)
         }

--- a/Tests/FOSMVVMTests/SwiftUI Support/SSEChannelParsingTests.swift
+++ b/Tests/FOSMVVMTests/SwiftUI Support/SSEChannelParsingTests.swift
@@ -168,7 +168,9 @@ private func collectSleeps(
             initialBackoff: initialBackoff,
             maxBackoff: maxBackoff
         ) { _, onOpen in
-            if await script.nextShouldOpen() { onOpen() }
+            if await script.nextShouldOpen() {
+                onOpen()
+            }
             throw DropError()
         }
     }
@@ -176,7 +178,9 @@ private func collectSleeps(
     var collected: [Duration] = []
     for await duration in durations {
         collected.append(duration)
-        if collected.count == count { break }
+        if collected.count == count {
+            break
+        }
     }
     loop.cancel()
     durationsCont.finish()
@@ -203,8 +207,12 @@ private func collectConnects(count: Int) async -> Int {
 
     var connects = 0
     for await event in events {
-        if case .connected = event { connects += 1 }
-        if connects == count { break }
+        if case .connected = event {
+            connects += 1
+        }
+        if connects == count {
+            break
+        }
     }
     loop.cancel()
     eventsCont.finish()

--- a/Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift
+++ b/Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift
@@ -90,9 +90,9 @@ private func makeContext<SR: ServerRequest>(
     on req: Vapor.Request
 ) -> ProjectionContext<SR, Void> {
     guard let plan = req.application.recordLoadPlan(for: SR.self) else {
-        return .init(vmRequest: vmRequest, appState: ())
+        return .init(vmRequest: vmRequest, appState: (), dependencySink: { _ in })
     }
-    return .init(vmRequest: vmRequest, appState: (), plan: plan, recordsByTuple: req.recordsByTuple())
+    return .init(vmRequest: vmRequest, appState: (), plan: plan, recordsByTuple: req.recordsByTuple(), dependencySink: { _ in })
 }
 
 // MARK: - Fixtures
@@ -454,7 +454,8 @@ struct ProjectionContextTests {
             vmRequest: DockPageRequest(),
             appState: (),
             plan: plan,
-            recordsByTuple: [:]
+            recordsByTuple: [:],
+            dependencySink: { _ in }
         )
 
         do {

--- a/Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift
+++ b/Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift
@@ -113,9 +113,9 @@ private final class PagedDockRequest: ViewModelRequest, @unchecked Sendable {
 /// Builds the context the way `serve` does — WITH the count snapshot.
 private func makeContext(for vmRequest: PagedDockRequest, on req: Vapor.Request) -> ProjectionContext<PagedDockRequest, Void> {
     guard let plan = req.application.recordLoadPlan(for: PagedDockRequest.self) else {
-        return .init(vmRequest: vmRequest, appState: ())
+        return .init(vmRequest: vmRequest, appState: (), dependencySink: { _ in })
     }
-    return .init(vmRequest: vmRequest, appState: (), plan: plan, recordsByTuple: req.recordsByTuple(), countsByTuple: req.countsByTuple())
+    return .init(vmRequest: vmRequest, appState: (), plan: plan, recordsByTuple: req.recordsByTuple(), countsByTuple: req.countsByTuple(), dependencySink: { _ in })
 }
 
 @Suite("Paginated total-count")

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidateProjectionsTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidateProjectionsTests.swift
@@ -1,0 +1,175 @@
+// InvalidateProjectionsTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+// The internal hub subscribe is block coverage of an internal seam (same note as
+// LiveTransactionTests); every asserted identity is minted/compared via public API.
+
+/// Neutral non-Fluent fixture: an Application-hosted source's state snapshot.
+/// FOSMVVM.Model only — deliberately NOT a FluentKit.Model.
+private struct StatusSnapshot: FOSMVVM.Model {
+    let id: ModelIdType?
+    var activeSessions: Int = 0
+}
+
+/// The stable identity the request-forwarding route nudges (minted once, file-private).
+private let pokeId = ModelIdType()
+
+@Suite("invalidateProjections(of:) — public write-side entry for non-Fluent sources")
+struct InvalidateProjectionsTests {
+    /// Outside any transaction, the call emits exactly the model's own identity.
+    @Test func emitsOwnIdentityImmediately() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, _ in
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let status = StatusSnapshot(id: ModelIdType(), activeSessions: 3)
+            try await app.invalidateProjections(of: status)
+
+            #expect(try await events.next() == Set([status.modelIdentity]))
+        }
+    }
+
+    /// Inside liveTransaction, the nudge joins the collector: ONE union event after
+    /// commit, containing the actor identity AND the SQL write's derived set.
+    @Test func joinsLiveTransactionUnionOnCommit() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.query(on: db).first())
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let status = StatusSnapshot(id: ModelIdType(), activeSessions: 1)
+            let berth = try Berth(number: 42, dockName: dock1.name, dockId: dock1.requireId())
+            try await app.liveTransaction { tx in
+                try await berth.save(on: tx)
+                try await app.invalidateProjections(of: status)
+            }
+
+            let expected = try Set([
+                status.modelIdentity,
+                berth.modelIdentity,
+                dock1.modelIdentity
+            ])
+            #expect(try await events.next() == expected)
+
+            // Exactly one flush: the next event is the sentinel, not a second emission.
+            let sentinel = try Set([harbor.modelIdentity])
+            await hub.emit(sentinel)
+            #expect(try await events.next() == sentinel)
+        }
+    }
+
+    /// A thrown liveTransaction discards the collected nudge — sentinel-first.
+    @Test func rolledBackTransactionEmitsNothing() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let harbor = try #require(await Harbor.query(on: db).first())
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let status = StatusSnapshot(id: ModelIdType(), activeSessions: 5)
+            await #expect(throws: Boom.self) {
+                try await app.liveTransaction { _ in
+                    try await app.invalidateProjections(of: status)
+                    throw Boom()
+                }
+            }
+
+            // Nothing was emitted: the first event the subscriber sees is the sentinel.
+            let sentinel = try Set([harbor.modelIdentity])
+            await hub.emit(sentinel)
+            #expect(try await events.next() == sentinel)
+        }
+    }
+
+    /// With live invalidation not enabled, the call is a no-op — no throw, no trap.
+    @Test func disabledIsNoOp() async throws {
+        try await withFluentTestApp { _ in
+            // Live invalidation NOT enabled.
+        } _: { app, _ in
+            let status = StatusSnapshot(id: ModelIdType())
+            try await app.invalidateProjections(of: status)
+            #expect(app.invalidationHub == nil)
+        }
+    }
+
+    /// An unpersisted model (nil id) throws ModelError.missingId — never a silent skip.
+    @Test func nilIdThrowsMissingId() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, _ in
+            await #expect(throws: ModelError.self) {
+                try await app.invalidateProjections(of: StatusSnapshot(id: nil))
+            }
+        }
+    }
+
+    /// Request forwarding reaches the same hub.
+    @Test func requestForwardingEmits() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+            app.get("poke") { req async throws -> HTTPStatus in
+                try await req.invalidateProjections(of: StatusSnapshot(id: pokeId))
+                return .ok
+            }
+        } _: { app, _ in
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let httpReq = Request(
+                application: app,
+                method: .GET,
+                url: URI(string: "/poke"),
+                on: app.eventLoopGroup.next()
+            )
+            let response = try await app.responder.respond(to: httpReq).get()
+            #expect(response.status == .ok)
+
+            #expect(try await events.next() == Set([StatusSnapshot(id: pokeId).modelIdentity]))
+        }
+    }
+}
+
+private struct Boom: Error {}
+
+/// Registers the harbor graph and enables live invalidation.
+/// (File-private and duplicated per test file with differing signatures — copied from
+/// LiveTransactionTests; not callable across files.)
+private func configureLiveHarbor(_ app: Application) throws {
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreatePier())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useLiveInvalidation(on: app.routes)
+}

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift
@@ -1,0 +1,315 @@
+// RegisterDependencyTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The read-side twin of invalidateProjections(of:): a factory calls
+// context.registerDependency(on:) for data the plan can't see, and that identity rides to the
+// client in the X-FOS-Registrations header alongside the plan's own set. Exercised through the
+// real HTTP responder so the factory's deposit reaches the shared buildResponse on the same
+// Request the header rides — the same served-HTTP pattern as RegistrationHeaderTests.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+// MARK: - Fixtures
+
+/// Neutral non-Fluent fixture: an Application-hosted source's state snapshot the plan can't see.
+/// FOSMVVM.Model only — deliberately NOT a FluentKit.Model (mirrors InvalidateProjectionsTests).
+private struct StatusSnapshot: FOSMVVM.Model {
+    let id: ModelIdType?
+    var activeSessions: Int = 0
+}
+
+/// The stable identity the zero-data dashboard registers (minted once, file-private) — shared by
+/// the membership, exactness, and end-to-end tests so register and invalidate name the same value.
+private let knownId = ModelIdType()
+
+/// The distinct identity the plan-bearing fixture registers — kept apart from the plan's container
+/// identities so the merge test proves both halves land.
+private let mergeSnapshotId = ModelIdType()
+
+/// A zero-data body (no ``dataRequirements``, no plan) whose factory registers a StatusSnapshot —
+/// exercises the serve else-branch sink.
+private struct StatusDashboardVM: RequestableViewModel, VaporResponseBodyFactory {
+    typealias Request = StatusDashboardRequest
+
+    var vmId = ViewModelId()
+    var activeSessions: Int = 0
+
+    init() {}
+    init(activeSessions: Int) {
+        self.activeSessions = activeSessions
+    }
+
+    func propertyNames() -> [LocalizableId: String] {
+        [:]
+    }
+
+    static func stub() -> Self {
+        .init()
+    }
+
+    static func body<R: ServerRequest>(context: ProjectionContext<R, Void>) throws -> Self where R.ResponseBody == Self {
+        let snapshot = StatusSnapshot(id: knownId, activeSessions: 3)
+        try context.registerDependency(on: snapshot)
+        return .init(activeSessions: snapshot.activeSessions)
+    }
+}
+
+private final class StatusDashboardRequest: ViewModelRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias ResponseError = EmptyError
+
+    let id: String
+    var responseBody: StatusDashboardVM?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil, requestBody: EmptyBody? = nil, responseBody: StatusDashboardVM? = nil) {
+        self.id = .random(length: 10)
+        self.responseBody = responseBody
+    }
+}
+
+/// An apex-rooted read WITH a plan (the HarborBerthsVM shape) whose factory ALSO registers a
+/// StatusSnapshot — so the header must carry the plan's container identities AND the snapshot's.
+private struct HarborStatusVM: RequestableViewModel, ComposableFactory, VaporResponseBodyFactory {
+    typealias Request = HarborStatusRequest
+
+    static let berths = LoadRequirement.read(Berth.self, in: .newRoot(.apex), via: Dock.self)
+    static var dataRequirements: [any DataRequirement] {
+        [berths]
+    }
+
+    var vmId = ViewModelId()
+    var berthNumbers: [Int] = []
+
+    init() {}
+    init(berthNumbers: [Int]) {
+        self.berthNumbers = berthNumbers
+    }
+
+    func propertyNames() -> [LocalizableId: String] {
+        [:]
+    }
+
+    static func stub() -> Self {
+        .init()
+    }
+
+    static func body<R: ServerRequest>(context: ProjectionContext<R, Void>) throws -> Self where R.ResponseBody == Self {
+        try context.registerDependency(on: StatusSnapshot(id: mergeSnapshotId))
+        return try .init(berthNumbers: context.records(berths).map(\.number).sorted())
+    }
+}
+
+private final class HarborStatusRequest: ViewModelRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias ResponseError = EmptyError
+
+    let id: String
+    var responseBody: HarborStatusVM?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil, requestBody: EmptyBody? = nil, responseBody: HarborStatusVM? = nil) {
+        self.id = .random(length: 10)
+        self.responseBody = responseBody
+    }
+}
+
+/// A zero-data body whose factory registers a StatusSnapshot with a `nil` id — the throwing
+/// `modelIdentity` getter must surface an error through serve, never a silently-missing deposit.
+private struct NilSnapshotVM: RequestableViewModel, VaporResponseBodyFactory {
+    typealias Request = NilSnapshotRequest
+
+    var vmId = ViewModelId()
+
+    func propertyNames() -> [LocalizableId: String] {
+        [:]
+    }
+
+    static func stub() -> Self {
+        .init()
+    }
+
+    static func body<R: ServerRequest>(context: ProjectionContext<R, Void>) throws -> Self where R.ResponseBody == Self {
+        try context.registerDependency(on: StatusSnapshot(id: nil))
+        return .init()
+    }
+}
+
+private final class NilSnapshotRequest: ViewModelRequest, @unchecked Sendable {
+    typealias Query = EmptyQuery
+    typealias ResponseError = EmptyError
+
+    let id: String
+    var responseBody: NilSnapshotVM?
+
+    init(query: EmptyQuery? = nil, sort: EmptySort? = nil, fragment: EmptyFragment? = nil, requestBody: EmptyBody? = nil, responseBody: NilSnapshotVM? = nil) {
+        self.id = .random(length: 10)
+        self.responseBody = responseBody
+    }
+}
+
+// MARK: - Harness
+
+/// The serving side: localization, the Harbor → Dock → Berth graph, and the storage-backed grants
+/// provider (grants are set per test, after seeding). Mirrors RegistrationHeaderTests' configureHarbor.
+private func configureServe(_ app: Application) throws {
+    try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
+    app.migrations.add(CreatePier())
+    try app.register(Harbor.self, migration: CreateHarbor())
+    try app.register(Dock.self, migration: CreateDock())
+    app.migrations.add(CreateBerth())
+    app.migrations.add(CreateCrewMember())
+    app.migrations.add(CreateDockCrew())
+    try app.useContainerAuthorizationProvider(TestGrantsProvider())
+}
+
+/// The serving side PLUS live invalidation — the end-to-end test needs both the header (serving)
+/// and the hub (emission). configureHarbor does not enable live, so this composes the two.
+private func configureLiveServe(_ app: Application) throws {
+    try configureServe(app)
+    try app.useLiveInvalidation(on: app.routes)
+}
+
+private func registerApexHarborResolver(_ app: Application) throws {
+    try app.useApexContainerResolver { req in
+        guard let harbor = try await Harbor.query(on: req.db).first() else {
+            throw Abort(.internalServerError, reason: "no harbor seeded")
+        }
+        return try harbor.modelIdentity
+    }
+}
+
+private func setGrants(_ app: Application, _ grants: [TestGrant]) {
+    app.storage[TestGrantsKey.self] = grants
+}
+
+private func berthReadGrant(container: ModelIdentity, _ ops: [ContainerOperation], types: [ModelNamespace]) -> TestGrant {
+    TestGrant(authorizedContainer: container, operations: ops, recordTypes: types)
+}
+
+private func getResponse(_ app: Application, for request: some ServerRequest) async throws -> Vapor.Response {
+    let base = try #require(URL(string: "http://localhost"))
+    let url = try #require(try base.appending(serverRequest: request))
+    let headers = HTTPHeaders([(HTTPHeaders.Name.acceptLanguage.description, "en")])
+    let httpReq = Request(
+        application: app, method: .GET, url: URI(string: url.absoluteString),
+        headers: headers, collectedBody: .init(), on: app.eventLoopGroup.next()
+    )
+    return try await app.responder.respond(to: httpReq).get()
+}
+
+// MARK: - Tests
+
+@Suite("Live invalidation: registerDependency(on:)")
+struct RegisterDependencyTests {
+    /// Contract 1: a factory register merges with the executed plan's set — no clobber. The header
+    /// carries the plan's container identities (Harbor root + every Dock) AND the snapshot's.
+    @Test func factoryRegisterMergesWithPlanSet() async throws {
+        try await withFluentTestApp { app in
+            try configureServe(app)
+            try registerApexHarborResolver(app)
+            try app.register(request: HarborStatusRequest.self)
+        } _: { app, db in
+            let (dock1, dock2) = try await seedHarbor(on: db)
+            let harbor = try #require(try await Harbor.query(on: db).first())
+            try setGrants(app, [
+                berthReadGrant(
+                    container: harbor.modelIdentity,
+                    [.readRecords],
+                    types: [Dock.modelIdentityNamespace, Berth.modelIdentityNamespace]
+                )
+            ])
+
+            let res = try await getResponse(app, for: HarborStatusRequest())
+            #expect(res.status == .ok)
+
+            let registered: [ModelIdentity] = try #require(res.headers.first(name: ModelIdentity.registrationsHeader)).fromJSON()
+            let carried = Set(registered)
+
+            // The plan's set survived …
+            #expect(try carried.contains(harbor.modelIdentity))
+            #expect(try carried.contains(dock1.modelIdentity))
+            #expect(try carried.contains(dock2.modelIdentity))
+            // … and the factory's register joined it.
+            #expect(try carried.contains(StatusSnapshot(id: mergeSnapshotId).modelIdentity))
+        }
+    }
+
+    /// Contract 2: a zero-data body registers too — header present, containing exactly the snapshot
+    /// identity (the serve else-branch sink).
+    @Test func zeroDataBodyRegisters() async throws {
+        try await withFluentTestApp { app in
+            try configureServe(app)
+            try app.register(request: StatusDashboardRequest.self)
+        } _: { app, _ in
+            let res = try await getResponse(app, for: StatusDashboardRequest())
+            #expect(res.status == .ok)
+
+            let registered: [ModelIdentity] = try #require(res.headers.first(name: ModelIdentity.registrationsHeader)).fromJSON()
+            #expect(try Set(registered) == [StatusSnapshot(id: knownId).modelIdentity])
+        }
+    }
+
+    /// Contract 3: registering a nil-id model surfaces an error through serve — never a silently
+    /// missing registration. The failure arrives as a non-`.ok` response or a thrown error; both
+    /// satisfy the contract, silence does not.
+    @Test func nilIdSurfacesError() async throws {
+        try await withFluentTestApp { app in
+            try configureServe(app)
+            try app.register(request: NilSnapshotRequest.self)
+        } _: { app, _ in
+            var sawFailure = false
+            do {
+                let res = try await getResponse(app, for: NilSnapshotRequest())
+                if res.status != .ok {
+                    sawFailure = true
+                }
+            } catch {
+                sawFailure = true
+            }
+            #expect(sawFailure)
+        }
+    }
+
+    /// Contract 4 (the invariant): serve the fixture, decode the header, then invalidate the same
+    /// model — the emitted set equals the snapshot's identity AND that identity is a member of the
+    /// decoded header set. Registration and emission name the same value; that pairing IS the contract.
+    @Test func registerAndInvalidateNameTheSameValue() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveServe(app)
+            try app.register(request: StatusDashboardRequest.self)
+        } _: { app, _ in
+            let res = try await getResponse(app, for: StatusDashboardRequest())
+            #expect(res.status == .ok)
+            let registered: [ModelIdentity] = try #require(res.headers.first(name: ModelIdentity.registrationsHeader)).fromJSON()
+
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            try await app.invalidateProjections(of: StatusSnapshot(id: knownId))
+
+            let snapshotIdentity = try StatusSnapshot(id: knownId).modelIdentity
+            #expect(await events.next() == Set([snapshotIdentity]))
+            #expect(Set(registered).contains(snapshotIdentity))
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-07-16-live-invalidation-emit-promotion.md
+++ b/docs/superpowers/plans/2026-07-16-live-invalidation-emit-promotion.md
@@ -1,0 +1,706 @@
+# Live-Invalidation Emit Promotion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give non-Fluent server-side sources (Application-hosted actors, computed aggregates) a public, typed entry into live invalidation: `invalidateProjections(of:)` on the write side, `registerDependency(on:)` on the read side.
+
+**Architecture:** The `.live` layer is abstracted transport with Fluent-only ignition — the hub → SSE → client pipeline speaks only `Set<ModelIdentity>`, but the only emit point is the Fluent `InvalidationEmitMiddleware` and the only registration writer is `PlanExecutor.depositRegistrationSet`. This plan opens both halves as one paired public contract, composing onto the existing collector/hub/header machinery with **no new protocol and no new mechanism**.
+
+**Tech Stack:** Swift 6 / Swift Testing, Vapor, FluentKit (test fixtures only — the new API itself is Fluent-free).
+
+---
+
+## Design & Rationale (the fosmvvm-planning gate output)
+
+### The ratified paired contract
+
+Naming ratified by David 2026-07-16. The teaching sentence:
+*register a dependency on what you read; invalidate projections of what you changed.*
+
+```swift
+// factory (read side) — ProjectionContext, FOSMVVMVapor extension:
+try context.registerDependency(on: status)
+
+// source (write side) — Vapor.Application (+ Request forwarding):
+try await app.invalidateProjections(of: status)
+```
+
+Both halves are REQUIRED — the symmetry invariant is pinned at
+`Sources/FOSMVVMVapor/Containment/PlanExecutor.swift` (`touchedContainers(of:)` doc):
+*"the live-invalidation contract holds only while a client registers on exactly what a
+write invalidates."* Emit without registration nudges nobody; registration without
+emit refreshes never.
+
+### Why the design is thin
+
+- `FOSMVVM.Model` (`Sources/FOSMVVM/Protocols/Model.swift:26`) is already Fluent-free
+  (`Codable + Hashable + id: ModelIdType?`) and mints unforgeable `ModelIdentity`
+  (internal init — nobody hand-forges one). Identity needs zero new work.
+- The routing discriminator is already ambient, not Fluent-attached:
+  `LiveTransactionState.$collector` (task-local,
+  `Sources/FOSMVVMVapor/LiveInvalidation/LiveTransaction.swift:97`). The public write-side
+  call consults the same task-local: inside `liveTransaction { }` the nudge joins the
+  transaction's collector and flushes only on commit; outside, it emits immediately
+  (an actor mutation is its own commit). Hub absent (live invalidation not enabled) → no-op,
+  matching `liveTransaction`'s degradation.
+- **No `InvalidationSource` protocol.** Cut as speculative (defer-API-until-client-exists):
+  nothing would require conformance; sources just call the two functions.
+
+### The one structural change: the dependency sink
+
+`ProjectionContext` (`Sources/FOSMVVM/Protocols/ProjectionContext.swift:32`) is a pure
+value struct — it holds no `Vapor.Request`, by design ("Everything a projection may
+see… Nothing else"). `registerDependency(on:)` therefore needs a conduit to
+`req.registrationSet`. Decision: a **package-level closure field installed at
+construction** —
+
+```swift
+package let dependencySink: (ModelIdentity) -> Void
+```
+
+- **Required (non-optional, no default).** A defaulted `{ _ in }` would be a silently-
+  dropping no-op — the misconfiguration's invisible mode this repo's `records(_:)`
+  throw-never-empty philosophy exists to forbid. Every constructor names its sink.
+- **Why a field, not a task-local:** the context is the factory's *entire* sanctioned
+  window; giving it the deposit capability at construction keeps the capability visible
+  in the type and testable by handing a capturing closure. A task-local would hide a
+  second ambient channel behind a surface whose whole point is "nothing else."
+- Non-Sendable closure inside the existing `@unchecked Sendable` struct is sound under
+  the already-documented contract: the context never escapes the projection; reads (and
+  now the sink call) happen only on the request's handler task.
+- Blast radius: the construction sites are
+  `Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift:40` and `:42`, plus the test
+  helpers in `Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift:89-97`
+  and `Tests/FOSMVVMVaporTests/Composition/TotalCountTests.swift:116-118` (both init
+  spellings in each). Task 2's grep is the authority — trust it over this list.
+
+### Sequencing is already safe (verified)
+
+`serve(_:)` (`Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift:30-45`) runs
+`executeRecordLoadPlan` — which **assigns** `registrationSet` — *before* constructing
+the context and calling `body(context:)`. The factory's `registerDependency` **inserts**
+into the already-deposited set, so plan-derived registrations and factory-added ones
+merge; nothing clobbers. The header attachment (`Response+FOS.swift:77`,
+`addRegistrations(from:)`) reads the union later in `buildResponse` and needs no change.
+
+`body(context:)` is **synchronous** (`ServeRequest.swift:44` — `try`, no `await`), so
+`registerDependency(on:)` is `throws`, not `async throws`. Actor state reaches the
+factory as a *value* via the `useAppState(_:builder:)` builder (which runs async, with
+full request power, at `ServeRequest.swift:37` — *before* the factory). DocC examples
+must show the snapshot taken in the builder, read synchronously in the factory.
+
+### Semantics pinned for DocC and tests
+
+- **Fluent-persisted models never need `invalidateProjections(of:)`** — their writes
+  already emit via middleware. Calling it anyway double-nudges (harmless refresh, not a
+  correctness break); the DocC says "never need," not "must not."
+- **v1 derives no containment for non-Fluent models** — the emitted set is the model's
+  own identity only. Sufficient for the hybrid case because `registerDependency`
+  registered that same identity. Containment declarations for non-Fluent sources in
+  `ModelTypeRegistry` are a separate future feature.
+- **Bare `database.transaction { }` around a mixed SQL+actor write is undetectable**
+  from `invalidateProjections` (no `db` handle crosses it) — the call would emit before
+  commit. The remedy is the same one the middleware's suppression warning already
+  teaches: use `liveTransaction`. Goes in DocC.
+- **Actor-held identity needs only process-lifetime stability**
+  (`let statusId = ModelIdType()` at actor init): a server restart is covered by the
+  client transport's `.connected` event → refresh-every-live-screen sweep
+  (`Sources/FOSMVVM/Protocols/InvalidationChannel.swift` DocC). Goes in the write-side
+  function's DocC.
+- Throws: both functions throw only `ModelError.missingId` (via `model.modelIdentity`).
+
+### Contract-test discipline
+
+All new tests exercise the **public** surface: identities are minted via
+`model.modelIdentity` / compared via the public `ModelIdentity == some Model` operator
+or `Set` equality; the header is decoded whole-value with `fromJSON()` — never parsed.
+Emission-absence uses the existing sentinel discipline (see the header comment of
+`Tests/FOSMVVMVaporTests/LiveInvalidation/LiveTransactionTests.swift:17-20`).
+New fixtures use neutral vocabulary (`StatusSnapshot`, `StatusDashboardVM`) — existing
+harbor-named *harness* helpers may be reused as plumbing, but no new harbor vocabulary
+is introduced. Reuse caveat: `withFluentTestApp` (public) and `seedHarbor`
+(module-internal) are callable from a new file, but `configureLiveHarbor` is
+**file-private and duplicated per test file with differing signatures** — COPY the
+single-arg version from `LiveTransactionTests.swift:189` into the new file; do not
+expect to call it across files.
+
+### Rejected alternatives (do not re-propose)
+
+Names: `invalidate(_:)` (bare verb, no context), `registerLive(_:)`, `register(live:)`,
+`register(_:)` (collides with boot `app.register(request:)`), `dependsOn(_:)`,
+`registerInterest(in:)`, `announceChanged(_:)`, `emitInvalidation(for:)`,
+`modelDidChange(_:)`, `notifyLiveClients(changed:)`, `invalidateLiveViews(of:)`.
+Mechanisms: `InvalidationSource` protocol (speculative), optional/defaulted sink
+(invisible no-op), task-local registration channel (hidden second window),
+`Set<ModelIdentity>`-taking emit (two spellings; the mutation site holds the model).
+
+---
+
+## File Structure
+
+- **Modify:** `Sources/FOSMVVM/Protocols/ProjectionContext.swift`
+  — add `package let dependencySink`, thread through both package inits.
+- **Modify:** `Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift:39-43`
+  — install the real sink (insert into `registrationSet`) in both context branches.
+- **Create:** `Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift`
+  — write-side pair (`Application` + `Request`) + shared routing core.
+- **Create:** `Sources/FOSMVVMVapor/LiveInvalidation/ProjectionContext+Dependencies.swift`
+  — read-side `registerDependency(on:)` (server capability, sited like
+  `ProjectionContext+Records.swift`).
+- **Modify:** `Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift:89-97`
+  — test helper passes a sink.
+- **Create:** `Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidateProjectionsTests.swift`
+- **Create:** `Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift`
+- **Modify:** `CHANGELOG.md`, `.claude/docs/FOSMVVMArchitecture.md`,
+  api-catalog entries (via the `fosutilities-api-catalog-update` skill).
+
+---
+
+### Task 0: Branch
+
+- [ ] **Step 1: Create the feature branch (repo is on `main`)**
+
+```bash
+cd /Users/david/Repository/FOS/FOSUtilities
+git checkout -b feature/live-invalidation-emit-promotion
+```
+
+---
+
+### Task 1: Write side — `invalidateProjections(of:)`
+
+**Files:**
+- Create: `Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidateProjectionsTests.swift`
+- Create: `Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidateProjectionsTests.swift`.
+Copy the license header from any sibling file. Mirror the harness idioms of
+`LiveTransactionTests.swift` in the same directory (`withFluentTestApp`,
+`configureLiveHarbor`, hub subscribe, sentinel discipline — read that file first).
+
+```swift
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+
+// The internal hub subscribe is block coverage of an internal seam (same note as
+// LiveTransactionTests); every asserted identity is minted/compared via public API.
+
+/// Neutral non-Fluent fixture: an Application-hosted source's state snapshot.
+/// FOSMVVM.Model only — deliberately NOT a FluentKit.Model.
+private struct StatusSnapshot: FOSMVVM.Model {
+    let id: ModelIdType?
+    var activeSessions: Int = 0
+}
+
+@Suite("invalidateProjections(of:) — public write-side entry for non-Fluent sources")
+struct InvalidateProjectionsTests {
+    /// Outside any transaction, the call emits exactly the model's own identity.
+    @Test func emitsOwnIdentityImmediately() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, _ in
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let status = StatusSnapshot(id: .init(), activeSessions: 3)
+            try await app.invalidateProjections(of: status)
+
+            let expected = try Set([status.modelIdentity])
+            #expect(await events.next() == expected)
+        }
+    }
+
+    /// Inside liveTransaction, the nudge joins the collector: ONE union event after
+    /// commit, containing the actor identity AND the SQL write's derived set.
+    @Test func joinsLiveTransactionUnionOnCommit() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let status = StatusSnapshot(id: .init(), activeSessions: 1)
+            try await app.liveTransaction { tx in
+                let berth = try Berth(number: 70, dockName: dock1.name, dockId: dock1.requireId())
+                try await berth.save(on: tx)
+                try await app.invalidateProjections(of: status)
+            }
+
+            let union = try #require(await events.next())
+            #expect(union.contains(try status.modelIdentity))
+            #expect(union.contains(try dock1.modelIdentity)) // berth's container, via middleware
+        }
+    }
+
+    /// A thrown liveTransaction discards the collected nudge — sentinel-first.
+    @Test func rolledBackTransactionEmitsNothing() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, db in
+            _ = try await seedHarbor(on: db)
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            let status = StatusSnapshot(id: .init(), activeSessions: 1)
+            struct Rollback: Error {}
+            await #expect(throws: Rollback.self) {
+                try await app.liveTransaction { _ in
+                    try await app.invalidateProjections(of: status)
+                    throw Rollback()
+                }
+            }
+
+            let sentinelSource = StatusSnapshot(id: .init())
+            let sentinel = try Set([sentinelSource.modelIdentity])
+            await hub.emit(sentinel)
+            #expect(await events.next() == sentinel)
+        }
+    }
+
+    /// With live invalidation not enabled, the call is a no-op — no throw, no trap.
+    @Test func disabledIsNoOp() async throws {
+        try await withFluentTestApp { _ in
+            // no configureLiveHarbor / useLiveInvalidation
+        } _: { app, _ in
+            let status = StatusSnapshot(id: .init())
+            try await app.invalidateProjections(of: status)
+            #expect(app.invalidationHub == nil)
+        }
+    }
+
+    /// An unpersisted model (nil id) throws ModelError.missingId — never a silent skip.
+    @Test func nilIdThrowsMissingId() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+        } _: { app, _ in
+            await #expect(throws: ModelError.self) {
+                try await app.invalidateProjections(of: StatusSnapshot(id: nil))
+            }
+        }
+    }
+
+    /// Request forwarding reaches the same hub (exercised through the routing core:
+    /// identical observable behavior to the Application call).
+    @Test func requestForwardingEmits() async throws {
+        try await withFluentTestApp { app in
+            try configureLiveHarbor(app)
+            app.get("poke") { req async throws -> HTTPStatus in
+                try await req.invalidateProjections(of: StatusSnapshot(id: pokeId))
+                return .ok
+            }
+        } _: { app, _ in
+            let hub = try #require(app.invalidationHub)
+            var events = await hub.subscribe().makeAsyncIterator()
+
+            try await app.test(.GET, "poke") { res async in
+                #expect(res.status == .ok)
+            }
+
+            let expected = try Set([StatusSnapshot(id: pokeId).modelIdentity])
+            #expect(await events.next() == expected)
+        }
+    }
+}
+
+/// Stable across the route closure and the assertion.
+private let pokeId = ModelIdType()
+```
+
+Adjust harness/fixture call shapes to what `LiveTransactionTests.swift` actually uses
+(e.g. `Berth.init` signature) — the assertions above are the contract; the plumbing
+must match the existing suite. For `requestForwardingEmits`, prefer the
+`app.responder.respond(to:).get()` idiom the LiveInvalidation suite already uses
+(`RegistrationHeaderTests.swift`) over `app.test(...)`: `app.test` runs only the sync
+`boot()` (the repo's known async-boot gotcha), and staying on one idiom keeps the
+suite uniform. Rewrite that test's serving plumbing accordingly.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+swift test --filter InvalidateProjectionsTests
+```
+Expected: COMPILE FAILURE — `invalidateProjections` does not exist yet.
+
+- [ ] **Step 3: Implement**
+
+Create `Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift`
+(license header from a sibling):
+
+```swift
+import FOSMVVM
+import Foundation
+import Vapor
+
+public extension Vapor.Application {
+    /// Nudges live clients to refresh every projection built from `model`
+    ///
+    /// Call it at each point a non-Fluent source commits a change — an
+    /// `Application`-hosted actor mutating its state, a computed aggregate
+    /// going stale:
+    ///
+    /// ```swift
+    /// actor StatusMonitor {
+    ///     // Minted once — the identity of "the status" for this process's
+    ///     // lifetime. A restart is covered: reconnecting clients refresh
+    ///     // every live screen.
+    ///     private let statusId = ModelIdType()
+    ///     private var activeSessions = 0
+    ///
+    ///     func sessionOpened(app: Application) async throws {
+    ///         activeSessions += 1
+    ///         try await app.invalidateProjections(of: snapshot())
+    ///     }
+    ///
+    ///     func snapshot() -> StatusSnapshot {
+    ///         .init(id: statusId, activeSessions: activeSessions)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Clients refresh the ViewModels whose factory called
+    /// ``FOSMVVM/ProjectionContext/registerDependency(on:)`` for this model.
+    /// Fluent-persisted models never need this call — their saves already
+    /// notify live clients. When the change ships together with Fluent writes,
+    /// make the call inside ``liveTransaction(_:)`` and it reaches clients
+    /// only if the transaction commits. With live invalidation not enabled
+    /// (no `useLiveInvalidation(on:)` at boot) it is a no-op.
+    ///
+    /// - Throws: `ModelError.missingId` when `model.id` is `nil`.
+    func invalidateProjections(of model: some FOSMVVM.Model) async throws {
+        try await routeProjectionInvalidation(of: model, hub: invalidationHub)
+    }
+}
+
+public extension Vapor.Request {
+    /// Nudges live clients to refresh every projection built from `model`
+    ///
+    /// The request-scoped spelling of
+    /// ``Vapor/Application/invalidateProjections(of:)`` — same behavior, for
+    /// call sites inside a route handler:
+    ///
+    /// ```swift
+    /// try await req.invalidateProjections(of: status)
+    /// ```
+    func invalidateProjections(of model: some FOSMVVM.Model) async throws {
+        try await application.invalidateProjections(of: model)
+    }
+}
+
+/// The shared routing core, mirroring the middleware's pinned order
+/// (InvalidationEmitMiddleware.route): task-local collector present → COLLECT
+/// (its liveTransaction flushes on commit); else hub present → EMIT; else live
+/// invalidation is not enabled → no-op. A collector is only ever installed by
+/// liveTransaction, which requires a hub — so collector-first never strands a nudge.
+private func routeProjectionInvalidation(
+    of model: some FOSMVVM.Model,
+    hub: InvalidationHub?
+) async throws {
+    let identity = try model.modelIdentity
+
+    if let collector = LiveTransactionState.collector {
+        await collector.collect([identity])
+    } else if let hub {
+        await hub.emit([identity])
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+swift test --filter InvalidateProjectionsTests
+```
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Run the full LiveInvalidation suite (no regression)**
+
+```bash
+swift test --filter LiveTransactionTests && swift test --filter EmitMiddlewareTests
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/FOSMVVMVapor/LiveInvalidation/InvalidateProjections.swift Tests/FOSMVVMVaporTests/LiveInvalidation/InvalidateProjectionsTests.swift
+git commit -m "feat: invalidateProjections(of:) — public write-side live-invalidation entry for non-Fluent sources"
+```
+
+---
+
+### Task 2: The dependency sink (conduit only — no public API yet)
+
+**Files:**
+- Modify: `Sources/FOSMVVM/Protocols/ProjectionContext.swift`
+- Modify: `Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift:39-43`
+- Modify: `Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift:89-97`
+
+- [ ] **Step 1: Add the field and thread it through both package inits**
+
+In `Sources/FOSMVVM/Protocols/ProjectionContext.swift`, after the `countsByTuple`
+declaration (line 53), add:
+
+```swift
+    /// Deposits one registered dependency identity into the serving request's
+    /// registration set. Installed at construction — required, never defaulted: a
+    /// silently-dropping sink would be a misconfiguration's invisible mode. Invoked
+    /// only within the projection, on the request's handler task (the same
+    /// no-escape contract the record snapshot already relies on).
+    package let dependencySink: (ModelIdentity) -> Void
+```
+
+Add `dependencySink: @escaping (ModelIdentity) -> Void` as the final parameter of
+**both** package inits, assigning it in each body.
+
+- [ ] **Step 2: Fix the two construction sites in `serve(_:)`**
+
+In `Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift`, replace lines 39-43 with:
+
+```swift
+        // The factory's dependency deposit: INSERTS into the set executeRecordLoadPlan
+        // already assigned — factory-registered identities merge with the plan's, and
+        // buildResponse attaches the union as X-FOS-Registrations.
+        let dependencySink: (ModelIdentity) -> Void = { self.registrationSet.insert($0) }
+        // A zero-data body has no derived plan; it constructs a context that carries no records.
+        let context: ProjectionContext<SR, SR.ResponseBody.AppState> = if let plan = application.recordLoadPlan(for: SR.self) {
+            .init(vmRequest: vmRequest, appState: appState, plan: plan, recordsByTuple: recordsByTuple(), countsByTuple: countsByTuple(), dependencySink: dependencySink)
+        } else {
+            .init(vmRequest: vmRequest, appState: appState, dependencySink: dependencySink)
+        }
+```
+
+- [ ] **Step 3: Fix the test helper**
+
+In `Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift` (helper at
+lines 89-97 — check for BOTH init spellings), pass a no-op sink explicitly:
+`dependencySink: { _ in }`. Grep for any other construction site:
+
+```bash
+grep -rn "init(vmRequest" Sources Tests
+```
+Every hit must now pass a sink.
+
+- [ ] **Step 4: Build + full test run (behavior-neutral refactor)**
+
+```bash
+swift build && swift test
+```
+Expected: PASS everywhere — this task changes no observable behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A Sources/FOSMVVM/Protocols/ProjectionContext.swift "Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift" Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift
+git commit -m "feat: ProjectionContext carries a required dependency sink into the request's registration set"
+```
+
+---
+
+### Task 3: Read side — `registerDependency(on:)`
+
+**Files:**
+- Create: `Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift`
+- Create: `Sources/FOSMVVMVapor/LiveInvalidation/ProjectionContext+Dependencies.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift`,
+patterned on `RegistrationHeaderTests.swift` (same directory): fixtures are served
+through the real HTTP responder so the deposit reaches `buildResponse` on the same
+request the header rides. Fixture VMs use neutral vocabulary. Cover these contracts:
+
+1. **Factory-registered identity lands in the header.** A `VaporResponseBodyFactory`
+   whose `body(context:)` calls
+   `try context.registerDependency(on: StatusSnapshot(id: knownId))` (a file-private
+   `let knownId = ModelIdType()`), served over HTTP. Decode the header whole-value —
+   `let registered: [ModelIdentity] = try #require(res.headers.first(name: ModelIdentity.registrationsHeader)).fromJSON()`
+   — and assert `Set(registered).contains(try StatusSnapshot(id: knownId).modelIdentity)`.
+2. **Merges with the plan's set — no clobber.** A fixture WITH a `LoadRequirement`
+   (reuse the `HarborBerthsVM` shape from `RegistrationHeaderTests.swift` as plumbing)
+   whose factory ALSO registers a `StatusSnapshot`: the header contains the plan's
+   container identities AND the snapshot's — assert both memberships.
+3. **Zero-data body registers too.** A fixture with no `dataRequirements` registering a
+   snapshot: header present, contains exactly the snapshot identity (covers the
+   `serve` else-branch sink).
+4. **nil id throws, request fails typed.** A factory registering
+   `StatusSnapshot(id: nil)` — the serve must surface an error, never a
+   silently-missing registration. Depending on error-middleware wiring the failure
+   arrives either as a non-`.ok` response or as a thrown error from
+   `respond(to:).get()` — assert whichever the TDD run reveals; both satisfy the
+   contract, silence does not.
+5. **End-to-end symmetry (the invariant test).** Serve fixture (1); decode the header;
+   subscribe to the hub; `try await app.invalidateProjections(of: StatusSnapshot(id: knownId))`;
+   assert the emitted set equals the snapshot's identity **and** that identity is a
+   member of the decoded header set — registration and emission name the same value.
+   Harness note: `RegistrationHeaderTests`' `configureHarbor` does NOT enable live
+   invalidation — this test's setup must compose the serving registration with
+   `useLiveInvalidation(on:)` (or the copied `configureLiveHarbor`), else
+   `invalidationHub` is nil and the emit is a no-op.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+swift test --filter RegisterDependencyTests
+```
+Expected: COMPILE FAILURE — `registerDependency` does not exist yet.
+
+- [ ] **Step 3: Implement**
+
+Create `Sources/FOSMVVMVapor/LiveInvalidation/ProjectionContext+Dependencies.swift`:
+
+```swift
+import FOSFoundation
+import FOSMVVM
+import Foundation
+
+public extension ProjectionContext {
+    /// Declares that this response depends on `model`, so live clients refresh
+    /// its projections when the model changes
+    ///
+    /// Plan-loaded records are registered automatically. Call this from your
+    /// factory for data the plan can't see — state your `appState` builder
+    /// snapshotted from an `Application`-hosted actor:
+    ///
+    /// ```swift
+    /// // boot: the builder snapshots the actor (async, before the factory runs)
+    /// app.useAppState(DashboardState.self) { req in
+    ///     DashboardState(status: await req.application.statusMonitor.snapshot())
+    /// }
+    ///
+    /// // factory: read the value, register the dependency
+    /// static func body<R: ServerRequest>(context: ProjectionContext<R, DashboardState>) throws -> Self
+    ///     where R.ResponseBody == Self {
+    ///     let status = context.appState.status
+    ///     try context.registerDependency(on: status)
+    ///     return .init(activeSessions: status.activeSessions)
+    /// }
+    /// ```
+    ///
+    /// The registered identity rides to the client with the response; a later
+    /// ``invalidateProjections(of:)`` for the same model triggers the refresh.
+    /// Register and invalidate must name the same entity — that pairing IS the
+    /// live contract.
+    ///
+    /// - Throws: `ModelError.missingId` when `model.id` is `nil`.
+    func registerDependency(on model: some FOSMVVM.Model) throws {
+        try dependencySink(model.modelIdentity)
+    }
+}
+```
+
+(Siting note, mirroring `ProjectionContext+Records.swift`'s header rationale: the
+registration deposit is a server capability, so the public method lives at this layer
+even though the sink field is FOSMVVM's.)
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+swift test --filter RegisterDependencyTests
+```
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Run the neighboring suites (no regression)**
+
+```bash
+swift test --filter RegistrationHeaderTests && swift test --filter ProjectionContextTests
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/FOSMVVMVapor/LiveInvalidation/ProjectionContext+Dependencies.swift Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift
+git commit -m "feat: registerDependency(on:) — factories register non-plan data for live refresh"
+```
+
+---
+
+### Task 4: Docs, catalog, changelog
+
+**Files:**
+- Modify: `CHANGELOG.md` (new Unreleased → Added entries)
+- Modify: `.claude/docs/FOSMVVMArchitecture.md` (live-invalidation section)
+- Modify: api-catalog (via skill)
+
+- [ ] **Step 1: CHANGELOG**
+
+Add under an `## [Unreleased]` → `### Added` section (create if absent), following the
+file's existing entry style:
+
+```markdown
+- `Application.invalidateProjections(of:)` / `Request.invalidateProjections(of:)` —
+  non-Fluent server-side sources (Application-hosted actors, computed aggregates)
+  nudge live clients when their state changes. Composes with `liveTransaction`.
+- `ProjectionContext.registerDependency(on:)` — factories register response data the
+  record-load plan can't see (e.g. `appState` actor snapshots) for live refresh.
+```
+
+State the **contract only** — no encoded shapes, no internals.
+
+- [ ] **Step 2: Architecture doc**
+
+In `.claude/docs/FOSMVVMArchitecture.md`, extend the live-invalidation section with a
+short subsection: the paired public contract, the teaching sentence (*register a
+dependency on what you read; invalidate projections of what you changed*), the
+Fluent-never-needs-this rule, and v1's own-identity-only scope for non-Fluent sources.
+
+- [ ] **Step 3: API catalog**
+
+Invoke the `fosutilities-api-catalog-update` skill — it audits the new public symbols
+into `FOSMVVMVapor.md`, updates the reach-for index, and bumps the plugin version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md .claude/docs/FOSMVVMArchitecture.md .claude/skills
+git commit -m "docs: live-invalidation emit promotion — contract docs, catalog, changelog"
+```
+
+---
+
+### Task 5: Verification sweep
+
+- [ ] **Step 1: Full test run**
+
+```bash
+swift test
+```
+Expected: PASS. (Known environment note: a cold-run intermittent exists in this repo —
+rerun once before investigating; see the issue-reporting taxonomy: classify, never
+"pre-existing, unrelated".)
+
+- [ ] **Step 2: Format + lint**
+
+```bash
+swiftformat . && swiftlint
+```
+Expected: no violations; commit any formatting deltas as `chore: swiftformat`.
+
+- [ ] **Step 3: Squash to logical commits**
+
+Squash granular commits down to a few logical ones (feature write-side, feature
+read-side, docs) per the repo's squash-before-PR practice.
+
+- [ ] **STOP — review gate.** Push of the branch is fine if asked; **do NOT open a PR**
+  until David has reviewed the finished work and said go.
+
+---
+
+## Out of Scope (deliberately)
+
+- Containment declarations for non-Fluent sources in `ModelTypeRegistry`.
+- Auto-emitting actor sugar (a `didMutate` wrapper) — cooperative calls are v1's
+  honest contract.
+- Multi-instance fan-out — stays behind `InvalidationHub` (DEF-L2-4), untouched.
+- Client-side changes — none needed; the client already consumes the header and the
+  SSE stream without knowing what produced them.

--- a/docs/superpowers/plans/2026-07-16-live-invalidation-emit-promotion.md
+++ b/docs/superpowers/plans/2026-07-16-live-invalidation-emit-promotion.md
@@ -525,6 +525,9 @@ request the header rides. Fixture VMs use neutral vocabulary. Cover these contra
    `let knownId = ModelIdType()`), served over HTTP. Decode the header whole-value —
    `let registered: [ModelIdentity] = try #require(res.headers.first(name: ModelIdentity.registrationsHeader)).fromJSON()`
    — and assert `Set(registered).contains(try StatusSnapshot(id: knownId).modelIdentity)`.
+   *Execution note (2026-07-16): shipped as 4 tests, not 5 — review found this
+   contract's path byte-identical to contract 3's with a strictly weaker assertion,
+   so it is subsumed by contracts 2 (merge) + 3 (exact equality) and was dropped.*
 2. **Merges with the plan's set — no clobber.** A fixture WITH a `LoadRequirement`
    (reuse the `HarborBerthsVM` shape from `RegistrationHeaderTests.swift` as plumbing)
    whose factory ALSO registers a `StatusSnapshot`: the header contains the plan's

--- a/scripts/api-catalog-audit.swift
+++ b/scripts/api-catalog-audit.swift
@@ -229,7 +229,9 @@ func catalogTitleNames(in text: String) -> CatalogFile {
                 let name = baseIdentifier(String(token))
                 if let first = name.first, first.isLetter || first == "_" {
                     catalog.names.insert(name)
-                    if isAppleOnly { catalog.appleOnly.insert(name) }
+                    if isAppleOnly {
+                        catalog.appleOnly.insert(name)
+                    }
                 }
             }
         }
@@ -283,8 +285,12 @@ do {
         for item in surface.auditItems where !ignored.contains(item.name) {
             let covered = catalogNames.contains(item.name)
                 || item.parent.map { catalogNames.contains($0) } ?? false
-            if !covered { gaps.append(item) }
-            if !item.hasDoc { docWorklist.append(item) }
+            if !covered {
+                gaps.append(item)
+            }
+            if !item.hasDoc {
+                docWorklist.append(item)
+            }
         }
     }
 
@@ -325,17 +331,23 @@ do {
     for g in gaps {
         print("  \(g.module): \(g.name)  [\(g.sourceFile)]")
     }
-    if gaps.isEmpty { print("  (none)") }
+    if gaps.isEmpty {
+        print("  (none)")
+    }
     print("\n== Stale catalog entries (ERROR): title symbols not in the API ==")
     for s in stale {
         print("  \(s.file): `\(s.name)`")
     }
-    if stale.isEmpty { print("  (none)") }
+    if stale.isEmpty {
+        print("  (none)")
+    }
     print("\n== DocC worklist (warning): audit-surface symbols with no doc comment ==")
     for d in docWorklist {
         print("  \(d.module): \(d.name)  [\(d.sourceFile)]")
     }
-    if docWorklist.isEmpty { print("  (none)") }
+    if docWorklist.isEmpty {
+        print("  (none)")
+    }
     print("\nSummary: \(gaps.count) gap(s), \(stale.count) stale, \(docWorklist.count) undocumented; " +
         "modules audited: \(presentModules.sorted().joined(separator: ", "))")
 

--- a/scripts/localizable-overload-sweep.swift
+++ b/scripts/localizable-overload-sweep.swift
@@ -496,8 +496,12 @@ func discoverTypeUSRs(_ graphs: [ExtractedGraphs]) throws -> (lsk: Set<String>, 
         }
     }
     var missing: [String] = []
-    if lsk.isEmpty { missing.append("LocalizedStringKey") }
-    if text.isEmpty { missing.append("Text") }
+    if lsk.isEmpty {
+        missing.append("LocalizedStringKey")
+    }
+    if text.isEmpty {
+        missing.append("Text")
+    }
     throw Failure("type symbol(s) not found in any symbol graph: " +
         "\(missing.joined(separator: ", ")) — cannot identify localizable " +
         "declarations and their delegate siblings")
@@ -620,7 +624,9 @@ func runSelect(graphs: [ExtractedGraphs], lskUSRs: Set<String>, filter: String?)
                 switch classify(symbol, platform: group.platform, module: group.module, lskUSRs: lskUSRs) {
                 case .candidate(let candidate):
                     canonicalUSRs.insert(candidate.usr)
-                    if let filter, candidate.extendedType != filter { continue }
+                    if let filter, candidate.extendedType != filter {
+                        continue
+                    }
                     candidates.append(candidate)
                 case .rejected(let reject):
                     canonicalUSRs.insert(reject.usr)
@@ -829,9 +835,13 @@ struct UnionResult {
 /// This is only reached on a genuine cross-platform conflict, which is counted
 /// and reported — it is not expected to fire.
 func resolveConflict(_ lhs: DomainAvailability, _ rhs: DomainAvailability) -> DomainAvailability {
-    if lhs == .unavailable || rhs == .unavailable { return .unavailable }
+    if lhs == .unavailable || rhs == .unavailable {
+        return .unavailable
+    }
     func version(_ state: DomainAvailability) -> SemVer {
-        if case .introduced(let v) = state { return v }
+        if case .introduced(let v) = state {
+            return v
+        }
         return SemVer(0)
     }
     return version(lhs) >= version(rhs) ? lhs : rhs
@@ -902,7 +912,9 @@ func runUnion(candidates: [Candidate], sdks: [PlatformSDK]) -> UnionResult {
     var order: [String] = []
     var platformContribution: [String: Int] = [:]
     for candidate in candidates {
-        if groups[candidate.usr] == nil { order.append(candidate.usr) }
+        if groups[candidate.usr] == nil {
+            order.append(candidate.usr)
+        }
         groups[candidate.usr, default: []].append(candidate)
         platformContribution[candidate.platform, default: 0] += 1
     }
@@ -946,7 +958,9 @@ func runUnion(candidates: [Candidate], sdks: [PlatformSDK]) -> UnionResult {
             // the merge itself.
             conflicted = mergeAvailability(candidate.availability, into: &states) || conflicted
         }
-        if conflicted { conflictCount += 1 }
+        if conflicted {
+            conflictCount += 1
+        }
 
         var betaDomains: Set<AvailabilityDomain> = []
         for domain in AvailabilityDomain.allCases {
@@ -1179,12 +1193,16 @@ func parseParameterSlots(_ fragments: [Symbol.Fragment]) -> [ParameterSlot]? {
     var paramsClosed = false
 
     func closeCurrent() {
-        if let slot = current { finished.append(slot) }
+        if let slot = current {
+            finished.append(slot)
+        }
         current = nil
     }
 
     for (index, fragment) in fragments.enumerated() {
-        if paramsClosed { break }
+        if paramsClosed {
+            break
+        }
         if fragment.kind == "text" {
             var previous: Character = " "
             for ch in fragment.spelling {
@@ -1213,7 +1231,9 @@ func parseParameterSlots(_ fragments: [Symbol.Fragment]) -> [ParameterSlot]? {
                 case "}": braceDepth -= 1
                 case "<": angleDepth += 1
                 case ">" where previous != "-": // "->" is an arrow
-                    if angleDepth > 0 { angleDepth -= 1 }
+                    if angleDepth > 0 {
+                        angleDepth -= 1
+                    }
                 case "," where parenDepth == 1 && angleDepth == 0
                     && squareDepth == 0 && braceDepth == 0:
                     closeCurrent()
@@ -1221,13 +1241,17 @@ func parseParameterSlots(_ fragments: [Symbol.Fragment]) -> [ParameterSlot]? {
                 default:
                     break
                 }
-                if paramsClosed { break }
+                if paramsClosed {
+                    break
+                }
                 if var slot = current {
                     slot.lastIndex = index
                     if slot.inTypeRegion {
                         slot.typeText.append(ch)
                         if !ch.isWhitespace {
-                            if slot.firstTypeIndex == nil { slot.firstTypeIndex = index }
+                            if slot.firstTypeIndex == nil {
+                                slot.firstTypeIndex = index
+                            }
                             slot.lastTypeIndex = index
                         }
                     } else if ch == ":" {
@@ -1250,7 +1274,9 @@ func parseParameterSlots(_ fragments: [Symbol.Fragment]) -> [ParameterSlot]? {
                 } else if slot.inTypeRegion {
                     slot.typeText += fragment.spelling
                     slot.typeFragments.append(fragment)
-                    if slot.firstTypeIndex == nil { slot.firstTypeIndex = index }
+                    if slot.firstTypeIndex == nil {
+                        slot.firstTypeIndex = index
+                    }
                     slot.lastTypeIndex = index
                     slot.lastIndex = index
                     current = slot
@@ -1341,10 +1367,16 @@ func stringSiblingSpelling(
     of slot: ParameterSlot,
     constrainedNames: Set<String>
 ) -> StringSiblingSpelling? {
-    if slot.typeText == "String" { return .bareString }
+    if slot.typeText == "String" {
+        return .bareString
+    }
     if slot.typeText == "some StringProtocol",
-       slot.containsType(in: [stringProtocolUSR]) { return .someStringProtocol }
-    if constrainedNames.contains(slot.typeText) { return .genericWhereClause }
+       slot.containsType(in: [stringProtocolUSR]) {
+        return .someStringProtocol
+    }
+    if constrainedNames.contains(slot.typeText) {
+        return .genericWhereClause
+    }
     return nil
 }
 
@@ -1571,7 +1603,9 @@ func runPolicy(
             case .unrecognizedShape: stats.rejectedUnrecognizedShape += 1
             case .deprecated: break // Stage 4 never rejects for deprecation
             }
-            if lskReturnOnly { stats.lskReturnOnly += 1 }
+            if lskReturnOnly {
+                stats.lskReturnOnly += 1
+            }
         }
     }
     return PolicyResult(classified: classified, rejected: rejected, stats: stats)
@@ -1759,7 +1793,9 @@ func transform(_ classified: ClassifiedAPI) -> TransformVerdict {
     var existingNames: Set<String> = []
     for slot in slots {
         existingNames.insert(slot.label)
-        if let internalName = slot.internalName { existingNames.insert(internalName) }
+        if let internalName = slot.internalName {
+            existingNames.insert(internalName)
+        }
     }
     let insertedNames = localizableNames + fallbackNames
     guard Set(insertedNames).count == insertedNames.count,
@@ -1816,7 +1852,9 @@ func transform(_ classified: ClassifiedAPI) -> TransformVerdict {
             forwardedValues.append(slot.label == "_" ? resolved : "\(slot.label): \(resolved)")
             continue
         }
-        if !slot.hasDefaultValue { hasOtherRequired = true }
+        if !slot.hasDefaultValue {
+            hasOtherRequired = true
+        }
         guard !slot.typeText.hasPrefix("inout ") else {
             return reject("inout parameter '\(slot.label)' cannot be forwarded verbatim")
         }
@@ -1836,7 +1874,9 @@ func transform(_ classified: ClassifiedAPI) -> TransformVerdict {
     var signature = ""
     for (index, fragment) in fragments.enumerated() {
         signature += replaceAt[index] ?? fragment.spelling
-        if let insertion = insertAfter[index] { signature += insertion }
+        if let insertion = insertAfter[index] {
+            signature += insertion
+        }
     }
     signature = signature.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -1889,7 +1929,9 @@ func runTransform(_ classified: [ClassifiedAPI]) -> TransformResult {
         switch transform(item) {
         case .transformed(let overload):
             overloads.append(overload)
-            if overload.insertedSlots.count > 1 { multiSlotCount += 1 }
+            if overload.insertedSlots.count > 1 {
+                multiSlotCount += 1
+            }
         case .rejected(let reject):
             rejected.append(reject)
         }
@@ -2278,7 +2320,9 @@ func renderGeneratedFile(
             // member — top-level declarations do not inherit it the way
             // `public extension` members do.
             for (index, member) in members.enumerated() {
-                if index > 0 { lines.append("") }
+                if index > 0 {
+                    lines.append("")
+                }
                 lines += renderMember(
                     member, isFirstInFile: isFirstInFile, indent: "", accessPrefix: "public "
                 )
@@ -2291,7 +2335,9 @@ func renderGeneratedFile(
             )
             lines.append("public extension \(extendedType)\(clause) {")
             for (index, member) in members.enumerated() {
-                if index > 0 { lines.append("") }
+                if index > 0 {
+                    lines.append("")
+                }
                 lines += renderMember(
                     member, isFirstInFile: isFirstInFile, indent: "    ", accessPrefix: ""
                 )
@@ -2446,7 +2492,9 @@ func renderEmitOutput(
     var typeOrder: [String] = []
     var byType: [String: [TransformedOverload]] = [:]
     for overload in overloads {
-        if byType[overload.extendedType] == nil { typeOrder.append(overload.extendedType) }
+        if byType[overload.extendedType] == nil {
+            typeOrder.append(overload.extendedType)
+        }
         byType[overload.extendedType, default: []].append(overload)
     }
     typeOrder.sort()
@@ -2671,7 +2719,9 @@ func driftReport(_ output: EmitOutput, packageRoot: URL) -> DriftReport {
             drift.append("differs: \(relativePath)")
             let isManifest = relativePath == manifestRelativePath
             if isManifest || fileExcerptsEmitted < 2 {
-                if !isManifest { fileExcerptsEmitted += 1 }
+                if !isManifest {
+                    fileExcerptsEmitted += 1
+                }
                 diagnostics.append("--- diff excerpt: \(relativePath) ---")
                 diagnostics.append(contentsOf: unifiedDiffExcerpt(
                     checkedIn: url,
@@ -2803,7 +2853,9 @@ func main(options: Options) throws -> Int32 {
                 .joined(separator: ", ")
             print("     introduced: \(introduced.isEmpty ? "(none — all at/below floor)" : introduced)")
             let unavailable = api.unavailableDomains.map(\.rawValue).joined(separator: ", ")
-            if !unavailable.isEmpty { print("     unavailable: \(unavailable)") }
+            if !unavailable.isEmpty {
+                print("     unavailable: \(unavailable)")
+            }
             if !api.betaTierDomains.isEmpty {
                 let beta = api.betaTierDomains.map(\.rawValue).sorted().joined(separator: ", ")
                 print("     beta-tier: \(beta)")


### PR DESCRIPTION
## Summary

Promotes the live-invalidation emit seam to a paired public contract, letting non-Fluent server-side sources (Application-hosted actors, computed aggregates) participate in live ViewModel refresh:

- **`Application.invalidateProjections(of:)`** / **`Request.invalidateProjections(of:)`** (write side) — a non-Fluent source nudges live clients when its state changes. Routes collector-first, so a call inside `liveTransaction { }` reaches clients only if the transaction commits; with live invalidation not enabled it is a no-op.
- **`ProjectionContext.registerDependency(on:)`** (read side) — a factory registers response data the record-load plan can't see (e.g. an `appState` actor snapshot). The identity rides to the client with the response.

*Register a dependency on what you read; invalidate projections of what you changed.*

No new protocol, no new mechanism — both functions compose onto the existing collector task-local, hub, and registration-header machinery. The one structural change: `ProjectionContext` carries a required (never defaulted) `package dependencySink`, installed by `serve(_:)` as an insert that merges with the plan's registration set.

Design, rationale, and rejected alternatives: `docs/superpowers/plans/2026-07-16-live-invalidation-emit-promotion.md` (committed on this branch).

## Scope notes

- v1 emits the changed model's **own identity only** — containment derivation for non-Fluent sources is deliberately deferred.
- Fluent-persisted models never need either call — their saves already notify live clients.
- Docs: CHANGELOG (Unreleased), architecture doc gains a Live Invalidation section, api-catalog + reach-for index updated (plugin 2.15.0).

## Test plan

- 10 new contract tests (`InvalidateProjectionsTests` 6, `RegisterDependencyTests` 4), including an end-to-end register↔invalidate symmetry test through the real HTTP header and hub.
- Full suite green: 695 tests across all targets; swiftlint 0 violations; swiftformat clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtqZcyJQRAddaffMSVJJqU