### PR TITLE
feat!: register(request:) moves to RoutesBuilder — mount requests behind caller middleware groups

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/skills/fosutilities-api-catalog/SKILL.md
+++ b/.claude/skills/fosutilities-api-catalog/SKILL.md
@@ -56,7 +56,7 @@ line via the `fosutilities-api-catalog-update` skill.
 - Rendering a ViewModel in SwiftUI — app setup, view binding, previews, form views → `FOSMVVM.md § SwiftUI Support`
 - Versioning ViewModel properties, choosing deployment URLs, negotiating versions over HTTP → `FOSMVVM.md § Versioning`
 - Booting a Vapor server for MVVM — YAML localization store, environment, locale, Leaf rendering → `FOSMVVMVapor.md § Extensions`
-- Registering request routes (reads and CRUD writes), or serving a request outside the guarded verbs → `FOSMVVMVapor.md § Vapor Support`
+- Registering request routes (reads and CRUD writes) — including mounting one behind a credential/middleware group — or serving a request outside the guarded verbs → `FOSMVVMVapor.md § Vapor Support`
 - Projecting loaded records into a response body, or reading them through the projection context → `FOSMVVMVapor.md § Containment`, `§ Protocols`
 - Declaring Fluent containers and their relations, or mapping sort meanings to database columns → `FOSMVVMVapor.md § Containment`
 - Registering the container authorization provider, apex resolver, per-request app state, or a container migration → `FOSMVVMVapor.md § Containment`, `§ Extensions`

--- a/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVMVapor.md
@@ -328,7 +328,7 @@ as…") that isn't a loaded record. Register one builder per `AppState` type in
 `configure(_:)`; it runs in the load phase with full request power and is handed to the
 synchronous `body(context:)` as a plain value (read via `ProjectionContext.appState`).
 Register it **before** the requests that project it — a non-`Void` `AppState` with no
-builder fails fast at `register(request:)`. `Void` (the default) needs no registration.
+builder fails fast at `register(request:app:)`. `Void` (the default) needs no registration.
 
 ```swift
 try app.useAppState(SessionBanner.self) { req in
@@ -452,7 +452,7 @@ factory's declared requirements — see FOSMVVM's `ComposableFactory` /
 `LoadRequirement`), so projection reads them, never loads them. The factory is
 handed a `ProjectionContext` (see Containment) — never a `Vapor.Request`, never a
 `Database`. A zero-data body conforms to the factory alone (no
-`ComposableFactory`). Registered with `register(request:)` (see Vapor Support);
+`ComposableFactory`). Registered with `register(request:app:)` (see Vapor Support);
 the default `encodeResponse` serves the body *localized* to the request's
 Accept-Language via `buildResponse()`. Data the factory can't declare as tuples
 loads through `SupplementalRecordLoading` (see Protocols).
@@ -576,7 +576,7 @@ extension DockPageViewModel: SupplementalRecordLoading {
 ## Vapor Support
 
 The routing layer that turns request types into live routes: the one
-Application-only registration door for every request (reads and the guarded CRUD
+`RoutesBuilder` registration door for every request (reads and the guarded CRUD
 writes), and the general dispatch controller for operations outside the guarded
 verbs (the request-binding host and middleware behind them are internal).
 
@@ -586,25 +586,31 @@ in `routes(_:)`. Its `ResponseBody` must be a `VaporResponseBodyFactory` (see
 Protocols); the route's path derives from the request type, so client and server can
 never disagree on it. A read registers GET; write requests (CreateRequest /
 UpdateRequest / DeleteRequest, FOSMVVM's Protocols) have their own overloads Swift
-picks by their Query/RequestBody constraints. Registration is Application-only by
-construction — there is no grouped/`Routes`-level door, so a composable body can never
-register without its plan. Register the app's containers
+picks by their Query/RequestBody constraints. It is a `RoutesBuilder` method taking
+the `Application` as a parameter: register on the route group whose middleware you want
+guarding the route — a credential group for privileged requests, the `Application`
+itself (which is a `RoutesBuilder`) for public ones. Where a request mounts is your
+decision; that its plan is derived is not. Register the app's containers
 (`register(_:migration:)`, see Extensions) **before** calling this: a composable
-body's load plan is derived and validated here, at boot.
-Don't reach for a removed `register(viewModel:)` — there is one `register(request:)`
+body's load plan is derived and validated here, at boot. Mount only on
+middleware-only groups — a path-prefixing group (`app.grouped("admin")`) is rejected
+at boot, because the client derives the served URL from the request type.
+Don't reach for a removed `register(viewModel:)` — there is one `register(request:app:)`
 door; a `ReplaceRequest`/`DestroyRequest`, or a write request that reaches the read
 door, fails fast at boot rather than registering GET-only.
 
 ```swift
 func routes(_ app: Application) throws {
-    try app.register(request: DockPageRequest.self)      // read (GET)
-    try app.register(request: UpdateBerthRequest.self)   // write door, picked by Swift
+    let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
+    try authed.register(request: DockPageRequest.self, app: app)   // guarded read (GET)
+    try authed.register(request: UpdateBerthRequest.self, app: app) // write door, picked by Swift
+    try app.register(request: LandingPageRequest.self, app: app)   // public (Application is a RoutesBuilder)
 }
 ```
 
 ### General request dispatch — `ServerRequestController` / `ServerRequestControllerError`
 Reach for this when: an operation falls outside the guarded verbs
-`register(request:)` covers (e.g. a `ReplaceRequest`, multi-record operations) —
+`register(request:app:)` covers (e.g. a `ReplaceRequest`, multi-record operations) —
 conform, supply one processor per `ServerRequestAction`, and register the controller
 as a route collection. Grouping, HTTP-method mapping (`.show` GET · `.create` POST ·
 `.replace` PUT · `.update` PATCH · `.delete`/`.destroy` DELETE), body decoding
@@ -614,7 +620,7 @@ typed request (query and sort parsed; `requestBody` decoded on a body verb). `.d
 and `.destroy` both ride DELETE at one URL, so a controller registers only one —
 the other throws `ServerRequestControllerError.invalidAction`; a body verb whose body
 is absent throws `.missingRequestBody`.
-Prefer `register(request:)` — it instantiates this same mechanism pre-specialized
+Prefer `register(request:app:)` — it instantiates this same mechanism pre-specialized
 with the framework's guarded pipelines (declared loads, write gates, refresh
 fall-through). Scaffolded by `fosmvvm-serverrequest-generator`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- **`register(request:)` moves to `RoutesBuilder`** (FOSMVVMVapor, **BREAKING**). The four
+  registration doors (read, create, update, delete) are now `RoutesBuilder` methods taking
+  an `app:` parameter; the `Vapor.Application`-sited versions are removed. Register a request
+  on the route group whose middleware you want guarding it — mount privileged requests behind
+  your credential group, public ones on the `Application` itself (an `Application` is a
+  `RoutesBuilder`). The old siting also deviated from standard Vapor practice, where routing
+  surfaces are where processing mounts and the `Application` receiver is for app-wide
+  configuration. Where a request mounts is your decision; that its plan is derived is not —
+  every door still derives and validates the request's load plan.
+  **Migration:** `try app.register(request: X.self)` → `try app.register(request: X.self, app: app)`,
+  or mount on a middleware group: `try authed.register(request: X.self, app: app)`. A
+  path-prefixing group (`app.grouped("admin")`) is now rejected at boot, because clients derive
+  the served URL from the request type; mount only on middleware-only groups.
 
 ## [0.8.0] - 2026-07-17
 

--- a/Sources/FOSMVVM/FOSMVVM.docc/ServerOverview.md
+++ b/Sources/FOSMVVM/FOSMVVM.docc/ServerOverview.md
@@ -32,22 +32,29 @@ public func configure(_ app: Application) async throws {
 
 #### Initializing Routes
 
-Register each ``ServerRequest`` whose `ResponseBody` is a `VaporResponseBodyFactory`. Registration is
-**Application-only** — one door for every request:
+Register each ``ServerRequest`` whose `ResponseBody` is a `VaporResponseBodyFactory` on a route group,
+passing the `Application` — one door for every request. The group you register on decides the middleware
+that guards the route: mount privileged requests behind your credential group, public ones on the
+`Application` itself (an `Application` is a `RoutesBuilder`):
 
 ```swift
 func routes(_ app: Application) throws {
-    try app.register(request: LandingPageRequest.self)
-    try app.register(request: DashboardPageRequest.self)
+    let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
+    try authed.register(request: DashboardPageRequest.self, app: app)
+    try app.register(request: LandingPageRequest.self, app: app)
 }
 ```
 
 Registration derives and validates each composable request's data-load plan at boot, so a forgotten or
 unresolvable data need fails fast at startup rather than at request time. Write requests
 (`CreateRequest`/`UpdateRequest`/`DeleteRequest`) register the same way — Swift selects the write door.
+Where a request mounts is your decision; that its plan is derived is not.
 
-There is no grouped/`Routes`-level registration and no per-route auth middleware for data access.
-**Authorization is by data-scoping:** the framework loads only the records the current subject is
+Mount only on **middleware-only** groups (`app.grouped(middleware)`): a path-prefixing group
+(`app.grouped("admin")`) would change the served URL while clients derive it from the request type, so
+registration rejects that at boot.
+
+**Data-scoping still applies:** the framework loads only the records the current subject is
 authorized for, through the app's registered `ContainerAuthorizationProvider` — the projection is handed
 an already-auth-scoped, read-only cache and cannot load anything else. Register the provider (and the
 app's containers) before registering requests.

--- a/Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md
+++ b/Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md
@@ -139,9 +139,13 @@ import Vapor
 import ViewModels
 
 func routes(_ app: Application) throws {
-    try app.register(request: LandingPageRequest.self)
+    try app.register(request: LandingPageRequest.self, app: app)
 }
 ```
+
+Register on the route group whose middleware you want guarding the route — mount a public request on the
+`Application` itself (an `Application` is a `RoutesBuilder`), a privileged one behind your credential
+group: `try app.grouped(ClientCredentialMiddleware(verifier: myVerifier)).register(request: DashboardPageRequest.self, app: app)`.
 
 ## Display-Only vs Interactive ViewModels
 

--- a/Sources/FOSMVVMVapor/Containment/AppStateRegistry.swift
+++ b/Sources/FOSMVVMVapor/Containment/AppStateRegistry.swift
@@ -29,7 +29,7 @@ public extension Vapor.Application {
     /// ```
     ///
     /// Register the builder **before** the requests that project it — a request whose `ResponseBody`
-    /// declares a non-`Void` `AppState` with no builder registered fails at ``register(request:)``.
+    /// declares a non-`Void` `AppState` with no builder registered fails at ``Vapor/RoutesBuilder/register(request:app:)``.
     ///
     /// The builder is keyed by the `AppState` type: everything the projection needs about the session
     /// arrives through the value it returns. Capturing the request's power in the closure is
@@ -54,7 +54,7 @@ public extension Vapor.Application {
 }
 
 extension Application {
-    /// Read side of the seam — consumed by the ``register(request:)`` boot check and by
+    /// Read side of the seam — consumed by the ``Vapor/RoutesBuilder/register(request:app:)`` boot check and by
     /// Request.resolveAppState at request time (same module).
     func appStateBuilder(forTypeIdentifier id: ObjectIdentifier) -> AppStateBuilder? {
         storage[AppStateBuilderStore.self]?[id]

--- a/Sources/FOSMVVMVapor/Containment/ContainmentError.swift
+++ b/Sources/FOSMVVMVapor/Containment/ContainmentError.swift
@@ -23,7 +23,9 @@ import Foundation
 /// `.duplicateAppStateBuilder` (useAppState registry validation at route registration),
 /// `.unstableRequirementTokens` (`dataRequirements`/`candidates` mints requirements inline
 /// instead of returning stored handles), `.writeRequestAtReadDoor` / `.unsupportedWriteProtocol` (a
-/// write-protocol conformer reaching the read door / a not-yet-supported write protocol).
+/// write-protocol conformer reaching the read door / a not-yet-supported write protocol),
+/// `.pathPrefixedMount` (a request registered on a path-prefixing group, whose served path would
+/// diverge from the type-derived path clients fetch).
 /// REQUEST-TIME:
 /// `.unregisteredNamespace` (registry lookup for a stored identity found no registered type),
 /// `.noAuthorizationProvider` (first authorized load with no provider registered),
@@ -54,6 +56,7 @@ enum ContainmentError: Error, CustomDebugStringConvertible {
     case unstableRequirementTokens(request: String, handle: String)
     case writeRequestAtReadDoor(request: String)
     case unsupportedWriteProtocol(request: String)
+    case pathPrefixedMount(request: String, mountedPath: String)
     case invalidCreateScope(container: String, recordType: String)
 
     var debugDescription: String {
@@ -81,7 +84,7 @@ enum ContainmentError: Error, CustomDebugStringConvertible {
         case .ambiguousRequirement(let recordType, let request, let matchCount):
             "A projection of \(request) read \(recordType) through a requirement handle that matched \(matchCount) declared loads — the handle is ambiguous. The same declaration was composed onto multiple paths — give each composition its own declaration so the handle names exactly one load; the framework never guesses which set to return."
         case .missingAppStateBuilder(let request, let appStateType):
-            "No AppState builder is registered for \(appStateType), which \(request)'s ResponseBody projects. Register one in configure(_:) via useAppState(\(appStateType).self) { req in ... } — call it BEFORE register(request:). A non-Void AppState with no builder is a boot-time configuration bug, never a first-request surprise."
+            "No AppState builder is registered for \(appStateType), which \(request)'s ResponseBody projects. Register one in configure(_:) via useAppState(\(appStateType).self) { req in ... } — call it BEFORE register(request:app:). A non-Void AppState with no builder is a boot-time configuration bug, never a first-request surprise."
         case .duplicateAppStateBuilder(let appStateType):
             "Duplicate AppState builder registration: a builder for \(appStateType) is already registered, so this one was rejected. Exactly one builder per AppState type (useAppState(_:builder:)); compose multiple sources inside that single closure."
         case .appStateInconsistency(let request, let appStateType, let reason):
@@ -89,9 +92,11 @@ enum ContainmentError: Error, CustomDebugStringConvertible {
         case .unstableRequirementTokens(let request, let handle):
             "\(request)'s \(handle) is not stable across evaluations: two reads minted different declaration identities. Mint each requirement in a stored static let handle and return those handles — a computed dataRequirements (or candidates) RETURNING stored handles is fine and canonical; minting inline in the getter allocates a fresh declaration identity on each access, which breaks the handle→load resolution."
         case .writeRequestAtReadDoor(let request):
-            "\(request) is a write-protocol request (Create/Update/Delete) but reached the read door (register(request:) for a plain read). Its Query/RequestBody do not satisfy the write overload's constraints (Query: TargetedQuery, RequestBody: DataModelWriter/WriteTargetProviding), so overload resolution fell through to the read door. Registering it read-only would be a silent write-drop — fix the Query/RequestBody so the write overload binds."
+            "\(request) is a write-protocol request (Create/Update/Delete) but reached the read door (register(request:app:) for a plain read). Its Query/RequestBody do not satisfy the write overload's constraints (Query: TargetedQuery, RequestBody: DataModelWriter/WriteTargetProviding), so overload resolution fell through to the read door. Registering it read-only would be a silent write-drop — fix the Query/RequestBody so the write overload binds."
         case .unsupportedWriteProtocol(let request):
             "\(request) speaks a write protocol that is not yet supported (ReplaceRequest/DestroyRequest). Only Create, Update, and Delete are wired. Registering it read-only would be a silent write-drop — this write protocol has no route yet."
+        case .pathPrefixedMount(let request, let mountedPath):
+            "\(request) was registered on a path-prefixing group — its served path became \(mountedPath), but clients derive the route from the request type, so the two would silently disagree (runtime 404s). Mount composable requests on middleware-only groups (app.grouped(middleware)) to guard them; a path prefix changes the served URL out from under the client. A deliberate, client-visible prefix is its own feature, not this door."
         case .invalidCreateScope(let container, let recordType):
             "Cannot create a \(recordType) into \(container): the containment relation for \(recordType) is a to-one parent relation, which is not a create scope. Create is defined only into a container's .children or .siblings relations, where the container owns the new record."
         }

--- a/Sources/FOSMVVMVapor/Containment/PlanExecutor.swift
+++ b/Sources/FOSMVVMVapor/Containment/PlanExecutor.swift
@@ -30,8 +30,8 @@ extension Vapor.Request {
     /// keys land in ``tupleCacheKeys``), then runs the ``SupplementalRecordLoading`` hooks.
     ///
     /// A non-composable (legacy) ResponseBody is a no-op. A composable ResponseBody with NO
-    /// stored plan throws `ContainmentError.invalidLoadPlan` — registration is Application-only
-    /// (`register(request:)`), which always derives the plan, so a missing plan means the request
+    /// stored plan throws `ContainmentError.invalidLoadPlan` — registration
+    /// (`register(request:app:)`) always derives the plan, so a missing plan means the request
     /// was never registered, and silently loading nothing would be the misconfiguration's
     /// invisible mode.
     func executeRecordLoadPlan<SR: ServerRequest>(for vmRequest: SR) async throws {
@@ -41,7 +41,7 @@ extension Vapor.Request {
         guard let plan = application.recordLoadPlan(for: SR.self) else {
             throw ContainmentError.invalidLoadPlan(
                 request: String(describing: SR.self),
-                reason: "\(String(describing: SR.ResponseBody.self)) is composable but no RecordLoadPlan was derived — register the request on the Application via try app.register(request:), which derives and validates the plan at boot"
+                reason: "\(String(describing: SR.ResponseBody.self)) is composable but no RecordLoadPlan was derived — register the request via try app.register(request: SR.self, app: app), which derives and validates the plan at boot"
             )
         }
 

--- a/Sources/FOSMVVMVapor/Containment/PlanRegistration.swift
+++ b/Sources/FOSMVVMVapor/Containment/PlanRegistration.swift
@@ -59,7 +59,7 @@ extension Application {
 
     /// The stored plan for a request type. `nil` means EITHER the ResponseBody is
     /// non-composable (legacy — expected, correct) OR the request was never registered.
-    /// Registration is Application-only (`register(request:)`) and always derives a composable
+    /// Registration (`register(request:app:)`) always derives a composable
     /// body's plan, so a composable body reaching the executor with no stored plan is a
     /// never-registered configuration error: the executor throws typed
     /// (`ContainmentError.invalidLoadPlan`) rather than silently loading nothing.

--- a/Sources/FOSMVVMVapor/Containment/WriteRoute.swift
+++ b/Sources/FOSMVVMVapor/Containment/WriteRoute.swift
@@ -141,7 +141,7 @@ extension Vapor.Request {
         guard let plan = application.candidatePlan(for: SR.self) else {
             throw ContainmentError.invalidLoadPlan(
                 request: String(describing: SR.self),
-                reason: "no candidate plan was derived — register the request as a write via try app.register(request:), which derives and validates the candidate plan at boot"
+                reason: "no candidate plan was derived — register the request as a write via try app.register(request: SR.self, app: app), which derives and validates the candidate plan at boot"
             )
         }
         let resolved = try await resolveRecordLoadPlan(plan, for: boundRequest)

--- a/Sources/FOSMVVMVapor/Protocols/VaporResponseBodyFactory.swift
+++ b/Sources/FOSMVVMVapor/Protocols/VaporResponseBodyFactory.swift
@@ -49,7 +49,7 @@ public protocol VaporResponseBodyFactory: ResponseBodyFactory, Vapor.AsyncRespon
 public extension VaporResponseBodyFactory {
     /// Serves the body *localized to the request's* [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Language).
     ///
-    /// The server route registered by ``Vapor/Application/register(request:)`` returns the
+    /// The server route registered by ``Vapor/RoutesBuilder/register(request:app:)`` returns the
     /// *unlocalized* body straight from its processor and hands it to the shared
     /// ``ServerRequestBody/buildResponse(_:)`` to build the HTTP `Response`. That is the single
     /// point where localization-on-serve happens — the request-binding

--- a/Sources/FOSMVVMVapor/Vapor Support/GuardedRequestController.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/GuardedRequestController.swift
@@ -17,7 +17,7 @@
 import FOSMVVM
 import Vapor
 
-/// The pre-specialized controller register(request:) instantiates: the general
+/// The pre-specialized controller register(request:app:) instantiates: the general
 /// dispatch mechanism carrying the framework's guarded pipelines as its processors.
 /// Guards live in the processors (and the register-door boot checks) — never in
 /// which door was walked through.

--- a/Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/ServeRequest.swift
@@ -77,7 +77,7 @@ package extension Vapor.Request {
     /// Resolves the projection's `AppState` value. `Void` is the zero-ceremony default (no builder,
     /// no registration). For a non-`Void` `AppState`, the builder registered with
     /// `useAppState(_:builder:)` runs here — in the load phase, with full request power — and its
-    /// value is handed to the projection. The boot check in `register(request:)` guarantees a
+    /// value is handed to the projection. The boot check in `register(request:app:)` guarantees a
     /// builder exists and produces this exact type, so a missing or mistyped builder here is a
     /// framework-invariant breakage, never an app misconfiguration.
     private func resolveAppState<AppState: Sendable>(_: AppState.Type, request: Any.Type) async throws -> AppState {

--- a/Sources/FOSMVVMVapor/Vapor Support/ServerRequestController.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/ServerRequestController.swift
@@ -39,7 +39,7 @@ import Vapor
 /// try app.routes.register(collection: ReplaceBerthController())
 /// ```
 ///
-/// Prefer ``Vapor/Application/register(request:)`` — it instantiates this mechanism
+/// Prefer ``Vapor/RoutesBuilder/register(request:app:)`` — it instantiates this mechanism
 /// pre-specialized with the framework's guarded pipelines (declared loads, write
 /// gates, the refresh fall-through). Reach for a hand-written controller when an
 /// operation falls outside the guarded verbs (e.g. `ReplaceRequest`, multi-record

--- a/Sources/FOSMVVMVapor/Vapor Support/VaporServerRequestMiddleware.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/VaporServerRequestMiddleware.swift
@@ -25,7 +25,7 @@ enum VaporServerRequestMiddlewareError: Error, CustomDebugStringConvertible {
     var debugDescription: String {
         switch self {
         case .missingRequest:
-            "requireServerRequest() found no bound ServerRequest on this Vapor.Request. The typed request is bound during routing by VaporServerRequestMiddleware, which is installed only when the route is registered through the FOS path — app.register(request:), or routes.register(collection:) on a ServerRequestController. A hand-rolled route that calls requireServerRequest() without that middleware always lands here; register it through one of those instead."
+            "requireServerRequest() found no bound ServerRequest on this Vapor.Request. The typed request is bound during routing by VaporServerRequestMiddleware, which is installed only when the route is registered through the FOS path — register(request:app:), or routes.register(collection:) on a ServerRequestController. A hand-rolled route that calls requireServerRequest() without that middleware always lands here; register it through one of those instead."
         }
     }
 }

--- a/Sources/FOSMVVMVapor/Vapor Support/ViewModelRequest.swift
+++ b/Sources/FOSMVVMVapor/Vapor Support/ViewModelRequest.swift
@@ -17,150 +17,228 @@
 import FOSMVVM
 import Vapor
 
-public extension Vapor.Application {
-    /// Registers a read request's route (GET). One door for every request — a body that is a
-    /// ViewModel and a body that is not (a report, an export) register the same way.
+public extension RoutesBuilder {
+    /// Registers a read request's route (GET) on this route group.
     ///
-    /// ## Example
+    /// The group you call it on decides the middleware that guards the route —
+    /// mount privileged requests behind your credential group, public ones on the
+    /// `Application` itself (an `Application` is a `RoutesBuilder`):
     ///
     /// ```swift
     /// func routes(_ app: Application) throws {
-    ///    try app.register(request: DockPageRequest.self)
+    ///     let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
+    ///     try authed.register(request: DockPageRequest.self, app: app)
+    ///     try app.register(request: LandingPageRequest.self, app: app)
     /// }
     /// ```
+    ///
+    /// One door for every request — a body that is a ViewModel and a body that is
+    /// not (a report, an export) register the same way.
     ///
     /// >  *ServerRequest* provides a protocol extension that sets *ServerRequest/path* based on
     /// >   the *ServerRequest/RequestBody* and *ServerRequest/ResponseBody* types. Thus, the
     /// >   route's path is automatically maintained and there is never a path collision or
-    /// >   confusion between the client and server.
+    /// >   confusion between the client and server. Mount on **middleware-only** groups: a
+    /// >   path-prefixing group would change the served URL while clients derive it from the
+    /// >   type — registration rejects that at boot.
     ///
-    /// Register the app's containers (``Application/register(_:migration:)``) **before** calling
-    /// this — a composable body's load plan is derived and validated here, against the containers
-    /// registered so far. Registration is Application-only by construction: there is no
-    /// grouped/`Routes`-level door, so a composable body can never be registered without its plan.
+    /// Register the app's containers (``Vapor/Application/register(_:migration:)``) **before**
+    /// calling this — a composable body's load plan is derived and validated here, against
+    /// `app`'s registered containers. Every door derives the plan: where a request mounts is
+    /// your decision; that its plan is derived is not.
     ///
     /// A write request (Create/Update/Delete) has its own overload; register it the same way
-    /// (`try app.register(request: UpdateBerthRequest.self)`), and Swift picks the write door. A
-    /// write request that reaches *this* read door — because its Query/RequestBody miss the write
-    /// overload's constraints, or because its protocol (Replace/Destroy) is not yet supported —
-    /// fails fast at boot rather than registering GET-only (which would silently drop the write).
+    /// (`try authed.register(request: BerthUpdateRequest.self, app: app)`), and Swift picks
+    /// the write door. A write request that reaches *this* read door — because its
+    /// Query/RequestBody miss the write overload's constraints, or because its protocol
+    /// (Replace/Destroy) is not yet supported — fails fast at boot rather than registering
+    /// GET-only (which would silently drop the write).
     ///
-    /// - Parameter request: A *ServerRequest* whose *ResponseBody* is a ``VaporResponseBodyFactory``
-    func register<SR: ServerRequest>(request _: SR.Type) throws
+    /// - Parameters:
+    ///   - request: A *ServerRequest* whose *ResponseBody* is a ``VaporResponseBodyFactory``
+    ///   - app: The application this route serves — the request's load plan is derived
+    ///     into and validated against it
+    func register<SR: ServerRequest>(request _: SR.Type, app: Vapor.Application) throws
         where SR.ResponseBody: VaporResponseBodyFactory {
         // Boot-time fail-fast: overload resolution can send a write request to this read door.
         // Catch it here — a GET-only registration of a write request would be the silent mode.
         try rejectWriteProtocolAtReadDoor(SR.self)
         // Boot-time fail-fast: a non-Void projection AppState needs a useAppState(_:) builder, and it
         // must already be registered — misconfiguration is a boot error, not a first-request surprise.
-        try requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
+        try app.requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
         // Boot-derivation seam: a composable ResponseBody's RecordLoadPlan is derived + validated
         // HERE, once per request type. A non-composable (zero-data) body derives no plan.
-        try registerRecordLoadPlan(for: SR.self)
-        try routes.register(collection: GuardedRequestController<SR>(actions: [
-            .show: { req, bound in try await req.serve(bound) }
-        ]))
+        try app.registerRecordLoadPlan(for: SR.self)
+        try mountVerifyingPath(SR.self, app: app) {
+            try register(collection: GuardedRequestController<SR>(actions: [
+                .show: { req, bound in try await req.serve(bound) }
+            ]))
+        }
     }
+}
 
-    /// Registers a create request's routes: POST for the write, plus the request's own read plan
-    /// for the response.
-    ///
-    /// ## Example
+public extension RoutesBuilder {
+    /// Registers a create request's route (POST) on this route group, plus the request's own read
+    /// plan for the response.
     ///
     /// ```swift
     /// func routes(_ app: Application) throws {
-    ///    try app.register(request: CreateBerthRequest.self)
+    ///     let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
+    ///     try authed.register(request: CreateBerthRequest.self, app: app)
     /// }
     /// ```
+    ///
+    /// Mount on **middleware-only** groups: a path-prefixing group is rejected at boot, because clients
+    /// derive the served URL from the request type.
     ///
     /// The framework instantiates a fresh `Target()`, calls the body's `apply`, sets the container
     /// foreign key from the candidate scope, and saves — then re-serves the request itself to build
     /// its `ResponseBody` from the refreshed records.
-    func register<SR: CreateRequest>(request _: SR.Type) throws
+    ///
+    /// - Parameters:
+    ///   - request: A *CreateRequest* whose *ResponseBody* is a ``VaporResponseBodyFactory``
+    ///   - app: The application this route serves — the request's candidate and response load plans
+    ///     are derived into and validated against it
+    func register<SR: CreateRequest>(request _: SR.Type, app: Vapor.Application) throws
         where SR.RequestBody: DataModelWriter,
         SR.ResponseBody: VaporResponseBodyFactory {
-        try requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
-        try registerRecordLoadPlan(for: SR.self)
-        try deriveCandidatePlan(for: SR.self, writer: SR.RequestBody.self, expectedOperation: .createRecords)
-        try routes.register(collection: GuardedRequestController<SR>(actions: [
-            .create: { req, bound in
-                let body = try req.content.decode(SR.RequestBody.self)
-                return try await req.serveCreate(bound, body: body)
-            }
-        ]))
+        try app.requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
+        try app.registerRecordLoadPlan(for: SR.self)
+        try app.deriveCandidatePlan(for: SR.self, writer: SR.RequestBody.self, expectedOperation: .createRecords)
+        try mountVerifyingPath(SR.self, app: app) {
+            try register(collection: GuardedRequestController<SR>(actions: [
+                .create: { req, bound in
+                    let body = try req.content.decode(SR.RequestBody.self)
+                    return try await req.serveCreate(bound, body: body)
+                }
+            ]))
+        }
     }
 
-    /// Registers an update request's routes: PATCH for the write, plus the request's own read plan
-    /// for the response. Swift picks this door when the update request's Query names a
+    /// Registers an update request's route (PATCH) on this route group, plus the request's own read
+    /// plan for the response. Swift picks this door when the update request's Query names a
     /// target and its RequestBody writes.
-    ///
-    /// ## Example
     ///
     /// ```swift
     /// func routes(_ app: Application) throws {
-    ///    try app.register(request: UpdateBerthRequest.self)
+    ///     let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
+    ///     try authed.register(request: UpdateBerthRequest.self, app: app)
     /// }
     /// ```
+    ///
+    /// Mount on **middleware-only** groups: a path-prefixing group is rejected at boot, because clients
+    /// derive the served URL from the request type.
     ///
     /// Register the app's containers and the request's response dependencies (apex resolver,
     /// `useAppState`) **before** calling this — the candidate plan and the response read plan are
     /// derived and validated here. After the update commits, the server re-serves the request itself
     /// through the genuine read pipeline to build its `ResponseBody`.
-    func register<SR: UpdateRequest>(request _: SR.Type) throws
+    ///
+    /// - Parameters:
+    ///   - request: An *UpdateRequest* whose *ResponseBody* is a ``VaporResponseBodyFactory``
+    ///   - app: The application this route serves — the request's candidate and response load plans
+    ///     are derived into and validated against it
+    func register<SR: UpdateRequest>(request _: SR.Type, app: Vapor.Application) throws
         where SR.RequestBody: DataModelWriter,
         SR.Query: TargetedQuery,
         SR.ResponseBody: VaporResponseBodyFactory {
-        try requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
-        try registerRecordLoadPlan(for: SR.self)
-        try deriveCandidatePlan(for: SR.self, writer: SR.RequestBody.self, expectedOperation: .writeRecords)
-        try routes.register(collection: GuardedRequestController<SR>(actions: [
-            .update: { req, bound in
-                let body = try req.content.decode(SR.RequestBody.self)
-                return try await req.serveUpdate(bound, body: body)
-            }
-        ]))
+        try app.requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
+        try app.registerRecordLoadPlan(for: SR.self)
+        try app.deriveCandidatePlan(for: SR.self, writer: SR.RequestBody.self, expectedOperation: .writeRecords)
+        try mountVerifyingPath(SR.self, app: app) {
+            try register(collection: GuardedRequestController<SR>(actions: [
+                .update: { req, bound in
+                    let body = try req.content.decode(SR.RequestBody.self)
+                    return try await req.serveUpdate(bound, body: body)
+                }
+            ]))
+        }
     }
 
-    /// Registers a delete request's routes: DELETE for the write, plus the request's own read plan
-    /// for the response. A delete body declares its candidate set only
+    /// Registers a delete request's route (DELETE) on this route group, plus the request's own read
+    /// plan for the response. A delete body declares its candidate set only
     /// (``WriteTargetProviding``); deletion is framework-owned.
-    ///
-    /// ## Example
     ///
     /// ```swift
     /// func routes(_ app: Application) throws {
-    ///    try app.register(request: DeleteBerthRequest.self)
+    ///     let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
+    ///     try authed.register(request: DeleteBerthRequest.self, app: app)
     /// }
     /// ```
     ///
+    /// Mount on **middleware-only** groups: a path-prefixing group is rejected at boot, because clients
+    /// derive the served URL from the request type.
+    ///
     /// After the delete commits, the server re-serves the request itself to build its `ResponseBody`
     /// from the refreshed records (or `EmptyBody` when there is nothing to return).
-    func register<SR: DeleteRequest>(request _: SR.Type) throws
+    ///
+    /// - Parameters:
+    ///   - request: A *DeleteRequest* whose *ResponseBody* is a ``VaporResponseBodyFactory``
+    ///   - app: The application this route serves — the request's candidate and response load plans
+    ///     are derived into and validated against it
+    func register<SR: DeleteRequest>(request _: SR.Type, app: Vapor.Application) throws
         where SR.RequestBody: WriteTargetProviding,
         SR.Query: TargetedQuery,
         SR.ResponseBody: VaporResponseBodyFactory {
-        try requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
-        try registerRecordLoadPlan(for: SR.self)
-        try deriveCandidatePlan(for: SR.self, writer: SR.RequestBody.self, expectedOperation: .deleteRecords)
-        try routes.register(collection: GuardedRequestController<SR>(actions: [
-            .delete: { req, bound in try await req.serveDelete(bound) }
-        ]))
+        try app.requireAppStateBuilder(appStateType: SR.ResponseBody.AppState.self, request: SR.self)
+        try app.registerRecordLoadPlan(for: SR.self)
+        try app.deriveCandidatePlan(for: SR.self, writer: SR.RequestBody.self, expectedOperation: .deleteRecords)
+        try mountVerifyingPath(SR.self, app: app) {
+            try register(collection: GuardedRequestController<SR>(actions: [
+                .delete: { req, bound in try await req.serveDelete(bound) }
+            ]))
+        }
     }
 }
 
-private extension Vapor.Application {
-    /// Overload resolution sends a write-protocol conformer that misses the write doors' constraints
-    /// to the base read door. Reject it there: Create/Update/Delete conformers name unmet write
-    /// constraints; Replace/Destroy name the not-yet-supported protocol.
-    func rejectWriteProtocolAtReadDoor<SR: ServerRequest>(_: SR.Type) throws {
-        let name = String(describing: SR.self)
-        if SR.self is any ReplaceRequest.Type || SR.self is any DestroyRequest.Type {
-            throw ContainmentError.unsupportedWriteProtocol(request: name)
-        }
-        if SR.self is any UpdateRequest.Type
-            || SR.self is any CreateRequest.Type
-            || SR.self is any DeleteRequest.Type {
-            throw ContainmentError.writeRequestAtReadDoor(request: name)
+// swiftformat:disable docComments
+// Overload resolution sends a write-protocol conformer that misses the write doors' constraints
+// to the base read door. Reject it there: Create/Update/Delete conformers name unmet write
+// constraints; Replace/Destroy name the not-yet-supported protocol.
+// swiftformat:enable docComments
+private func rejectWriteProtocolAtReadDoor<SR: ServerRequest>(_: SR.Type) throws {
+    let name = String(describing: SR.self)
+    if SR.self is any ReplaceRequest.Type || SR.self is any DestroyRequest.Type {
+        throw ContainmentError.unsupportedWriteProtocol(request: name)
+    }
+    if SR.self is any UpdateRequest.Type
+        || SR.self is any CreateRequest.Type
+        || SR.self is any DeleteRequest.Type {
+        throw ContainmentError.writeRequestAtReadDoor(request: name)
+    }
+}
+
+// swiftformat:disable docComments
+// Runs `mount` (the `register(collection:)` that appends the request's route), then verifies
+// every route it appended carries exactly the type-derived path. A middleware-only group adds no
+// path components and passes untouched; a path-prefixing group (`app.grouped("admin")`) shifts the
+// served URL away from the type — the client derives the URL from the request type, so that
+// divergence is a boot error, not a silent runtime 404.
+//
+// Both the before-snapshot and the after-scan read `app.routes.all` — never the receiver builder:
+// a `MiddlewareGroup` has no route storage, forwarding registrations up to the root. `Routes.all`
+// is append-only and boot registration is single-threaded, so the suffix past the snapshot is
+// exactly the routes this registration added.
+//
+// The check assumes the receiver builder belongs to `app`: registering a builder derived from a
+// different Application is outside the contract — the suffix past `app.routes.all`'s snapshot would
+// hold none of this registration's routes, so the path check would pass vacuously.
+// swiftformat:enable docComments
+private func mountVerifyingPath<SR: ServerRequest>(
+    _: SR.Type,
+    app: Vapor.Application,
+    _ mount: () throws -> Void
+) throws {
+    let priorCount = app.routes.all.count
+    try mount()
+    let expected = SR.path.pathComponents.map(\.description)
+    for route in app.routes.all[priorCount...] {
+        let mounted = route.path.map(\.description)
+        if mounted != expected {
+            throw ContainmentError.pathPrefixedMount(
+                request: String(describing: SR.self),
+                mountedPath: "/" + mounted.joined(separator: "/")
+            )
         }
     }
 }

--- a/Tests/FOSMVVMVaporTests/Composition/PlanRegistrationTests.swift
+++ b/Tests/FOSMVVMVaporTests/Composition/PlanRegistrationTests.swift
@@ -142,6 +142,14 @@ private struct DockRootedQuery: RootedQuery {
     let rootIdentity: ModelIdentity
 }
 
+/// A no-op middleware — grouping on it proves the registration door works on a middleware group
+/// (not only the `Application`) while changing nothing about the served path.
+private struct PassthroughMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        try await next.respond(to: request)
+    }
+}
+
 // MARK: - The positive pair: hop-validated plan through the REAL registration seam
 
 /// Conforms to VaporResponseBodyFactory (not RegistrationFixture) so `register(request:)` —
@@ -480,8 +488,28 @@ struct PlanRegistrationTests {
     @Test func routeRegistrationSeamDerivesThePlan() async throws {
         try await withFluentTestApp { app in
             try configureContainers(app)
-            try app.register(request: DockPageRequest.self)
+            try app.register(request: DockPageRequest.self, app: app)
             #expect(app.recordLoadPlan(for: DockPageRequest.self) != nil)
+        } _: { _, _ in }
+    }
+
+    /// Contract 5: registering on a middleware group derives and validates the plan exactly as the
+    /// root form does — a composable body mounted on a group WITHOUT its containers registered
+    /// throws the same boot error as `try app.register(request:app:)`. Where a request mounts is the
+    /// caller's decision; that its plan is derived is not.
+    @Test func groupMountDerivesPlanAndFailsFastWithoutContainers() async throws {
+        try await withFluentTestApp { app in
+            let grouped = app.grouped(PassthroughMiddleware())
+            do {
+                try grouped.register(request: DockPageRequest.self, app: app) // no configureContainers
+                Issue.record("expected ContainmentError.invalidLoadPlan on a group mount without containers")
+            } catch let error as ContainmentError {
+                guard case .invalidLoadPlan = error else {
+                    Issue.record("wrong case: \(error)")
+                    return
+                }
+            }
+            #expect(app.recordLoadPlan(for: DockPageRequest.self) == nil)
         } _: { _, _ in }
     }
 
@@ -689,9 +717,10 @@ struct PlanRegistrationTests {
         } _: { _, _ in }
     }
 
-    // compile-audit: registration is Application-only. `register(request:)` is declared on
-    // `Vapor.Application` alone — there is no `RoutesBuilder`/grouped overload, so a composable
-    // body can never be registered through a path that skips plan derivation. Uncommenting the
-    // next line must fail to compile (no such member on RoutesBuilder):
-    // try app.grouped("api").register(request: DockPageRequest.self)
+    // contract: `register(request:app:)` is a `RoutesBuilder` method, so grouped mounting compiles —
+    // it is how a request mounts behind its guarding middleware. Plan derivation runs inside the door
+    // regardless of the builder, so no mount path can skip it. A path-prefixing group is caught at
+    // boot, not compile time: `try app.grouped("api").register(request: DockPageRequest.self, app: app)`
+    // compiles and throws `ContainmentError.pathPrefixedMount`, because the client derives the served
+    // URL from the request type.
 }

--- a/Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift
+++ b/Tests/FOSMVVMVaporTests/Composition/ProjectionContextTests.swift
@@ -478,7 +478,7 @@ struct ProjectionContextTests {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
             try configureContainers(app)
-            try app.register(request: DockPageRequest.self)
+            try app.register(request: DockPageRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try grantDockReads(app, dock: dock1)

--- a/Tests/FOSMVVMVaporTests/Containment/AppStateTests.swift
+++ b/Tests/FOSMVVMVaporTests/Containment/AppStateTests.swift
@@ -117,7 +117,7 @@ struct AppStateTests {
             try app.useAppState(SessionBanner.self) { req in
                 SessionBanner(userName: req.headers.first(name: signedInHeader) ?? "anonymous")
             }
-            try app.register(request: BannerRequest.self)
+            try app.register(request: BannerRequest.self, app: app)
         } _: { app, _ in
             let first = try await serveBanner(on: app, signedInAs: "Captain Ahab")
             #expect(first == "Captain Ahab")
@@ -133,7 +133,7 @@ struct AppStateTests {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
             // No useAppState call — TestViewModel's AppState is Void.
-            try app.register(request: TestViewModelRequest.self)
+            try app.register(request: TestViewModelRequest.self, app: app)
         } _: { app, _ in
             let prefix = "http://localhost"
             let base = try #require(URL(string: prefix))
@@ -160,7 +160,7 @@ struct AppStateTests {
     @Test func nonVoidAppStateWithoutBuilderFailsAtBoot() async throws {
         do {
             try await withFluentTestApp { app in
-                try app.register(request: BannerRequest.self) // no useAppState registered
+                try app.register(request: BannerRequest.self, app: app) // no useAppState registered
             } _: { _, _ in }
             Issue.record("expected register(request:) to throw at boot for a non-Void AppState with no builder")
         } catch let error as ContainmentError {
@@ -198,7 +198,7 @@ struct AppStateTests {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
             try app.useAppState(SessionBanner.self) { _ in SessionBanner(userName: "David") }
-            try app.register(request: BannerRequest.self)
+            try app.register(request: BannerRequest.self, app: app)
         } _: { app, _ in
             let signedInAs = try await serveBanner(on: app, signedInAs: "ignored-header")
             #expect(signedInAs == "David")

--- a/Tests/FOSMVVMVaporTests/Containment/WriteRouteTests.swift
+++ b/Tests/FOSMVVMVaporTests/Containment/WriteRouteTests.swift
@@ -98,7 +98,7 @@ struct WriteRouteUpdateTests {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -132,7 +132,7 @@ struct WriteRouteUpdateTests {
     @Test func updateReflectsPostWriteState() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -161,7 +161,7 @@ struct WriteRouteUpdateTests {
     @Test func pageReadPlanNotLoadedPreApply() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -187,10 +187,10 @@ struct WriteRouteUpdateTests {
     @Test func cacheInvalidatedNoStaleRead() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
             // The pre-write prime reads through BerthListRequest, so register it as a read too —
             // a write now derives only its OWN response plan, not a separate refresh request's.
-            try app.register(request: BerthListRequest.self)
+            try app.register(request: BerthListRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -216,7 +216,7 @@ struct WriteRouteUpdateTests {
     @Test func grantMemoSurvivesTheWrite() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -239,7 +239,7 @@ struct WriteRouteUpdateTests {
     @Test func saveConstraintViolationPropagates() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app, uniqueBerthNumber: true)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -271,7 +271,7 @@ struct WriteRouteCreateTests {
     @Test func createAddsRecordVisibleInRefresh() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: CreateBerthRequest.self)
+            try app.register(request: CreateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .createRecords])])
@@ -308,7 +308,7 @@ struct WriteRouteDeleteTests {
     @Test func deleteRemovesRecordFromRefresh() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: DeleteBerthRequest.self)
+            try app.register(request: DeleteBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .deleteRecords])])
@@ -337,7 +337,7 @@ struct WriteRouteValidationTests {
     @Test func failingValidationNeverReachesApply() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -369,7 +369,7 @@ struct WriteRouteRetargetTests {
     @Test func targetOutsideCandidateSetIsNotFound() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, dock2) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -394,7 +394,7 @@ struct WriteRouteRetargetTests {
     @Test func candidateHonorsWriteVerbInGrantChecks() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords])]) // NO write grant
@@ -458,7 +458,7 @@ struct WriteRouteBootTests {
     @Test func fullyConstrainedWriteRequestBindsWriteDoor() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, _ in
             #expect(app.candidatePlan(for: UpdateBerthRequest.self) != nil)
             #expect(app.recordLoadPlan(for: UpdateBerthRequest.self) != nil) // its own response plan too
@@ -469,7 +469,7 @@ struct WriteRouteBootTests {
     @Test func replaceRequestNotYetSupported() async throws {
         await #expect(throws: ContainmentError.self) {
             try await withFluentTestApp { app in
-                try app.register(request: EchoReplaceRequest.self)
+                try app.register(request: EchoReplaceRequest.self, app: app)
             } _: { _, _ in }
         }
     }
@@ -479,7 +479,7 @@ struct WriteRouteBootTests {
     @Test func writeConformerAtReadDoorFailsFast() async throws {
         await #expect(throws: ContainmentError.self) {
             try await withFluentTestApp { app in
-                try app.register(request: SelfRefreshUpdateRequest.self)
+                try app.register(request: SelfRefreshUpdateRequest.self, app: app)
             } _: { _, _ in }
         }
     }
@@ -490,7 +490,7 @@ struct WriteRouteBootTests {
         await #expect(throws: ContainmentError.self) {
             try await withFluentTestApp { app in
                 try configureWriteContainers(app)
-                try app.register(request: NoRootUpdateRequest.self)
+                try app.register(request: NoRootUpdateRequest.self, app: app)
             } _: { _, _ in }
         }
     }
@@ -501,7 +501,7 @@ struct WriteRouteBootTests {
         await #expect(throws: ContainmentError.self) {
             try await withFluentTestApp { app in
                 try configureWriteContainers(app)
-                try app.register(request: ApexUpdateRequest.self)
+                try app.register(request: ApexUpdateRequest.self, app: app)
             } _: { _, _ in }
         }
     }
@@ -511,7 +511,7 @@ struct WriteRouteBootTests {
         await #expect(throws: ContainmentError.self) {
             try await withFluentTestApp { app in
                 try configureWriteContainers(app)
-                try app.register(request: ComputedCandidatesUpdateRequest.self)
+                try app.register(request: ComputedCandidatesUpdateRequest.self, app: app)
             } _: { _, _ in }
         }
     }
@@ -521,7 +521,7 @@ struct WriteRouteBootTests {
         await #expect(throws: ContainmentError.self) {
             try await withFluentTestApp { app in
                 try configureWriteContainers(app)
-                try app.register(request: ComputedReadRequest.self)
+                try app.register(request: ComputedReadRequest.self, app: app)
             } _: { _, _ in }
         }
     }
@@ -537,7 +537,7 @@ struct WriteRouteResponseParityTests {
     @Test func writeResponseMatchesDirectServe() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .writeRecords])])
@@ -627,7 +627,7 @@ struct WriteRouteCreateGateTests {
     @Test func unauthorizedCreateWithZeroGrantsIsNotFound() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: CreateBerthRequest.self)
+            try app.register(request: CreateBerthRequest.self, app: app)
         } _: { app, db in
             _ = try await seedHarbor(on: db)
             let dock = try await makeEmptyDock(named: "Zero Grant Dock", on: db)
@@ -655,7 +655,7 @@ struct WriteRouteCreateGateTests {
     @Test func unauthorizedCreateWithReadOnlyGrantIsNotFound() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: CreateBerthRequest.self)
+            try app.register(request: CreateBerthRequest.self, app: app)
         } _: { app, db in
             _ = try await seedHarbor(on: db)
             let dock = try await makeEmptyDock(named: "Read Only Dock", on: db)
@@ -684,7 +684,7 @@ struct WriteRouteCreateGateTests {
     @Test func authorizedCreateIntoEmptyContainerSucceeds() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: CreateBerthRequest.self)
+            try app.register(request: CreateBerthRequest.self, app: app)
         } _: { app, db in
             _ = try await seedHarbor(on: db)
             let dock = try await makeEmptyDock(named: "Empty Granted Dock", on: db)
@@ -710,7 +710,7 @@ struct WriteRouteCreateGateTests {
     @Test func deniedCreateMatchesMissingContainerShape() async throws {
         try await withFluentTestApp { app in
             try configureWriteContainers(app)
-            try app.register(request: CreateBerthRequest.self)
+            try app.register(request: CreateBerthRequest.self, app: app)
         } _: { app, db in
             _ = try await seedHarbor(on: db)
 
@@ -775,7 +775,7 @@ struct WriteRouteVerbDoorTests {
         do {
             try await withFluentTestApp { app in
                 try configureWriteContainers(app)
-                try app.register(request: WrongVerbDeleteRequest.self)
+                try app.register(request: WrongVerbDeleteRequest.self, app: app)
             } _: { _, _ in }
             Issue.record("expected a boot throw for a .write candidate at the delete door")
         } catch let error as ContainmentError {
@@ -794,7 +794,7 @@ struct WriteRouteVerbDoorTests {
         do {
             try await withFluentTestApp { app in
                 try configureWriteContainers(app)
-                try app.register(request: RefinedCandidatesUpdateRequest.self)
+                try app.register(request: RefinedCandidatesUpdateRequest.self, app: app)
             } _: { _, _ in }
             Issue.record("expected a boot throw for .refinedByRequest candidates")
         } catch let error as ContainmentError {
@@ -833,7 +833,7 @@ struct WriteRouteVerbDoorTests {
     @Test func destroyRequestNotYetSupported() async throws {
         do {
             try await withFluentTestApp { app in
-                try app.register(request: EchoDestroyRequest.self)
+                try app.register(request: EchoDestroyRequest.self, app: app)
             } _: { _, _ in }
             Issue.record("expected a boot throw for a DestroyRequest at the read door")
         } catch let error as ContainmentError {
@@ -975,7 +975,7 @@ struct WriteRouteHTTPPipelineTests {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
             try configureWriteContainers(app)
-            try app.register(request: CreateBerthRequest.self)
+            try app.register(request: CreateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .createRecords])])
@@ -1009,7 +1009,7 @@ struct WriteRouteHTTPPipelineTests {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
             try configureWriteContainers(app)
-            try app.register(request: DeleteBerthRequest.self)
+            try app.register(request: DeleteBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [berthGrant(dock1, [.readRecords, .deleteRecords])])

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/RegisterDependencyTests.swift
@@ -227,7 +227,7 @@ struct RegisterDependencyTests {
         try await withFluentTestApp { app in
             try configureServe(app)
             try registerApexHarborResolver(app)
-            try app.register(request: HarborStatusRequest.self)
+            try app.register(request: HarborStatusRequest.self, app: app)
         } _: { app, db in
             let (dock1, dock2) = try await seedHarbor(on: db)
             let harbor = try #require(try await Harbor.query(on: db).first())
@@ -259,7 +259,7 @@ struct RegisterDependencyTests {
     @Test func zeroDataBodyRegisters() async throws {
         try await withFluentTestApp { app in
             try configureServe(app)
-            try app.register(request: StatusDashboardRequest.self)
+            try app.register(request: StatusDashboardRequest.self, app: app)
         } _: { app, _ in
             let res = try await getResponse(app, for: StatusDashboardRequest())
             #expect(res.status == .ok)
@@ -275,7 +275,7 @@ struct RegisterDependencyTests {
     @Test func nilIdSurfacesError() async throws {
         try await withFluentTestApp { app in
             try configureServe(app)
-            try app.register(request: NilSnapshotRequest.self)
+            try app.register(request: NilSnapshotRequest.self, app: app)
         } _: { app, _ in
             var sawFailure = false
             do {
@@ -296,7 +296,7 @@ struct RegisterDependencyTests {
     @Test func registerAndInvalidateNameTheSameValue() async throws {
         try await withFluentTestApp { app in
             try configureLiveServe(app)
-            try app.register(request: StatusDashboardRequest.self)
+            try app.register(request: StatusDashboardRequest.self, app: app)
         } _: { app, _ in
             let res = try await getResponse(app, for: StatusDashboardRequest())
             #expect(res.status == .ok)

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/RegistrationHeaderTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/RegistrationHeaderTests.swift
@@ -176,7 +176,7 @@ struct RegistrationHeaderTests {
         try await withFluentTestApp { app in
             try configureHarbor(app)
             try registerApexHarborResolver(app)
-            try app.register(request: HarborBerthsRequest.self)
+            try app.register(request: HarborBerthsRequest.self, app: app)
         } _: { app, db in
             let (dock1, dock2) = try await seedHarbor(on: db)
             let harbor = try #require(try await Harbor.query(on: db).first())
@@ -206,7 +206,7 @@ struct RegistrationHeaderTests {
     @Test func writeDoorCarriesRefreshedSet() async throws {
         try await withFluentTestApp { app in
             try configureHarbor(app)
-            try app.register(request: UpdateBerthRequest.self)
+            try app.register(request: UpdateBerthRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [
@@ -247,7 +247,7 @@ struct RegistrationHeaderTests {
     @Test func headerValueRoundTrips() async throws {
         try await withFluentTestApp { app in
             try configureHarbor(app)
-            try app.register(request: BerthListRequest.self)
+            try app.register(request: BerthListRequest.self, app: app)
         } _: { app, db in
             let (dock1, _) = try await seedHarbor(on: db)
             try setGrants(app, [
@@ -275,7 +275,7 @@ struct RegistrationHeaderTests {
     @Test func noPlanCarriesNoHeader() async throws {
         try await withFluentTestApp { app in
             try configureHarbor(app)
-            try app.register(request: PlainRequest.self)
+            try app.register(request: PlainRequest.self, app: app)
         } _: { app, _ in
             let response = try await getResponse(app, for: PlainRequest())
             #expect(response.status == .ok)

--- a/Tests/FOSMVVMVaporTests/Middleware/GroupMountedRegistrationTests.swift
+++ b/Tests/FOSMVVMVaporTests/Middleware/GroupMountedRegistrationTests.swift
@@ -1,0 +1,234 @@
+// GroupMountedRegistrationTests.swift
+//
+// Copyright 2026 FOS Computer Services, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the  License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The read door lives on `RoutesBuilder`: where a request mounts is the caller's
+// decision (mount privileged reads behind a credential group), while its plan is
+// derived regardless. These contracts pin that end to end through the served pipeline:
+//   • a group's credential middleware guards the mounted read — no token → the TYPED
+//     rejection (asserted on `credentialRejection`, never status alone); token → the body,
+//   • root mounting through the Application receiver (an `Application` IS a `RoutesBuilder`)
+//     serves normally,
+//   • a path-prefixing group is rejected at registration, naming the request type — the
+//     client derives the URL from the type, so a silent prefix would 404 at runtime.
+
+import Fluent
+import FluentKit
+import FOSFoundation
+import FOSMVVM
+@testable import FOSMVVMVapor
+import FOSTestingVapor
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite("Group-mounted registration (read door on RoutesBuilder)", .serialized)
+struct GroupMountedRegistrationTests {
+    /// Contract 1: a read mounted behind a credential group is guarded by that group's
+    /// middleware. Without a token the request is rejected with the typed credential
+    /// rejection; with the token the body arrives.
+    @Test func groupMiddlewareGuardsTheMountedRead() async throws {
+        try await withGuardApp { app in
+            let authed = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { $0 == "current-token" })
+            )
+            try authed.register(request: TestViewModelRequest.self, app: app)
+        } _: { app in
+            // No credential → the middleware rejects before the route runs.
+            try await app.testing().test(TestViewModelRequest()) { response in
+                #expect(response.status == .unauthorized)
+                #expect(response.credentialRejection?.code == .missing) // typed, not status alone
+                #expect(response.body == nil)
+            }
+
+            // Valid credential → the route runs and the body arrives.
+            try await app.testing().test(
+                TestViewModelRequest(),
+                headers: ["Authorization": "Bearer current-token"]
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(response.credentialRejection == nil)
+                #expect(response.body != nil)
+            }
+        }
+    }
+
+    /// Contract 3: mounting at the root through the Application receiver — an `Application`
+    /// conforms to `RoutesBuilder`, so the same door serves an unguarded request normally.
+    @Test func rootMountingThroughApplicationReceiverServes() async throws {
+        try await withGuardApp { app in
+            try app.register(request: TestViewModelRequest.self, app: app)
+        } _: { app in
+            try await app.testing().test(TestViewModelRequest()) { response in
+                #expect(response.status == .ok)
+                #expect(response.body != nil)
+            }
+        }
+    }
+
+    /// Contract 2: a write mounted behind a credential group is guarded BEFORE it mutates.
+    /// A PATCH with no token is rejected by the middleware with the typed credential rejection
+    /// and the record is unchanged in the database; a PATCH with the token mutates and returns
+    /// the refreshed body.
+    @Test func groupMiddlewareGuardsTheMountedWriteBeforeMutation() async throws {
+        try await withGuardWriteApp { app in
+            let authed = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { $0 == "current-token" })
+            )
+            try authed.register(request: UpdateBerthRequest.self, app: app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            app.storage[TestGrantsKey.self] = try [TestGrant(
+                authorizedContainer: dock1.modelIdentity,
+                operations: [.readRecords, .writeRecords],
+                recordTypes: [Berth.modelIdentityNamespace]
+            )]
+            let berth = try #require(try await Berth.query(on: db).filter(\.$dock.$id == dock1.requireId()).first())
+            let originalNumber = berth.number
+            let originalName = berth.dockName
+
+            // No credential → the middleware rejects before the handler mutates anything.
+            let unauthed = try UpdateBerthRequest(
+                query: .init(rootIdentity: dock1.modelIdentity, target: berth.modelIdentity),
+                sort: nil, fragment: nil,
+                requestBody: UpdateBerthBody(number: originalNumber + 100, dockName: "Hijacked"),
+                responseBody: nil
+            )
+            try await app.testing().test(unauthed) { response in
+                #expect(response.status == .unauthorized)
+                #expect(response.credentialRejection?.code == .missing) // typed, not status alone
+            }
+            // The record is untouched — the write never ran.
+            let afterReject = try #require(try await Berth.find(berth.requireId(), on: db))
+            #expect(afterReject.number == originalNumber)
+            #expect(afterReject.dockName == originalName)
+
+            // Valid credential → the write commits and the response is the refreshed body.
+            let authedReq = try UpdateBerthRequest(
+                query: .init(rootIdentity: dock1.modelIdentity, target: berth.modelIdentity),
+                sort: nil, fragment: nil,
+                requestBody: UpdateBerthBody(number: 88, dockName: "Wired"),
+                responseBody: nil
+            )
+            try await app.testing().test(
+                authedReq,
+                headers: ["Authorization": "Bearer current-token"]
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(response.credentialRejection == nil)
+                let body = try #require(response.body)
+                #expect(body.berthNumbers.contains(88))
+            }
+            let afterWrite = try #require(try await Berth.find(berth.requireId(), on: db))
+            #expect(afterWrite.number == 88)
+            #expect(afterWrite.dockName == "Wired")
+        }
+    }
+
+    /// Contract 4: a path-prefixing group changes the served URL while the client keeps
+    /// deriving it from the request type — registration rejects that at boot, naming the
+    /// request type and the actual mounted path.
+    @Test func pathPrefixingGroupIsRejectedAtRegistration() async throws {
+        try await withGuardApp { app in
+            do {
+                try app.grouped("admin").register(request: TestViewModelRequest.self, app: app)
+                Issue.record("expected registration on a path-prefixing group to throw")
+            } catch ContainmentError.pathPrefixedMount(let request, let mountedPath) {
+                #expect(request.contains("TestViewModelRequest"))
+                #expect(mountedPath.contains("admin"))
+            }
+        } _: { _ in }
+    }
+
+    /// Contract 6: a plan-bearing request mounted behind the credential middleware still carries
+    /// its executed plan's staleness surface as `X-FOS-Registrations` when served with the token —
+    /// guarding the route does not strip the live-invalidation header.
+    @Test func registrationsHeaderRidesAGuardedRoute() async throws {
+        try await withGuardWriteApp { app in
+            let authed = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { $0 == "current-token" })
+            )
+            try authed.register(request: BerthListRequest.self, app: app)
+        } _: { app, db in
+            let (dock1, _) = try await seedHarbor(on: db)
+            app.storage[TestGrantsKey.self] = try [TestGrant(
+                authorizedContainer: dock1.modelIdentity,
+                operations: [.readRecords],
+                recordTypes: [Berth.modelIdentityNamespace]
+            )]
+
+            try await app.testing().test(
+                BerthListRequest(query: .init(rootIdentity: dock1.modelIdentity)),
+                headers: ["Authorization": "Bearer current-token"]
+            ) { response in
+                #expect(response.status == .ok)
+                let value = try #require(response.headers.first(name: ModelIdentity.registrationsHeader))
+                let carried: [ModelIdentity] = try value.fromJSON()
+                #expect(try Set(carried) == [dock1.modelIdentity]) // membership via public equality
+            }
+        }
+    }
+}
+
+/// Boots an in-process `.testing` Application with the YAML localization store and FOS
+/// `ErrorMiddleware.default` installed (so a credential rejection surfaces as the typed
+/// envelope `credentialRejection` decodes), runs `configure` then `body`, and shuts the
+/// app down on both the success and failure paths.
+private func withGuardApp(
+    configure: (Application) throws -> Void,
+    _ body: (Application) async throws -> Void
+) async throws {
+    let app = try await Application.make(.testing)
+    do {
+        try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
+        app.middleware = .init()
+        app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+        try configure(app)
+        // asyncBoot (not app.testing()'s sync boot): the YAML localization store loads through an
+        // async lifecycle handler that only runs under async boot.
+        try await app.asyncBoot()
+        try await body(app)
+    } catch {
+        try await app.asyncShutdown()
+        throw error
+    }
+    try await app.asyncShutdown()
+}
+
+/// The write-guard variant of `withGuardApp`: a fresh in-memory SQLite database (the write reads
+/// its record back), the Harbor→Dock→Berth container graph plus an authorization provider, YAML
+/// localization, and FOS `ErrorMiddleware.default` (so a credential rejection surfaces as the typed
+/// envelope `credentialRejection` decodes). Runs `configure` then `body`, always shutting down.
+private func withGuardWriteApp(
+    configure: @Sendable (Application) throws -> Void,
+    _ body: @Sendable (Application, any Database) async throws -> Void
+) async throws {
+    try await withFluentTestApp { app in
+        try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
+        app.middleware = .init()
+        app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+        app.migrations.add(CreatePier()) // CreateDock's DDL references piers
+        try app.register(Harbor.self, migration: CreateHarbor())
+        try app.register(Dock.self, migration: CreateDock())
+        app.migrations.add(CreateBerth())
+        app.migrations.add(CreateCrewMember())
+        app.migrations.add(CreateDockCrew())
+        try app.useContainerAuthorizationProvider(TestGrantsProvider())
+        try configure(app)
+    } _: { app, db in
+        try await body(app, db)
+    }
+}

--- a/Tests/FOSMVVMVaporTests/Protocols/VaporResponseBodyFactoryTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/VaporResponseBodyFactoryTests.swift
@@ -35,7 +35,7 @@ struct VaporResponseBodyFactoryTests {
     @Test func zeroDataScreenServesWithoutTrait() async throws {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
-            try app.register(request: TestViewModelRequest.self)
+            try app.register(request: TestViewModelRequest.self, app: app)
         } _: { app, _ in
             let prefix = "http://localhost"
             let base = try #require(URL(string: prefix))
@@ -68,7 +68,7 @@ struct VaporResponseBodyFactoryTests {
     @Test func servedResponseCarriesExactlyOneVersionHeader() async throws {
         try await withFluentTestApp { app in
             try app.initYamlLocalization(bundle: Bundle.module, resourceDirectoryName: "TestYAML")
-            try app.register(request: TestViewModelRequest.self)
+            try app.register(request: TestViewModelRequest.self, app: app)
         } _: { app, _ in
             let prefix = "http://localhost"
             let base = try #require(URL(string: prefix))

--- a/docs/superpowers/plans/2026-07-17-routesbuilder-register-door.md
+++ b/docs/superpowers/plans/2026-07-17-routesbuilder-register-door.md
@@ -1,0 +1,374 @@
+# RoutesBuilder Register Door Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the four `register(request:)` methods from `Vapor.Application` to `RoutesBuilder` (taking `app:` as a parameter) and delete the Application-sited versions, so a request can be mounted behind the caller's middleware group (the credential-guarding case) — while keeping the guarantee that registering a request always derives and validates its load plan.
+
+**Architecture:** The receiver becomes the mount point (`try adminAuth.register(request:app:)`); the `app:` parameter supplies the Application, which remains where everything registers (plan derivation, appState checks, candidate plans all land in `Application.storage`, which serve-time reads via `req.application`). Vapor's `Application` conforms to `RoutesBuilder`, so mounting at the root still works through this same single method. A boot-time path check rejects path-prefixing groups, which would otherwise silently change the served URL while clients keep deriving it from the request type.
+
+**Tech Stack:** Swift 6 / Swift Testing, Vapor, existing FOSMVVMVapor machinery (no new mechanisms).
+
+---
+
+## Design & Rationale (the fosmvvm-planning gate output)
+
+### The ruling and the shape
+
+David's ruling (2026-07-17): the Application-sited `register(request:)` methods are
+**eliminated**, replaced by RoutesBuilder-sited doors. The house sentence:
+
+*Where a request mounts is your decision; that its plan is derived is not.*
+
+```swift
+func routes(_ app: Application) throws {
+    let authed = app.grouped(ClientCredentialMiddleware(verifier: harborVerifier))
+    try authed.register(request: DocksRequest.self, app: app)      // guarded
+    try app.register(request: LandingPageRequest.self, app: app)   // public (Application IS a RoutesBuilder)
+}
+```
+
+### Why this design (and what the old constraint actually protected)
+
+- **What the old restriction actually guaranteed — and why the move keeps it.** The
+  existing DocC says: "Registration is Application-only by construction: there is no
+  grouped/`Routes`-level door, so a composable body can never be registered without its
+  plan" (`ViewModelRequest.swift:39`). The guarantee behind that sentence is simply:
+  *every registered request gets its load plan derived and validated.* That guarantee
+  holds because the derivation call sits inside `register(request:)` itself — the same
+  function that mounts the route. It does not depend on which builder the route mounts
+  on. The new method still takes the Application and still derives the plan in the same
+  function body, so the guarantee is unchanged. Restricting registration to the
+  Application was the original *way* of ensuring it, not the guarantee itself.
+- **The middleware ordering already works — no new code.**
+  `ServerRequestController.boot` wraps its routes in `VaporServerRequestMiddleware`
+  (the framework middleware that decodes and binds the typed request) on top of
+  whatever builder it is registered on (`ServerRequestController.swift:82`). Mount on a
+  credential group and the chain is: credential middleware first, then the framework's
+  request-binding middleware, then the handler — so an unauthenticated write is
+  rejected before anything mutates. After a write commits, the server builds the
+  response by calling `serve()` directly in-process; there is no second trip through
+  routing (`ServeRequest.swift:24-29`), so a response build can never be rejected after
+  the data already changed. A `.live` refresh re-fetches through the same URL and
+  therefore the same middleware (`ViewModelView.refreshInPlace` →
+  `processRequestCapturingRegistrations`), so guarded screens stay guarded on every
+  refresh.
+- **Why delete the Application methods instead of keeping both:** two public ways to
+  register the same request is API duplication this repo doesn't allow, and Vapor
+  already conforms `Application` to `RoutesBuilder`
+  (`vapor/Routing/Routes.swift:62`) — so mounting at the root still works through the
+  one remaining method. The new siting is also the Vapor-aligned one (David,
+  2026-07-17): in standard Vapor practice, routing surfaces are where processing is
+  mounted (`routes.get(...)`, Vapor's own `register(collection:)`), while the
+  `Application` receiver is for app-wide configuration (`app.middleware.use`,
+  `app.migrations.add`). `register(request:)` mounts a route; siting it on the
+  Application was the deviation. The one non-standard remainder is the `app:` parameter
+  itself, needed because plan derivation runs at registration time — before any request
+  exists, so `req.application` (how Vapor handlers normally reach the app) isn't
+  available, and `RoutesBuilder` carries no app reference. David asked whether removing
+  the Application methods loses anything; verified: nothing functional. The real cost:
+  every existing call site breaks (dozens in-repo — grep is the authority; the fix is
+  one added argument). Pre-1.0 is the time to make this break.
+
+### The conflation the old restriction hid, and the boot check that separates it
+
+The old Application-only restriction conflated two different things a Vapor group can
+do (David, 2026-07-17):
+
+1. **Path prefixing** (`app.grouped("admin")`) — changes the served URL. FOS cannot
+   follow this: the client derives `<Request>.path` from the type and would never learn
+   the prefix — client and server silently disagree; runtime 404s. (Supporting a
+   deliberate, client-visible prefix someday would be its own designed feature; today a
+   prefixed deployment already requires a stripping proxy, and that stays true.)
+2. **Middleware attachment** (`app.grouped(middleware)`) — changes nothing about the
+   URL, and applications require it (credential guarding).
+
+The old design banned both to avoid the first. This change permits the second and
+turns the first from a silent runtime failure into a boot error: after
+`register(collection:)` returns, the method verifies the routes just added carry
+exactly the type-derived path; any prefix throws, naming the request type and the
+actual mounted path. Middleware-only groups add no path components and pass untouched.
+
+Mechanics (implementer note): `Routes.all` is append-only and registration is
+single-threaded at boot — snapshot `app.routes.all.count` before the
+`register(collection:)` call, then validate `route.path.map(\.description) ==
+SR.path.pathComponents.map(\.description)` for each appended route. Both the snapshot
+and the post-register validation read `app.routes.all` — **never `self`** (the receiver
+may be a `MiddlewareGroup`, which has no route storage; groups forward `add(route:)` up
+the chain to the root). The error is a new case on **`ContainmentError`**
+(`Containment/ContainmentError.swift` — the existing internal home of the sibling boot
+diagnostics `writeRequestAtReadDoor` / `missingAppStateBuilder`, already thrown from
+`ViewModelRequest.swift`; apps never catch it, its value is the boot diagnostic). Do
+NOT add it to `ServerRequestControllerError` — that enum is `public`, and this change
+adds no public symbols beyond the doors.
+
+### Step-1 gate results (public surface)
+
+Four public symbols moved (none added beyond the `app:` parameter), four removed:
+
+- `RoutesBuilder.register(request:app:)` — read door (`SR: ServerRequest`)
+- `RoutesBuilder.register(request:app:)` — create door (`SR: CreateRequest`)
+- `RoutesBuilder.register(request:app:)` — update door (`SR: UpdateRequest`)
+- `RoutesBuilder.register(request:app:)` — delete door (`SR: DeleteRequest`)
+- **Removed:** the four `Vapor.Application.register(request:)` methods.
+
+Gate: one method per operation (the duplicate Application spelling is removed, and no
+new duplicate is added) ✓; no
+stringly-typing (mount point is a typed `RoutesBuilder`, path stays type-derived) ✓;
+parameter label settled as **`app:`** — plain and honest; `deriving:`/`for:`/`in:`
+considered and cut (jargon or vague; the parameter's role IS the Application whose
+registries receive the derivation). Sits harmoniously beside Vapor's own
+RoutesBuilder-sited `register(collection:)`. Boundaries unchanged ✓. Old-code migration
+UX: `app.register(request: X.self)` fails with a missing-argument diagnostic pointing at
+the new signature (Application is a RoutesBuilder, so overload resolution finds the new
+door and names the missing `app:`).
+
+Internal relocations (not public surface): `rejectWriteProtocolAtReadDoor` uses no
+Application state — becomes a private free function (or private RoutesBuilder extension)
+in `ViewModelRequest.swift`. The registry helpers stay Application extensions
+(`app.registerRecordLoadPlan(...)`, `app.requireAppStateBuilder(...)`,
+`app.deriveCandidatePlan(...)` — all internal, same module, verified).
+
+### Step-2 DocC (drafted first — the read door; write doors adapt the same frame)
+
+```swift
+/// Registers a read request's route (GET) on this route group
+///
+/// The group you call it on decides the middleware that guards the route —
+/// mount privileged requests behind your credential group, public ones on the
+/// `Application` itself (an `Application` is a `RoutesBuilder`):
+///
+/// ```swift
+/// func routes(_ app: Application) throws {
+///     let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
+///     try authed.register(request: DockPageRequest.self, app: app)
+///     try app.register(request: LandingPageRequest.self, app: app)
+/// }
+/// ```
+///
+/// One door for every request — a body that is a ViewModel and a body that is
+/// not (a report, an export) register the same way.
+///
+/// >  *ServerRequest* provides a protocol extension that sets *ServerRequest/path* based on
+/// >   the *ServerRequest/RequestBody* and *ServerRequest/ResponseBody* types. Thus, the
+/// >   route's path is automatically maintained and there is never a path collision or
+/// >   confusion between the client and server. Mount on **middleware-only** groups: a
+/// >   path-prefixing group would change the served URL while clients derive it from the
+/// >   type — registration rejects that at boot.
+///
+/// Register the app's containers (``Vapor/Application/register(_:migration:)``) **before**
+/// calling this — a composable body's load plan is derived and validated here, against
+/// `app`'s registered containers. Every door derives the plan: where a request mounts is
+/// your decision; that its plan is derived is not.
+///
+/// A write request (Create/Update/Delete) has its own overload; register it the same way
+/// (`try authed.register(request: BerthUpdateRequest.self, app: app)`), and Swift picks
+/// the write door. A write request that reaches *this* read door — because its
+/// Query/RequestBody miss the write overload's constraints, or because its protocol
+/// (Replace/Destroy) is not yet supported — fails fast at boot rather than registering
+/// GET-only (which would silently drop the write).
+///
+/// - Parameters:
+///   - request: A *ServerRequest* whose *ResponseBody* is a ``VaporResponseBodyFactory``
+///   - app: The application this route serves — the request's load plan is derived
+///     into and validated against it
+```
+
+Write doors: keep each existing DocC body, reframed to the group receiver (example call
+shows `try authed.register(request: ..., app: app)`), plus the shared `- Parameters:`
+block. No rationale, no representation, contract only.
+
+### Step-3 contract tests (public surface only)
+
+1. **A group's middleware guards the route** (the harbor case, end to end): register a
+   read request on `app.grouped(ClientCredentialMiddleware(verifier:
+   BearerCredentialVerifier(...)))`; serve without a token → the typed credential
+   rejection (assert via the shipped `TestingServerRequestResponse.credentialRejection`
+   helper — never on status alone); serve with the token → the body arrives.
+2. **A write is rejected BEFORE it mutates:** unauthenticated PATCH to a group-mounted
+   update request → credential rejection AND the record is unchanged in the database
+   (read it back).
+3. **Root mounting via the Application receiver:** `try app.register(request: X.self,
+   app: app)` serves normally (Application-as-RoutesBuilder — the migration's own
+   spelling, asserted once explicitly; the migrated call sites cover it implicitly).
+4. **Path-prefixed group fails at boot:** registering on `app.grouped("admin")` throws
+   at registration, naming the request type; nothing is served.
+5. **Plan derivation still runs on a group:** a composable body registered on a group
+   without its containers registered → the same boot throw as today (existing
+   `PlanRegistrationTests` migrate and keep covering derivation; add one group-sited
+   assertion).
+6. **Registrations header rides a group-mounted route:** a plan-bearing request mounted
+   behind middleware still carries `X-FOS-Registrations` (whole-value `fromJSON()`
+   decode, membership via public equality — pattern: `RegistrationHeaderTests`).
+
+All identities/bodies via public API; no `@testable`-for-contract; no raw JSON
+inspection.
+
+### Rejected alternatives (do not re-propose)
+
+- **Keeping both sitings** (Application + RoutesBuilder): two spellings of one act.
+- **Realm/type-declared guards** (request type declares its plane, boot binds a
+  verifier): parked, not rejected on merit — compile-forced guarding at real ceremony
+  cost; defer until a client exists (e.g. client-side per-request credential selection).
+- **In-pipeline verify call inside `serve()`**: wrong placement — runs after a write's
+  mutation on the post-commit re-serve, and double-verifies internal re-entries.
+- **DocC-only warning for path-prefix groups** (no boot check): the invisible mode —
+  client 404s at runtime instead of a named boot failure.
+- **Deprecation shims for the old methods**: pre-1.0 removes cleanly; a parallel
+  "legacy" door is the composition failure David's standards ban.
+
+---
+
+## File Structure
+
+- **Modify:** `Sources/FOSMVVMVapor/Vapor Support/ViewModelRequest.swift`
+  — the four doors become `public extension RoutesBuilder` (same file, same
+  responsibility: the registration doors); Application extensions removed;
+  `rejectWriteProtocolAtReadDoor` becomes file-private free function; the path
+  check added to the shared mounting step.
+- **Modify:** `Sources/FOSMVVMVapor/Containment/ContainmentError.swift`
+  — new internal boot-diagnostic case for the path-check failure.
+- **Modify (mechanical migration):** every `register(request:` **invocation** gains
+  `, app: app`. The grep is the authority, but it returns two populations — actual
+  call sites (`try …register(request:` — migrate mechanically) and *references*
+  (DocC cross-links, `.docc` guide examples, error-message strings, comments — these
+  go through Task 3's documentation sweep, and must NOT get a mechanical
+  `, app: app` appended).
+- **Create:** `Tests/FOSMVVMVaporTests/Middleware/GroupMountedRegistrationTests.swift`
+  — contracts 1, 2, 3, 4, 6 above (contract 5 lands as an added assertion in
+  `Tests/FOSMVVMVaporTests/Composition/PlanRegistrationTests.swift`).
+- **Modify:** `CHANGELOG.md` (Unreleased → Changed, breaking, with the one-line
+  migration), `.claude/docs/FOSMVVMArchitecture.md` (registration prose), api-catalog +
+  generator-skill docs that show the old spelling (sweep; plugin bump via the
+  catalog-update skill).
+
+---
+
+### Task 0: Branch
+
+- [ ] **Step 1:**
+```bash
+cd /Users/david/Repository/FOS/FOSUtilities
+git checkout -b feature/routesbuilder-register-door
+```
+
+---
+
+### Task 1: Move the read door + the path check
+
+**Files:**
+- Create: `Tests/FOSMVVMVaporTests/Middleware/GroupMountedRegistrationTests.swift`
+- Modify: `Sources/FOSMVVMVapor/Vapor Support/ViewModelRequest.swift`
+- Modify: `Sources/FOSMVVMVapor/Containment/ContainmentError.swift`
+- Modify: read-door call sites (compiler-driven)
+
+- [ ] **Step 1: Write the failing contract tests** — contracts 1, 3, 4 (read-door
+  scope; contracts 2 lands in Task 2, 5-6 in later steps). Pattern the served-HTTP
+  harness on `RegistrationHeaderTests.swift`; the credential fixture uses
+  `ClientCredentialMiddleware` + `BearerCredentialVerifier` (both shipped, see
+  `Middleware/ClientCredentialMiddleware.swift`) and asserts rejection via
+  `TestingServerRequestResponse.credentialRejection` (FOSTestingVapor, shipped 0.7.0).
+  Neutral fixture vocabulary; reuse existing SQL fixtures only as plumbing.
+
+- [ ] **Step 2: Run to verify red** — `swift test --filter GroupMountedRegistrationTests`
+  fails: no `register(request:app:)` on RoutesBuilder.
+
+- [ ] **Step 3: Implement the read door.** In `ViewModelRequest.swift`: change
+  `public extension Vapor.Application` to `public extension RoutesBuilder` for the read
+  door; signature `func register<SR: ServerRequest>(request _: SR.Type, app:
+  Vapor.Application) throws`; body calls become `app.`-qualified
+  (`try app.registerRecordLoadPlan(for: SR.self)` etc.); mounting becomes
+  `try register(collection: GuardedRequestController<SR>(...))` on `self`, bracketed by
+  the path check (snapshot `app.routes.all.count`, validate appended routes'
+  paths equal `SR.path.pathComponents` — reading `app.routes.all`, never `self`;
+  mismatch throws the new internal `ContainmentError` case naming the request and the
+  mounted path). Replace
+  the DocC with the draft from this plan's Design section (verbatim).
+  `rejectWriteProtocolAtReadDoor` → file-private free function, unchanged body.
+
+- [ ] **Step 4: Migrate read-door call sites** — compiler-driven; write doors still
+  compile on Application in this task. `swift build` until clean, then
+  `swift test --filter GroupMountedRegistrationTests` → green.
+
+- [ ] **Step 5: Commit** (trailers per repo convention).
+
+---
+
+### Task 2: Move the three write doors
+
+**Files:**
+- Modify: `Sources/FOSMVVMVapor/Vapor Support/ViewModelRequest.swift`
+- Modify: `Tests/FOSMVVMVaporTests/Middleware/GroupMountedRegistrationTests.swift` (add contract 2)
+- Modify: remaining call sites (compiler-driven)
+
+- [ ] **Step 1: Add the failing write-guard test** (contract 2: unauthenticated PATCH →
+  typed rejection + record unchanged; authenticated → mutates and returns the refreshed
+  body). Red: write doors not on RoutesBuilder yet — the test's group-mounted write
+  registration doesn't compile.
+- [ ] **Step 2: Move the create/update/delete doors** — same mechanical transform as
+  Task 1 (receiver `RoutesBuilder`, `app:` parameter, `app.`-qualified helpers,
+  path check, DocC reframed to the group receiver with the shared
+  `- Parameters:` block). All Application-sited register(request:) methods are now GONE.
+- [ ] **Step 3: Migrate every remaining call site** (`grep -rn "register(request:"` is
+  the authority — its hits split into invocations, which migrate, and doc/DocC
+  references, which go to Task 3's sweep). Full `swift test` → green.
+- [ ] **Step 4: Add contract 5's group-sited assertion** to `PlanRegistrationTests` and
+  contract 6 (registrations header on a guarded route) to
+  `GroupMountedRegistrationTests`. Green.
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 3: Docs, catalog, changelog
+
+- [ ] **Step 1: CHANGELOG** — Unreleased → `### Changed` (BREAKING, house style):
+  the four doors moved to `RoutesBuilder` with the mount-point rationale and the
+  one-line migration (`try app.register(request: X.self)` →
+  `try app.register(request: X.self, app: app)`, or mount on a middleware group);
+  note the new boot rejection of path-prefixing groups. Contract only.
+- [ ] **Step 2: Architecture doc** — update registration prose (grep
+  `.claude/docs/FOSMVVMArchitecture.md` for register(request:) / Application-only
+  language; recut to the mount-point sentence).
+- [ ] **Step 3: Sweep ALL in-`Sources` documentation** — `grep -rn "register(request:"
+  Sources` and fix every *reference* (never by appending `, app: app` mechanically —
+  each is prose or a link):
+  - `.docc` guides teaching the old root call:
+    `Sources/FOSMVVM/FOSMVVM.docc/ServerOverview.md:40-41`,
+    `Sources/FOSMVVM/FOSMVVM.docc/ViewModelandViewModelRequest.md:142` — update to the
+    new spelling (show the guarded and root forms).
+  - Dangling DocC symbol cross-refs to the deleted methods:
+    `VaporResponseBodyFactory.swift:52`, `ServerRequestController.swift:42` — repoint
+    at the RoutesBuilder door (verify resolution as in prior work: extension symbols
+    catalog under the extending module's path).
+  - Stale error strings and maintainer comments that name the old siting:
+    `PlanRegistration.swift:62` ("Registration is Application-only"),
+    `PlanExecutor.swift:44`, `WriteRoute.swift:144` (error strings telling users to
+    `try app.register(request:)`), `AppStateRegistry.swift:32,57`,
+    `ContainmentError.swift:84`, `GuardedRequestController.swift:20`,
+    `VaporServerRequestMiddleware.swift:28`, `ServeRequest.swift:80`.
+  Line numbers are start-of-task hints; the grep is the authority.
+- [ ] **Step 3b: Sweep skill docs** — `grep -rn "register(request:" .claude/skills` —
+  generator skills teach the old spelling; update examples to the new door (guarded and
+  root forms).
+- [ ] **Step 4: Run the `fosutilities-api-catalog-update` skill** (catalog entries for
+  the four doors, reach-for index, plugin version bump).
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 4: Verification sweep
+
+- [ ] **Step 1:** full `swift test`; `swiftformat .`; `swiftlint` (commit any format
+  deltas separately as chore).
+- [ ] **Step 2:** final whole-branch review.
+- [ ] **STOP — review gate.** No PR until David reviews and says go.
+
+---
+
+## Out of Scope (deliberately)
+
+- Realm/type-declared guards (parked; see Rejected alternatives).
+- Any change to `useLiveInvalidation(on:)` (already RoutesBuilder-sited; unchanged).
+- Container registration `register(_:migration:)` stays Application-sited — it is
+  persistence registration, not routing.
+- Client-side changes: none — the URL contract is unchanged by design (and now
+  boot-enforced).


### PR DESCRIPTION
## Summary

**BREAKING.** The four `register(request:)` doors (read, create, update, delete) move from `Vapor.Application` to `RoutesBuilder`, taking an `app:` parameter; the Application-sited versions are removed.

The group you register on decides the middleware that guards the route — mount privileged requests behind your credential group, public ones on the `Application` itself (an `Application` is a `RoutesBuilder`):

```swift
func routes(_ app: Application) throws {
    let authed = app.grouped(ClientCredentialMiddleware(verifier: myVerifier))
    try authed.register(request: DashboardPageRequest.self, app: app)
    try app.register(request: LandingPageRequest.self, app: app)
}
```

*Where a request mounts is your decision; that its plan is derived is not* — every door still derives and validates the request's load plan against `app` at boot.

## Why

The old Application-only siting conflated two different things a Vapor group can do: **path prefixing** (which FOS genuinely can't follow — clients derive the URL from the request type) and **middleware attachment** (which applications require, e.g. credential guarding). It also deviated from standard Vapor practice, where routing surfaces are where processing mounts. This change permits the middleware half and turns the path half from a silent runtime failure into a boot error: a path-prefixing group (`app.grouped("admin")`) is rejected at registration, naming the request and the mounted path.

## Migration

```swift
try app.register(request: X.self)              // old
try app.register(request: X.self, app: app)    // new (root)
try authed.register(request: X.self, app: app) // new (guarded)
```

## Test plan

- Six new contract tests: credential-guarded read (typed rejection without a token, body with one); credential-guarded write **proven rejected before mutation** by database read-back; root mounting through the same method; path-prefix boot rejection; plan derivation enforced on a group; `X-FOS-Registrations` riding a guarded route.
- Full suite green: 701 tests across all targets; swiftformat/swiftlint clean; DocC cross-refs verified resolving.
- Docs: CHANGELOG (BREAKING + migration), `.docc` guides recut, stale error strings/comments swept, api-catalog updated (plugin 2.16.0). Implementation plan committed at `docs/superpowers/plans/2026-07-17-routesbuilder-register-door.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtqZcyJQRAddaffMSVJJqU