### PR TITLE
Credential refresh seam: recover from a rotated server credential

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fosmvvm-generators",
   "description": "FOSMVVM architecture generators for ViewModels, Fields, DataModels, ServerRequests, Leaf Views, and ViewModel Tests",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "author": {
     "name": "FOS Computer Services"
   },

--- a/.claude/skills/fosutilities-api-catalog/SKILL.md
+++ b/.claude/skills/fosutilities-api-catalog/SKILL.md
@@ -51,7 +51,7 @@ line via the `fosutilities-api-catalog-update` skill.
 - Container-scoped authorization — declaring containers, grant verbs, who may touch which records → `FOSMVVM.md § Protocols`
 - Client-chosen sort or pagination on a request → `FOSMVVM.md § Protocols`
 - Live-updating screens that refresh when server data changes (`@ViewModel(options: [.live])`), or replacing the invalidation transport → `FOSMVVM.md § Protocols`, `FOSMVVMVapor.md § Live Invalidation`
-- Attaching auth headers (bearer token, API key) to every client request, rotation-safe → `FOSMVVM.md § Protocols`
+- Attaching auth headers (bearer token, API key) to every client request, rotation-safe — or recovering when the server refuses one (refresh the credential and retry the request once) → `FOSMVVM.md § Protocols`
 - Declaring the data a server-rendered body needs — composable factory, load requirements, rooted scopes → `FOSMVVM.md § Protocols`
 - Rendering a ViewModel in SwiftUI — app setup, view binding, previews, form views → `FOSMVVM.md § SwiftUI Support`
 - Versioning ViewModel properties, choosing deployment URLs, negotiating versions over HTTP → `FOSMVVM.md § Versioning`

--- a/.claude/skills/shared/api-catalog/FOSMVVM.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVM.md
@@ -450,9 +450,10 @@ complement is `ClientCredentialMiddleware` (see `FOSMVVMVapor.md § Middleware`)
 To recover from a *server-side* rotation — the credential you presented was
 refused — implement `credentialHeaders(afterRejection:)` on your own conforming
 type: refresh, return replacement headers, and the request is retried exactly
-once (the live-invalidation channel nudges the same seam on an SSE 401);
-returning `nil` — the default — rethrows the `CredentialRejectedError` to the
-caller. Persist the refreshed credential — the retry headers apply once; every
+once (the live-invalidation channel nudges the same seam on an SSE 401 — there
+it always reports `.invalid` and may nudge once per failed reconnect, not just
+once); returning `nil` — the default — rethrows the `CredentialRejectedError`
+to the caller. Persist the refreshed credential — the retry headers apply once; every
 later request and every reconnect consults `credentialHeaders()` again.
 `BearerCredentialProvider` does not refresh (a refused token throws).
 Don't bake a token into the static `requestHeaders` — a rotating credential

--- a/.claude/skills/shared/api-catalog/FOSMVVM.md
+++ b/.claude/skills/shared/api-catalog/FOSMVVM.md
@@ -447,6 +447,14 @@ token, an API key) without per-call header plumbing — set a provider once on
 so a credential that rotates mid-session is picked up on the next call. A `nil`
 token sends no header (the request proceeds unauthenticated). The server-side
 complement is `ClientCredentialMiddleware` (see `FOSMVVMVapor.md § Middleware`).
+To recover from a *server-side* rotation — the credential you presented was
+refused — implement `credentialHeaders(afterRejection:)` on your own conforming
+type: refresh, return replacement headers, and the request is retried exactly
+once (the live-invalidation channel nudges the same seam on an SSE 401);
+returning `nil` — the default — rethrows the `CredentialRejectedError` to the
+caller. Persist the refreshed credential — the retry headers apply once; every
+later request and every reconnect consults `credentialHeaders()` again.
+`BearerCredentialProvider` does not refresh (a refused token throws).
 Don't bake a token into the static `requestHeaders` — a rotating credential
 goes stale there; the provider is the dynamic sibling.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`ClientCredentialProvider.credentialHeaders(afterRejection:)`** (FOSMVVM) — a refresh
+  seam that lets a client recover from a server-side credential rotation. When a request is
+  refused with `CredentialRejectedError`, the provider may supply replacement headers and the
+  request is retried exactly once; returning `nil` (the default) preserves the previous
+  behavior of throwing the rejection to the caller. The live-invalidation channel nudges the
+  same seam when an SSE open is refused with 401. Providers must persist the refreshed
+  credential — later requests and reconnects consult `credentialHeaders()`.
 
 ## [0.9.0] - 2026-07-17
 

--- a/Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift
+++ b/Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift
@@ -60,6 +60,45 @@ public protocol ClientCredentialProvider: Sendable {
     ///     ``MVVMEnvironment/requestErrorHandler`` handles only typed
     ///     `ServerRequestError`s
     func credentialHeaders() async throws -> [(field: String, value: String)]
+
+    /// The replacement headers to retry with after the server refused the last set
+    ///
+    /// Called when a request fails with ``CredentialRejectedError``. Refresh your
+    /// credential and return its headers to have the request retried once with
+    /// them; return `nil` — the default — and the rejection throws to the caller
+    /// unchanged.
+    ///
+    /// ```swift
+    /// func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+    ///     guard afterRejection.code == .invalid else { return nil }
+    ///     guard let token = await SessionStore.shared.refreshAccessToken() else { return nil }
+    ///     return [(field: "Authorization", value: "Bearer \(token)")]
+    /// }
+    /// ```
+    ///
+    /// - Important: **Persist the refreshed credential** — returning it is not enough.
+    ///     The returned headers are used for this one retry; every later request, and
+    ///     every live-channel reconnect, calls ``credentialHeaders()`` instead. A
+    ///     provider that returns a fresh credential without storing it keeps handing
+    ///     out the refused one.
+    /// - Important: Several screens can be refused at once — each bound ViewModel
+    ///     issues its own request and is refused independently. Coalesce concurrent
+    ///     refreshes (single-flight) inside your provider; this method may be called
+    ///     several times in quick succession with the same rejection.
+    /// - Parameter afterRejection: The rejection the server returned, so a provider
+    ///     can distinguish a missing credential from an invalid one
+    /// - Returns: Headers to retry the request with once, or `nil` when no fresh
+    ///     credential is available — the rejection then throws to the caller
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]?
+}
+
+public extension ClientCredentialProvider {
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        // A *requirement* with a default, not an extension-only method: `MVVMEnvironment`
+        // holds the provider as `(any ClientCredentialProvider)?`, and an extension-only
+        // method binds to the default through the existential — the override would never run.
+        nil
+    }
 }
 
 /// The stock ``ClientCredentialProvider`` for `Authorization: Bearer` authentication
@@ -71,6 +110,10 @@ public protocol ClientCredentialProvider: Sendable {
 ///
 /// When the closure yields `nil` — the user is signed out, no token has been
 /// issued yet — no headers are produced and the request proceeds unauthenticated.
+///
+/// This provider never refreshes on rejection: a refused credential throws to the
+/// caller. To recover from server-side rotation, conform your own type and implement
+/// ``ClientCredentialProvider/credentialHeaders(afterRejection:)``.
 ///
 /// ## Example
 ///

--- a/Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift
+++ b/Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift
@@ -86,7 +86,10 @@ public protocol ClientCredentialProvider: Sendable {
     ///     refreshes (single-flight) inside your provider; this method may be called
     ///     several times in quick succession with the same rejection.
     /// - Parameter afterRejection: The rejection the server returned, so a provider
-    ///     can distinguish a missing credential from an invalid one
+    ///     can distinguish a missing credential from an invalid one. A refused
+    ///     ServerRequest carries the server's actual code; a refused live-channel
+    ///     reconnect cannot read it and always presents `.invalid`, and may call
+    ///     this once per failed reconnect rather than only once.
     /// - Returns: Headers to retry the request with once, or `nil` when no fresh
     ///     credential is available — the rejection then throws to the caller
     func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]?

--- a/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
+++ b/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
@@ -178,26 +178,9 @@ public extension ServerRequest {
     @discardableResult
     internal func processRequestCapturingRegistrations(mvvmEnv: MVVMEnvironment) async throws -> [ModelIdentity] {
         do {
-            var headers = [(field: String, value: String)]()
-            if ResponseBody.self == EmptyBody.self {
-                headers.append((field: "Accept", value: "text/plain"))
-            }
-            for (key, value) in mvvmEnv.requestHeaders {
-                headers.append((field: key, value: value))
-            }
+            let headers = try await credentialedRequestHeaders(mvvmEnv: mvvmEnv)
 
-            // Credential headers append AFTER the static requestHeaders: headers apply to the
-            // URLRequest in order (setValue), so on a duplicate field the per-request
-            // credential wins.
-            if let credentialProvider = mvvmEnv.clientCredentialProvider {
-                headers += try await credentialProvider.credentialHeaders()
-            }
-
-            return try await processRequestCapturingRegistrations(
-                baseURL: mvvmEnv.serverBaseURL,
-                headers: headers,
-                session: mvvmEnv.session
-            ).registrations
+            return try await sendCapturingRegistrations(headers: headers, mvvmEnv: mvvmEnv)
         } catch let rejection as CredentialRejectedError {
             // A surface rejection always reaches the caller — recovery
             // (refresh credential, retry) is a call-site decision.
@@ -210,6 +193,47 @@ public extension ServerRequest {
                 throw error
             }
         }
+    }
+}
+
+private extension ServerRequest {
+    /// The static headers: `Accept` (when the response carries no body) followed by
+    /// `MVVMEnvironment.requestHeaders`.
+    func staticRequestHeaders(mvvmEnv: MVVMEnvironment) -> [(field: String, value: String)] {
+        var headers = [(field: String, value: String)]()
+        if ResponseBody.self == EmptyBody.self {
+            headers.append((field: "Accept", value: "text/plain"))
+        }
+        for (key, value) in mvvmEnv.requestHeaders {
+            headers.append((field: key, value: value))
+        }
+
+        return headers
+    }
+
+    /// The static headers with the provider's credential appended.
+    func credentialedRequestHeaders(mvvmEnv: MVVMEnvironment) async throws -> [(field: String, value: String)] {
+        var headers = staticRequestHeaders(mvvmEnv: mvvmEnv)
+        // Credential headers append AFTER the static requestHeaders: headers apply to the
+        // URLRequest in order (setValue), so on a duplicate field the per-request
+        // credential wins.
+        if let credentialProvider = mvvmEnv.clientCredentialProvider {
+            headers += try await credentialProvider.credentialHeaders()
+        }
+
+        return headers
+    }
+
+    /// One send of this request with exactly these headers.
+    func sendCapturingRegistrations(
+        headers: [(field: String, value: String)],
+        mvvmEnv: MVVMEnvironment
+    ) async throws -> [ModelIdentity] {
+        try await processRequestCapturingRegistrations(
+            baseURL: mvvmEnv.serverBaseURL,
+            headers: headers,
+            session: mvvmEnv.session
+        ).registrations
     }
 }
 

--- a/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
+++ b/Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
@@ -178,9 +178,29 @@ public extension ServerRequest {
     @discardableResult
     internal func processRequestCapturingRegistrations(mvvmEnv: MVVMEnvironment) async throws -> [ModelIdentity] {
         do {
+            // Composition sits outside the retry-aware `do`: a rejection thrown by the provider
+            // itself is a client-side failure, not a server refusal, and must not open the
+            // refresh seam.
             let headers = try await credentialedRequestHeaders(mvvmEnv: mvvmEnv)
 
-            return try await sendCapturingRegistrations(headers: headers, mvvmEnv: mvvmEnv)
+            do {
+                return try await sendCapturingRegistrations(headers: headers, mvvmEnv: mvvmEnv)
+            } catch let rejection as CredentialRejectedError {
+                guard
+                    let provider = mvvmEnv.clientCredentialProvider,
+                    let refreshed = await provider.credentialHeaders(afterRejection: rejection)
+                else {
+                    throw rejection
+                }
+
+                // Exactly one retry. A second rejection falls to the outer arm and reaches the
+                // caller; a non-rejection `ServerRequestError` falls to the outer arm, which
+                // `catch` clauses cannot do on their own (they do not chain).
+                return try await sendCapturingRegistrations(
+                    headers: staticRequestHeaders(mvvmEnv: mvvmEnv) + refreshed,
+                    mvvmEnv: mvvmEnv
+                )
+            }
         } catch let rejection as CredentialRejectedError {
             // A surface rejection always reaches the caller — recovery
             // (refresh credential, retry) is a call-site decision.

--- a/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
+++ b/Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift
@@ -128,6 +128,15 @@ struct SSEInvalidationChannel: InvalidationChannel {
         // credential. Treat non-2xx as a drop: back-off grows, and the next open re-consults the
         // credential provider (rotation still self-heals).
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            // A 401 is the credential being refused. Tell the provider so it can refresh and
+            // persist; the return is discarded because the reconnect below re-consults
+            // `credentialHeaders()` — the channel carries no credential state of its own.
+            if http.statusCode == 401 {
+                _ = await credentialProvider?.credentialHeaders(
+                    afterRejection: CredentialRejectedError(code: .invalid)
+                )
+            }
+
             throw SSEStreamOpenError.badStatus(http.statusCode)
         }
         onOpen()

--- a/Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift
+++ b/Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift
@@ -54,6 +54,30 @@ struct ClientCredentialProviderTests {
         let second = try await provider.credentialHeaders()
         #expect(second.first?.value == "Bearer second")
     }
+
+    @Test("A provider that does not override the refresh seam declines to refresh")
+    func refreshSeamDefaultsToDeclining() async {
+        let provider = BearerCredentialProvider { "abc" }
+
+        let refreshed = await provider.credentialHeaders(
+            afterRejection: CredentialRejectedError(code: .invalid)
+        )
+
+        #expect(refreshed == nil)
+    }
+
+    @Test("An overriding provider supplies replacement headers")
+    func refreshSeamOverrideSuppliesHeaders() async {
+        let provider = RefreshingProvider(refreshedTo: "fresh")
+
+        let refreshed = await provider.credentialHeaders(
+            afterRejection: CredentialRejectedError(code: .invalid)
+        )
+
+        #expect(refreshed?.count == 1)
+        #expect(refreshed?.first?.field == "Authorization")
+        #expect(refreshed?.first?.value == "Bearer fresh")
+    }
 }
 
 /// A mutable token source — models an app session whose credential rotates between requests.
@@ -66,5 +90,21 @@ private actor TokenVault {
 
     func rotate(to newToken: String?) {
         token = newToken
+    }
+}
+
+/// A provider that returns fresh replacement headers when asked after a rejection.
+private struct RefreshingProvider: ClientCredentialProvider {
+    let vault = TokenVault(token: nil)
+    let refreshedTo: String
+
+    func credentialHeaders() async throws -> [(field: String, value: String)] {
+        guard let token = await vault.token else { return [] }
+        return [(field: "Authorization", value: "Bearer \(token)")]
+    }
+
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        await vault.rotate(to: refreshedTo)
+        return [(field: "Authorization", value: "Bearer \(refreshedTo)")]
     }
 }

--- a/Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift
@@ -144,6 +144,100 @@ struct ClientChannelRoundTripTests {
             #expect(await log.events.isEmpty)
         }
     }
+
+    /// A 401 open is the credential being refused: the channel consults the seam
+    /// (`credentialHeaders(afterRejection:)`) so the provider can refresh and persist. The channel
+    /// carries no credential state; the reconnect below re-consults `credentialHeaders()`.
+    @Test func openRefusedWith401ConsultsCredentialSeam() async throws {
+        try await withServedFluentTestApp { app in
+            app.invalidationHeartbeatInterval = .milliseconds(200)
+            let denied = app.grouped(DenyAllMiddleware())
+            try configureLiveHarbor(app, on: denied)
+        } _: { _, baseURL in
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() }
+
+            let sleeps = SleepRecorder()
+            let refreshes = RequestTally()
+            let channel = SSEInvalidationChannel(
+                baseURL: { baseURL },
+                credentialProvider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: refreshes
+                ),
+                session: session,
+                sleep: { await sleeps.record($0) },
+                initialBackoff: .milliseconds(1),
+                maxBackoff: .milliseconds(8)
+            )
+
+            let log = EventLog()
+            let consumer = Task {
+                for await event in channel.events() {
+                    await log.record(event)
+                }
+            }
+
+            // Wait until several real 401 opens have happened (each drives a back-off), then stop.
+            try await withTimeout(.seconds(15)) {
+                while await sleeps.durations.count < 3 {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+            }
+            consumer.cancel()
+
+            // Each 401 open consults the seam; the reconnect loop runs indefinitely, so assert a
+            // lower bound, never equality (the count keeps climbing while the channel lives).
+            #expect(await refreshes.count >= 1)
+        }
+    }
+
+    /// A 500 open is a server error, NOT a credential refusal: the channel still reconnects
+    /// (back-off) but never consults the credential seam.
+    @Test func openRefusedWith500DoesNotConsultCredentialSeam() async throws {
+        try await withServedFluentTestApp { app in
+            app.invalidationHeartbeatInterval = .milliseconds(200)
+            let denied = app.grouped(Deny500Middleware())
+            try configureLiveHarbor(app, on: denied)
+        } _: { _, baseURL in
+            let session = URLSession(configuration: .ephemeral)
+            defer { session.invalidateAndCancel() }
+
+            let sleeps = SleepRecorder()
+            let refreshes = RequestTally()
+            let channel = SSEInvalidationChannel(
+                baseURL: { baseURL },
+                credentialProvider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: refreshes
+                ),
+                session: session,
+                sleep: { await sleeps.record($0) },
+                initialBackoff: .milliseconds(1),
+                maxBackoff: .milliseconds(8)
+            )
+
+            let log = EventLog()
+            let consumer = Task {
+                for await event in channel.events() {
+                    await log.record(event)
+                }
+            }
+
+            // Reconnects still happen on 500 (back-off), so wait for a few to prove the channel is
+            // actively retrying — THEN assert the seam was never consulted.
+            try await withTimeout(.seconds(15)) {
+                while await sleeps.durations.count < 3 {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+            }
+            consumer.cancel()
+
+            #expect(await refreshes.count == 0)
+        }
+    }
 }
 
 // MARK: - Helpers
@@ -177,6 +271,13 @@ private struct CapturingMiddleware: AsyncMiddleware {
 private struct DenyAllMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
         Response(status: .unauthorized)
+    }
+}
+
+/// Answers every request 500 — a server-error stand-in that must NOT be read as a credential refusal.
+private struct Deny500Middleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        Response(status: .internalServerError)
     }
 }
 

--- a/Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift
@@ -111,7 +111,256 @@ struct ClientCredentialRoundTripTests {
         }
     }
 
+    @Test("A refreshed credential retries once and succeeds")
+    func refreshRetriesOnceAndSucceeds() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let attempts = RequestTally()
+        let refreshes = RequestTally()
+
+        try await Self.withProtectedServer { token in
+            await attempts.increment()
+            return await serverCredential.isCurrent(token)
+        } register: { group in
+            try group.register(collection: Self.headerEchoController())
+        } body: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: refreshes
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            try await request.processRequest(mvvmEnv: env)
+
+            #expect(request.responseBody?.authorization == "Bearer rotated")
+            #expect(await attempts.count == 2)
+            #expect(await refreshes.count == 1)
+        }
+    }
+
+    @Test("A provider that declines to refresh rethrows the original rejection, unretried")
+    func decliningProviderRethrowsUnretried() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let attempts = RequestTally()
+        let refreshes = RequestTally()
+
+        try await Self.withProtectedServer { token in
+            await attempts.increment()
+            return await serverCredential.isCurrent(token)
+        } register: { group in
+            try group.register(collection: Self.headerEchoController())
+        } body: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: nil,
+                    refreshTally: refreshes
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected the original rejection to be rethrown")
+            } catch let rejection as CredentialRejectedError {
+                #expect(rejection.code == .invalid)
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+
+            #expect(await attempts.count == 1)
+            #expect(await refreshes.count == 1)
+        }
+    }
+
+    @Test("A second rejection throws — the retry is never recursive")
+    func secondRejectionThrowsWithoutFurtherRetry() async throws {
+        let serverCredential = ServerCredential(current: "never-matches")
+        let attempts = RequestTally()
+        let refreshes = RequestTally()
+
+        try await Self.withProtectedServer { token in
+            await attempts.increment()
+            return await serverCredential.isCurrent(token)
+        } register: { group in
+            try group.register(collection: Self.headerEchoController())
+        } body: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "also-wrong",
+                    refreshTally: refreshes
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            await #expect(throws: CredentialRejectedError.self) {
+                try await request.processRequest(mvvmEnv: env)
+            }
+
+            #expect(await attempts.count == 2)
+            #expect(await refreshes.count == 1)
+        }
+    }
+
+    @Test("The retry preserves static requestHeaders, and the refreshed credential still wins")
+    func retryPreservesStaticHeaders() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+
+        try await Self.withProtectedServer { token in
+            await serverCredential.isCurrent(token)
+        } register: { group in
+            try group.register(collection: Self.headerEchoController())
+        } body: { base in
+            let env = Self.environment(
+                base: base,
+                requestHeaders: [
+                    "Authorization": "Bearer stale-static",
+                    "X-Client-Marker": "static-value"
+                ],
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: RequestTally()
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            try await request.processRequest(mvvmEnv: env)
+
+            #expect(request.responseBody?.authorization == "Bearer rotated")
+            #expect(request.responseBody?.clientMarker == "static-value")
+        }
+    }
+
+    @Test("A rejection thrown by the provider itself does not open the refresh seam")
+    func providerThrownRejectionDoesNotOpenSeam() async throws {
+        let refreshes = RequestTally()
+        let attempts = RequestTally()
+
+        try await Self.withProtectedServer { _ in
+            await attempts.increment()
+            return true
+        } register: { group in
+            try group.register(collection: Self.headerEchoController())
+        } body: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RejectingCredentialProvider(refreshTally: refreshes)
+            )
+
+            let request = ShowObservedHeadersRequest()
+            await #expect(throws: CredentialRejectedError.self) {
+                try await request.processRequest(mvvmEnv: env)
+            }
+
+            #expect(await attempts.count == 0)
+            #expect(await refreshes.count == 0)
+        }
+    }
+
+    @Test("A non-rejection error on the retry still reaches requestErrorHandler")
+    func retryOperationErrorReachesHandler() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let handled = ErrorSink()
+
+        try await Self.withProtectedServer { token in
+            await serverCredential.isCurrent(token)
+        } register: { group in
+            try group.register(collection: RoundTripController<ShowOperationFailureRequest>(actions: [
+                .show: { _, _ in throw StrictContractError(errorCode: 42) }
+            ]))
+        } body: { base in
+            let env = MVVMEnvironment(
+                currentVersion: SystemVersion.current,
+                appBundle: Bundle.main,
+                requestHeaders: [:],
+                clientCredentialProvider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: RequestTally()
+                ),
+                deploymentURLs: [
+                    .production: base, .staging: base, .debug: base, .test: base
+                ],
+                session: nil,
+                requestErrorHandler: { _, error in handled.record(error) }
+            )
+
+            let request = ShowOperationFailureRequest()
+            try await request.processRequest(mvvmEnv: env)
+
+            #expect(handled.count == 1)
+            #expect(handled.last is StrictContractError)
+        }
+    }
+
+    @Test("Concurrent refused requests each consult the seam")
+    func concurrentRejectionsEachConsultTheSeam() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let refreshes = RequestTally()
+
+        try await Self.withProtectedServer { token in
+            await serverCredential.isCurrent(token)
+        } register: { group in
+            try group.register(collection: Self.headerEchoController())
+        } body: { base in
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for _ in 0..<4 {
+                    group.addTask {
+                        // Each task carries its OWN stale vault, so every first-send is refused
+                        // and every task must consult the seam — not just whichever wins the
+                        // race to rotate a shared vault. All 4 then retry with "rotated".
+                        let env = Self.environment(
+                            base: base,
+                            provider: RefreshingCredentialProvider(
+                                vault: TokenVault(token: "stale"),
+                                refreshedTo: "rotated",
+                                refreshTally: refreshes
+                            )
+                        )
+
+                        let request = ShowObservedHeadersRequest()
+                        try await request.processRequest(mvvmEnv: env)
+                        #expect(request.responseBody?.authorization == "Bearer rotated")
+                    }
+                }
+                try await group.waitForAll()
+            }
+
+            #expect(await refreshes.count == 4)
+        }
+    }
+
     // MARK: - Fixtures
+
+    /// Boots `withRunningServer` with the stock error serializer replaced by FOS
+    /// `ErrorMiddleware` — without which a rejection reaches the client as
+    /// `DataFetchError.badStatus(401)` rather than a typed `CredentialRejectedError` — and mounts
+    /// `register`'s routes behind a `ClientCredentialMiddleware(verifier:)`. Centralizing the
+    /// middleware install here means an individual test can never forget it.
+    private static func withProtectedServer(
+        verifier: @escaping @Sendable (String) async -> Bool,
+        register: (any RoutesBuilder) throws -> Void,
+        body: (URL) async throws -> Void
+    ) async throws {
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier(isValid: verifier))
+            )
+            try register(protectedGroup)
+        } _: { base in
+            try await body(base)
+        }
+    }
 
     /// Echoes the request headers the server observed back over the wire.
     private static func headerEchoController() -> RoundTripController<ShowObservedHeadersRequest> {
@@ -151,20 +400,6 @@ struct ClientCredentialRoundTripTests {
     }
 }
 
-/// A mutable token source — models an app session whose credential rotates between requests.
-/// (Mirrors the helper in `ClientCredentialProviderTests` — separate test targets, same shape.)
-private actor TokenVault {
-    var token: String?
-
-    init(token: String?) {
-        self.token = token
-    }
-
-    func rotate(to newToken: String?) {
-        token = newToken
-    }
-}
-
 /// The failure a credential provider raises when its credential cannot be resolved.
 private struct CredentialResolutionFailure: Error {}
 
@@ -175,12 +410,38 @@ private struct FailingCredentialProvider: ClientCredentialProvider {
     }
 }
 
-/// Counts the requests the server actually served.
-private actor RequestTally {
-    private(set) var count = 0
+/// Synchronous, lock-guarded error sink — the handler is a plain @Sendable
+/// closure; an actor + Task would make the count assertion racy on the
+/// failure path this test exists to catch.
+private final class ErrorSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [any Error] = []
 
-    func increment() {
-        count += 1
+    func record(_ error: any Error) {
+        lock.withLock { errors.append(error) }
+    }
+
+    var count: Int {
+        lock.withLock { errors.count }
+    }
+
+    var last: (any Error)? {
+        lock.withLock { errors.last }
+    }
+}
+
+/// A provider whose own header composition throws a rejection — models a client-side
+/// credential failure, which must NOT be treated as a server refusal (spec §5.1).
+private struct RejectingCredentialProvider: ClientCredentialProvider {
+    let refreshTally: RequestTally
+
+    func credentialHeaders() async throws -> [(field: String, value: String)] {
+        throw CredentialRejectedError(code: .missing)
+    }
+
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        await refreshTally.increment()
+        return [(field: "Authorization", value: "Bearer anything")]
     }
 }
 

--- a/Tests/FOSMVVMVaporTests/Protocols/CredentialSeamFixtures.swift
+++ b/Tests/FOSMVVMVaporTests/Protocols/CredentialSeamFixtures.swift
@@ -78,3 +78,60 @@ final class ShowOperationFailureRequest: ServerRequest, @unchecked Sendable {
         self.responseBody = responseBody
     }
 }
+
+/// A mutable token source — models an app session whose credential rotates between requests.
+/// (Mirrors the helper in `ClientCredentialProviderTests` — separate test targets, same shape.)
+actor TokenVault {
+    var token: String?
+
+    init(token: String?) {
+        self.token = token
+    }
+
+    func rotate(to newToken: String?) {
+        token = newToken
+    }
+}
+
+/// Counts the requests the server actually served.
+actor RequestTally {
+    private(set) var count = 0
+
+    func increment() {
+        count += 1
+    }
+}
+
+/// The server's current good credential — rotates to model a server restart.
+actor ServerCredential {
+    private var current: String
+
+    init(current: String) {
+        self.current = current
+    }
+
+    func isCurrent(_ token: String) -> Bool {
+        token == current
+    }
+}
+
+/// A client provider that refreshes on rejection and **persists** the refreshed value,
+/// so a later `credentialHeaders()` yields it too (spec §4.1).
+struct RefreshingCredentialProvider: ClientCredentialProvider {
+    let vault: TokenVault
+    let refreshedTo: String?
+    let refreshTally: RequestTally
+
+    func credentialHeaders() async throws -> [(field: String, value: String)] {
+        guard let token = await vault.token else { return [] }
+        return [(field: "Authorization", value: "Bearer \(token)")]
+    }
+
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        await refreshTally.increment()
+        guard let refreshedTo else { return nil }
+        await vault.rotate(to: refreshedTo)
+
+        return [(field: "Authorization", value: "Bearer \(refreshedTo)")]
+    }
+}

--- a/docs/superpowers/plans/2026-07-19-credential-refresh-seam.md
+++ b/docs/superpowers/plans/2026-07-19-credential-refresh-seam.md
@@ -1,0 +1,921 @@
+# Credential Refresh Seam — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a bound ViewModel recover from a rotated server credential, by giving `ClientCredentialProvider` a refresh seam and retrying the refused request exactly once.
+
+**Architecture:** One new protocol requirement — `credentialHeaders(afterRejection:)` — declared on `ClientCredentialProvider` with a `nil`-returning default, so every existing conformance keeps compiling and keeps today's behavior. `ServerRequest+Fetch` splits header composition from the send, wraps **only the send** in a retry-aware `do`, and re-sends once when the provider supplies replacement headers. The SSE channel notifies the same seam on a 401 and discards the return, relying on the provider having persisted the refresh.
+
+**Tech Stack:** Swift 6 (`swiftLanguageModes: [.v6]`), Swift Testing, Vapor (server-side round-trip tests only).
+
+**Spec:** `docs/superpowers/specs/2026-07-19-credential-refresh-seam-design.md` — read it before starting. Rationale lives there, not here.
+
+**Version target:** 0.10.0 (additive, minor).
+
+---
+
+## Required Reading Before Task 1
+
+- The spec, especially **§4.1** (persistence obligation), **§5.1** (only a *server* rejection opens the seam), **§5.2** (Swift `catch` clauses do not chain).
+- `Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift` — the harness Task 3 extends. It provides `withRunningServer` (via `RoundTripHarness.swift`), `RoundTripController`, and the actors `TokenVault` and `RequestTally` (Task 3 moves the latter two to the shared fixtures file).
+- `Tests/FOSMVVMVaporTests/Protocols/CredentialSeamFixtures.swift` — the shared home for credential-seam fixtures. Already holds `StrictContractError` and `ShowOperationFailureRequest`, both of which Task 3 reuses.
+- `Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift:266` **and** `:380` — the two ends of the wire-shape contract. Read both before writing any round-trip test; see the warning at the head of Task 3.
+
+**Two constraints that will bite if forgotten:**
+
+1. The new method **must be a protocol requirement**, not extension-only. `MVVMEnvironment.clientCredentialProvider` is `(any ClientCredentialProvider)?` (`MVVMEnvironment.swift:111`); an extension-only method binds to the default through the existential, so the seam would silently never fire and nothing would fail to compile.
+2. Contract tests use the **public** API only. No `@testable` for contract coverage.
+
+**Already covered, do not re-test:** spec §7's first bullet — a provider with no override
+throws the rejection after one request — is pinned today by `rejectionBypassesRequestErrorHandler`
+part (a) at `Tests/FOSMVVMVaporTests/Middleware/ClientCredentialMiddlewareTests.swift:201`,
+which uses a stock `BearerCredentialProvider`. That test passing unchanged after Task 3 **is**
+the additivity proof.
+
+---
+
+## File Structure
+
+**Modify:**
+- `Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift` — the requirement + defaulted extension + DocC
+- `Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift:178-213` — split composition from send; add the bounded retry
+- `Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift:130-132` — notify the seam on 401
+- `CHANGELOG.md` — 0.10.0 entry
+
+**Test:**
+- `Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift` — default-implementation behavior (unit)
+- `Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift` — retry contract, real client ↔ real server
+- `Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift` — SSE 401 notification
+
+---
+
+## Task 1: The protocol requirement and its default
+
+**Files:**
+- Modify: `Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift`
+- Test: `Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ClientCredentialProviderTests.swift`, inside `struct ClientCredentialProviderTests`:
+
+```swift
+    @Test("A provider that does not override the refresh seam declines to refresh")
+    func refreshSeamDefaultsToDeclining() async throws {
+        let provider = BearerCredentialProvider { "abc" }
+
+        let refreshed = await provider.credentialHeaders(
+            afterRejection: CredentialRejectedError(code: .invalid)
+        )
+
+        #expect(refreshed == nil)
+    }
+
+    @Test("An overriding provider supplies replacement headers")
+    func refreshSeamOverrideSuppliesHeaders() async throws {
+        let provider = RefreshingProvider(refreshedTo: "fresh")
+
+        let refreshed = await provider.credentialHeaders(
+            afterRejection: CredentialRejectedError(code: .invalid)
+        )
+
+        #expect(refreshed?.count == 1)
+        #expect(refreshed?.first?.field == "Authorization")
+        #expect(refreshed?.first?.value == "Bearer fresh")
+    }
+```
+
+And at file scope, beside the existing `private actor TokenVault`:
+
+```swift
+/// A provider that refreshes on rejection and **persists** the result, so a later
+/// `credentialHeaders()` yields the refreshed credential (spec §4.1).
+private struct RefreshingProvider: ClientCredentialProvider {
+    let vault: TokenVault
+    let refreshedTo: String
+
+    init(refreshedTo: String, initial: String? = nil) {
+        self.refreshedTo = refreshedTo
+        self.vault = TokenVault(token: initial)
+    }
+
+    func credentialHeaders() async throws -> [(field: String, value: String)] {
+        guard let token = await vault.token else { return [] }
+        return [(field: "Authorization", value: "Bearer \(token)")]
+    }
+
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        await vault.rotate(to: refreshedTo)
+        return [(field: "Authorization", value: "Bearer \(refreshedTo)")]
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter ClientCredentialProviderTests`
+Expected: FAIL — `value of type 'BearerCredentialProvider' has no member 'credentialHeaders(afterRejection:)'`
+
+- [ ] **Step 3: Add the requirement and its default**
+
+In `ClientCredentialProvider.swift`, add to the `public protocol ClientCredentialProvider` body, after `credentialHeaders()` (currently line 62):
+
+```swift
+
+    /// The replacement headers to retry with after the server refused the last set
+    ///
+    /// Called when a request fails with ``CredentialRejectedError``. Refresh your
+    /// credential and return its headers to have the request retried once with
+    /// them; return `nil` — the default — and the rejection throws to the caller
+    /// unchanged.
+    ///
+    /// ```swift
+    /// func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+    ///     guard afterRejection.code == .invalid else { return nil }
+    ///     guard let token = await SessionStore.shared.refreshAccessToken() else { return nil }
+    ///     return [(field: "Authorization", value: "Bearer \(token)")]
+    /// }
+    /// ```
+    ///
+    /// - Important: **Persist the refreshed credential** — returning it is not enough.
+    ///     The returned headers are used for this one retry; every later request, and
+    ///     every live-channel reconnect, calls ``credentialHeaders()`` instead. A
+    ///     provider that returns a fresh credential without storing it keeps handing
+    ///     out the refused one.
+    /// - Important: Several screens can be refused at once — each bound ViewModel
+    ///     issues its own request and is refused independently. Coalesce concurrent
+    ///     refreshes (single-flight) inside your provider; this method may be called
+    ///     several times in quick succession with the same rejection.
+    /// - Parameter afterRejection: The rejection the server returned, so a provider
+    ///     can distinguish a missing credential from an invalid one
+    /// - Returns: Headers to retry the request with once, or `nil` when no fresh
+    ///     credential is available — the rejection then throws to the caller
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]?
+```
+
+Then, immediately after the protocol's closing brace:
+
+```swift
+
+public extension ClientCredentialProvider {
+    // A *requirement* with a default, not an extension-only method: `MVVMEnvironment`
+    // holds the provider as `(any ClientCredentialProvider)?`, and an extension-only
+    // method binds to the default through the existential — the override would never run.
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        nil
+    }
+}
+```
+
+- [ ] **Step 4: Extend `BearerCredentialProvider`'s DocC**
+
+`BearerCredentialProvider` deliberately does **not** override the seam — it is built from a token closure with no refresh capability. Add to its DocC, after the "When the closure yields `nil`…" paragraph:
+
+```swift
+/// This provider never refreshes on rejection: a refused credential throws to the
+/// caller. To recover from server-side rotation, conform your own type and implement
+/// ``ClientCredentialProvider/credentialHeaders(afterRejection:)``.
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `swift test --filter ClientCredentialProviderTests`
+Expected: PASS (5 tests)
+
+- [ ] **Step 6: Verify additivity — the whole suite still builds and passes**
+
+Run: `swift build && swift test`
+Expected: PASS. Any conformance that failed to compile means the default was not applied correctly.
+
+- [ ] **Step 7: Format, lint, commit**
+
+```bash
+swiftformat . && swiftlint
+git add Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift
+git commit -m "feat(credential): add credentialHeaders(afterRejection:) refresh seam"
+```
+
+---
+
+## Task 2: Split header composition from the send (pure refactor)
+
+No behavior changes. This exists so Task 3 can wrap **only the send** — see spec §5.1 and §5.2.
+
+**Files:**
+- Modify: `Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift:178-213`
+
+- [ ] **Step 1: Confirm the baseline is green**
+
+Run: `swift test --filter ClientCredentialRoundTripTests`
+Expected: PASS (3 tests). These are the regression net for this refactor.
+
+- [ ] **Step 2: Replace the method**
+
+Replace lines **178-213** — the range **starts at the `@discardableResult` attribute**, not at
+the `func` line. The replacement block below re-declares it; replacing from 179 leaves two
+attributes and fails to compile.
+
+```swift
+    @discardableResult
+    internal func processRequestCapturingRegistrations(mvvmEnv: MVVMEnvironment) async throws -> [ModelIdentity] {
+        do {
+            let headers = try await credentialedRequestHeaders(mvvmEnv: mvvmEnv)
+
+            return try await sendCapturingRegistrations(headers: headers, mvvmEnv: mvvmEnv)
+        } catch let rejection as CredentialRejectedError {
+            // A surface rejection always reaches the caller — recovery
+            // (refresh credential, retry) is a call-site decision.
+            throw rejection
+        } catch let error as ServerRequestError {
+            if let errorHandler = mvvmEnv.requestErrorHandler {
+                errorHandler(self, error)
+                return []
+            } else {
+                throw error
+            }
+        }
+    }
+```
+
+(Replace only lines 178-213 — line 214's `}` already closes the `public extension`. Do not add another.)
+
+Then add a new file-scope extension after that `public extension`'s closing brace:
+
+```swift
+private extension ServerRequest {
+    /// The static headers: `Accept` (when the response carries no body) followed by
+    /// `MVVMEnvironment.requestHeaders`.
+    func staticRequestHeaders(mvvmEnv: MVVMEnvironment) -> [(field: String, value: String)] {
+        var headers = [(field: String, value: String)]()
+        if ResponseBody.self == EmptyBody.self {
+            headers.append((field: "Accept", value: "text/plain"))
+        }
+        for (key, value) in mvvmEnv.requestHeaders {
+            headers.append((field: key, value: value))
+        }
+
+        return headers
+    }
+
+    /// The static headers with the provider's credential appended.
+    func credentialedRequestHeaders(mvvmEnv: MVVMEnvironment) async throws -> [(field: String, value: String)] {
+        var headers = staticRequestHeaders(mvvmEnv: mvvmEnv)
+        // Credential headers append AFTER the static requestHeaders: headers apply to the
+        // URLRequest in order (setValue), so on a duplicate field the per-request
+        // credential wins. (Maintainer rationale — `//`, not `///`; it is not customer contract.)
+        if let credentialProvider = mvvmEnv.clientCredentialProvider {
+            headers += try await credentialProvider.credentialHeaders()
+        }
+
+        return headers
+    }
+
+    /// One send of this request with exactly these headers.
+    func sendCapturingRegistrations(
+        headers: [(field: String, value: String)],
+        mvvmEnv: MVVMEnvironment
+    ) async throws -> [ModelIdentity] {
+        try await processRequestCapturingRegistrations(
+            baseURL: mvvmEnv.serverBaseURL,
+            headers: headers,
+            session: mvvmEnv.session
+        ).registrations
+    }
+}
+```
+
+- [ ] **Step 3: Verify no behavior changed**
+
+Run: `swift test --filter ClientCredentialRoundTripTests`
+Expected: PASS (3 tests, unchanged)
+
+Run: `swift test`
+Expected: PASS
+
+- [ ] **Step 4: Format, lint, commit**
+
+```bash
+swiftformat . && swiftlint
+git add Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift
+git commit -m "refactor(fetch): split header composition from the send"
+```
+
+---
+
+## Task 3: The bounded retry
+
+**Files:**
+- Modify: `Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift`
+- Test: `Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift`
+
+### The one thing that will silently break every test here
+
+`withRunningServer` boots the app with **Vapor's stock error serializer**, under which a
+rejection reaches the client as `DataFetchError.badStatus(401)` — *not* a typed
+`CredentialRejectedError`. The typed error only crosses the wire when FOS `ErrorMiddleware`
+replaces the stock one. This is already pinned both ways:
+`ClientCredentialMiddlewareTests.swift:266` (stock → `badStatus`) and
+`ClientCredentialMiddlewareTests.swift:380` (FOS → typed).
+
+**Every `withRunningServer { app in … }` register-closure in this task must therefore open
+with these two lines**, before `app.grouped(…)`:
+
+```swift
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+```
+
+Omit them and the retry tests fail for a reason that looks like the retry is broken: the
+client never sees a `CredentialRejectedError`, so the seam is never consulted and
+`attempts.count` stays 1.
+
+- [ ] **Step 1: Add the test fixtures**
+
+Task 4 needs `RefreshingCredentialProvider` from a *different* file in the same target, so it
+goes in the shared home: `Tests/FOSMVVMVaporTests/Protocols/CredentialSeamFixtures.swift`
+(members there are internal, not `private`).
+
+**That forces a move.** `TokenVault` and `RequestTally` are currently `private` in
+`ClientCredentialRoundTripTests.swift` — an internal fixture cannot reference them
+across files. So:
+
+1. **Cut** `TokenVault` (lines **154-166**, including its two doc-comment lines) and
+   `RequestTally` (lines **178-185**) from `ClientCredentialRoundTripTests.swift`.
+   **These two ranges are not contiguous** — `CredentialResolutionFailure` (168-169) and
+   `FailingCredentialProvider` (171-176) sit between them and must stay, or
+   `throwingProviderSurfacesAndSendsNothing` breaks. Cut by name, two separate ranges.
+2. **Paste** both into `CredentialSeamFixtures.swift`, dropping the `private` keyword.
+3. Leave the *separate* `private actor TokenVault` in
+   `Tests/FOSMVVMTests/Protocols/ClientCredentialProviderTests.swift` alone — different test
+   target, and its existing comment already notes the deliberate duplication.
+
+Then add to `CredentialSeamFixtures.swift`:
+
+```swift
+/// The server's current good credential — rotates to model a server restart.
+actor ServerCredential {
+    private var current: String
+
+    init(current: String) {
+        self.current = current
+    }
+
+    func isCurrent(_ token: String) -> Bool {
+        token == current
+    }
+}
+
+/// A client provider that refreshes on rejection and **persists** the refreshed value,
+/// so a later `credentialHeaders()` yields it too (spec §4.1).
+struct RefreshingCredentialProvider: ClientCredentialProvider {
+    let vault: TokenVault
+    let refreshedTo: String?
+    let refreshTally: RequestTally
+
+    func credentialHeaders() async throws -> [(field: String, value: String)] {
+        guard let token = await vault.token else { return [] }
+        return [(field: "Authorization", value: "Bearer \(token)")]
+    }
+
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        await refreshTally.increment()
+        guard let refreshedTo else { return nil }
+        await vault.rotate(to: refreshedTo)
+
+        return [(field: "Authorization", value: "Bearer \(refreshedTo)")]
+    }
+}
+```
+
+Note the test counts requests **in the verifier**, not the controller: the middleware rejects before the route runs, so a controller-side tally would never see a refused request.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `struct ClientCredentialRoundTripTests`:
+
+```swift
+    @Test("A refreshed credential retries once and succeeds")
+    func refreshRetriesOnceAndSucceeds() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let attempts = RequestTally()
+        let refreshes = RequestTally()
+
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { token in
+                    await attempts.increment()
+                    return await serverCredential.isCurrent(token)
+                })
+            )
+            try protectedGroup.register(collection: Self.headerEchoController())
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: refreshes
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            try await request.processRequest(mvvmEnv: env)
+
+            #expect(request.responseBody?.authorization == "Bearer rotated")
+            #expect(await attempts.count == 2)
+            #expect(await refreshes.count == 1)
+        }
+    }
+
+    @Test("A provider that declines to refresh rethrows the original rejection, unretried")
+    func decliningProviderRethrowsUnretried() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let attempts = RequestTally()
+        let refreshes = RequestTally()
+
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { token in
+                    await attempts.increment()
+                    return await serverCredential.isCurrent(token)
+                })
+            )
+            try protectedGroup.register(collection: Self.headerEchoController())
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: nil,
+                    refreshTally: refreshes
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            do {
+                try await request.processRequest(mvvmEnv: env)
+                Issue.record("Expected the original rejection to be rethrown")
+            } catch let rejection as CredentialRejectedError {
+                // The observable proxy for "the rejection reached the caller intact".
+                // The framework never re-mints with a different code, so this cannot
+                // distinguish original from freshly-minted — and reaching for something
+                // that could would be asserting the representation.
+                #expect(rejection.code == .invalid)
+            } catch {
+                Issue.record("Expected CredentialRejectedError, got \(error)")
+            }
+
+            #expect(await attempts.count == 1)
+            #expect(await refreshes.count == 1)
+        }
+    }
+
+    @Test("A second rejection throws — the retry is never recursive")
+    func secondRejectionThrowsWithoutFurtherRetry() async throws {
+        let serverCredential = ServerCredential(current: "never-matches")
+        let attempts = RequestTally()
+        let refreshes = RequestTally()
+
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { token in
+                    await attempts.increment()
+                    return await serverCredential.isCurrent(token)
+                })
+            )
+            try protectedGroup.register(collection: Self.headerEchoController())
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "also-wrong",
+                    refreshTally: refreshes
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            await #expect(throws: CredentialRejectedError.self) {
+                try await request.processRequest(mvvmEnv: env)
+            }
+
+            #expect(await attempts.count == 2)
+            #expect(await refreshes.count == 1)
+        }
+    }
+
+    @Test("The retry preserves static requestHeaders, and the refreshed credential still wins")
+    func retryPreservesStaticHeaders() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { token in
+                    await serverCredential.isCurrent(token)
+                })
+            )
+            try protectedGroup.register(collection: Self.headerEchoController())
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                requestHeaders: [
+                    "Authorization": "Bearer stale-static",
+                    "X-Client-Marker": "static-value"
+                ],
+                provider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: RequestTally()
+                )
+            )
+
+            let request = ShowObservedHeadersRequest()
+            try await request.processRequest(mvvmEnv: env)
+
+            #expect(request.responseBody?.authorization == "Bearer rotated")
+            #expect(request.responseBody?.clientMarker == "static-value")
+        }
+    }
+
+    @Test("A rejection thrown by the provider itself does not open the refresh seam")
+    func providerThrownRejectionDoesNotOpenSeam() async throws {
+        let refreshes = RequestTally()
+        let attempts = RequestTally()
+
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { _ in
+                    await attempts.increment()
+                    return true
+                })
+            )
+            try protectedGroup.register(collection: Self.headerEchoController())
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RejectingCredentialProvider(refreshTally: refreshes)
+            )
+
+            let request = ShowObservedHeadersRequest()
+            await #expect(throws: CredentialRejectedError.self) {
+                try await request.processRequest(mvvmEnv: env)
+            }
+
+            // No request was sent, so no server refusal occurred — the seam stays shut (spec §5.1)
+            #expect(await attempts.count == 0)
+            #expect(await refreshes.count == 0)
+        }
+    }
+```
+
+**The highest-value test in the set** — spec §5.2. A wrong-but-compiling implementation
+(inlining the retry into the existing `catch` arm) passes every test above and fails only
+this one, because Swift `catch` clauses do not chain and the retry's non-rejection error
+would escape `requestErrorHandler`:
+
+```swift
+    @Test("A non-rejection error on the retry still reaches requestErrorHandler")
+    func retryOperationErrorReachesHandler() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let handled = ErrorSink()
+
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { token in
+                    await serverCredential.isCurrent(token)
+                })
+            )
+            // Admission succeeds on the retry; the CONTROLLER then throws a typed
+            // operation error — the path that must land in requestErrorHandler.
+            try protectedGroup.register(collection: RoundTripController<ShowOperationFailureRequest>(actions: [
+                .show: { _, _ in throw StrictContractError(errorCode: 42) }
+            ]))
+        } _: { base in
+            let env = MVVMEnvironment(
+                currentVersion: SystemVersion.current,
+                appBundle: Bundle.main,
+                requestHeaders: [:],
+                clientCredentialProvider: RefreshingCredentialProvider(
+                    vault: TokenVault(token: "stale"),
+                    refreshedTo: "rotated",
+                    refreshTally: RequestTally()
+                ),
+                deploymentURLs: [
+                    .production: base, .staging: base, .debug: base, .test: base
+                ],
+                session: nil,
+                requestErrorHandler: { _, error in handled.record(error) }
+            )
+
+            let request = ShowOperationFailureRequest()
+            // Swallowed into the handler, NOT thrown — that is the contract
+            try await request.processRequest(mvvmEnv: env)
+
+            #expect(handled.count == 1)
+            #expect(handled.last is StrictContractError)
+        }
+    }
+
+    @Test("Concurrent refused requests each consult the seam")
+    func concurrentRejectionsEachConsultTheSeam() async throws {
+        let serverCredential = ServerCredential(current: "rotated")
+        let refreshes = RequestTally()
+        let vault = TokenVault(token: "stale")
+
+        try await withRunningServer { app in
+            app.middleware = .init()
+            app.middleware.use(FOSMVVMVapor.ErrorMiddleware.default(environment: app.environment))
+
+            let protectedGroup = app.grouped(
+                ClientCredentialMiddleware(verifier: BearerCredentialVerifier { token in
+                    await serverCredential.isCurrent(token)
+                })
+            )
+            try protectedGroup.register(collection: Self.headerEchoController())
+        } _: { base in
+            let env = Self.environment(
+                base: base,
+                provider: RefreshingCredentialProvider(
+                    vault: vault,
+                    refreshedTo: "rotated",
+                    refreshTally: refreshes
+                )
+            )
+
+            // Models several bound ViewModels refused at once (spec §4 DocC warning)
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for _ in 0..<4 {
+                    group.addTask {
+                        let request = ShowObservedHeadersRequest()
+                        try await request.processRequest(mvvmEnv: env)
+                        #expect(request.responseBody?.authorization == "Bearer rotated")
+                    }
+                }
+                try await group.waitForAll()
+            }
+
+            // Each refused request consults the seam independently — the framework does NOT
+            // coalesce, which is exactly why the DocC tells providers to single-flight.
+            // A request that starts after the vault has rotated is never refused, so the
+            // lower bound is 1, not 4.
+            #expect(await refreshes.count >= 1)
+        }
+    }
+```
+
+Plus two more fixtures at file scope. The first is a **verbatim copy** of `ErrorSink` from
+`ClientCredentialMiddlewareTests.swift:528` — copy it, do not reinvent it. Its doc comment
+explains why: `requestErrorHandler` is a plain sync `@Sendable` closure, so an actor plus a
+`Task` would make the count assertion racy on exactly the failure path this test exists to
+catch.
+
+```swift
+/// Synchronous, lock-guarded error sink — the handler is a plain @Sendable
+/// closure; an actor + Task would make the count assertion racy on the
+/// failure path this test exists to catch.
+private final class ErrorSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var errors: [any Error] = []
+
+    func record(_ error: any Error) {
+        lock.withLock { errors.append(error) }
+    }
+
+    var count: Int {
+        lock.withLock { errors.count }
+    }
+
+    var last: (any Error)? {
+        lock.withLock { errors.last }
+    }
+}
+```
+
+and:
+
+```swift
+/// A provider whose own header composition throws a rejection — models a client-side
+/// credential failure, which must NOT be treated as a server refusal (spec §5.1).
+private struct RejectingCredentialProvider: ClientCredentialProvider {
+    let refreshTally: RequestTally
+
+    func credentialHeaders() async throws -> [(field: String, value: String)] {
+        throw CredentialRejectedError(code: .missing)
+    }
+
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        await refreshTally.increment()
+        return [(field: "Authorization", value: "Bearer anything")]
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `swift test --filter ClientCredentialRoundTripTests`
+Expected: the retry tests FAIL (no retry happens — `attempts.count == 1` where 2 expected, and the success cases throw). `providerThrownRejectionDoesNotOpenSeam` may already PASS — that is fine, it is a regression guard for Step 4.
+
+**If a test fails with `DataFetchError.badStatus(401)` rather than a missing retry, the
+`ErrorMiddleware` lines are missing from that test's register-closure.** See the warning at
+the head of this task.
+
+- [ ] **Step 4: Add the retry**
+
+In `ServerRequest+Fetch.swift`, replace `processRequestCapturingRegistrations(mvvmEnv:)` — again
+**including its `@discardableResult` attribute line**, since the block below re-declares it:
+
+```swift
+    @discardableResult
+    internal func processRequestCapturingRegistrations(mvvmEnv: MVVMEnvironment) async throws -> [ModelIdentity] {
+        do {
+            // Composition sits outside the retry-aware `do`: a rejection thrown by the provider
+            // itself is a client-side failure, not a server refusal, and must not open the
+            // refresh seam.
+            let headers = try await credentialedRequestHeaders(mvvmEnv: mvvmEnv)
+
+            do {
+                return try await sendCapturingRegistrations(headers: headers, mvvmEnv: mvvmEnv)
+            } catch let rejection as CredentialRejectedError {
+                guard
+                    let provider = mvvmEnv.clientCredentialProvider,
+                    let refreshed = await provider.credentialHeaders(afterRejection: rejection)
+                else {
+                    throw rejection
+                }
+
+                // Exactly one retry. A second rejection falls to the outer arm and reaches the
+                // caller; a non-rejection failure falls to the outer `ServerRequestError` arm,
+                // which `catch` clauses cannot do on their own (they do not chain).
+                return try await sendCapturingRegistrations(
+                    headers: staticRequestHeaders(mvvmEnv: mvvmEnv) + refreshed,
+                    mvvmEnv: mvvmEnv
+                )
+            }
+        } catch let rejection as CredentialRejectedError {
+            // A surface rejection always reaches the caller — recovery
+            // (refresh credential, retry) is a call-site decision.
+            throw rejection
+        } catch let error as ServerRequestError {
+            if let errorHandler = mvvmEnv.requestErrorHandler {
+                errorHandler(self, error)
+                return []
+            } else {
+                throw error
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `swift test --filter ClientCredentialRoundTripTests`
+Expected: PASS (10 tests — 3 pre-existing + 7 new)
+
+Run: `swift test`
+Expected: PASS
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+swiftformat . && swiftlint
+git add Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift Tests/FOSMVVMVaporTests/Protocols/ClientCredentialRoundTripTests.swift
+git commit -m "feat(fetch): retry once with a refreshed credential after rejection"
+```
+
+---
+
+## Task 4: SSE 401 notification
+
+**Files:**
+- Modify: `Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift:130-132`
+- Test: `Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift`
+
+**Read first:** `ClientChannelRoundTripTests.swift` in full — it uses `withServedFluentTestApp`,
+**not** `withRunningServer`. Model the new tests on `non2xxOpenBacksOffWithoutConnected`
+(`ClientChannelRoundTripTests.swift:105`) and on the existing `DenyAllMiddleware`
+(`ClientChannelRoundTripTests.swift:177`). Do not invent a second harness.
+
+- [ ] **Step 1: Write the failing test**
+
+Two tests, both asserting the refresh tally only — never recovery behavior. The channel's own
+recovery is back-off reconnect, which is already covered.
+
+- **401 → the seam is consulted.** Serve 401 via `DenyAllMiddleware`; use
+  `RefreshingCredentialProvider` from Task 3 (already internal in `CredentialSeamFixtures.swift`).
+- **500 → the seam is not consulted.** Add a `Deny500Middleware` beside the existing
+  `DenyAllMiddleware`.
+
+**Assert `>= 1`, never `== 1`.** The reconnect loop retries indefinitely with growing back-off,
+so the 401 test's tally keeps climbing for as long as the channel lives — an equality assertion
+is flaky by construction. The 500 test asserts `== 0`, which is stable.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter ClientChannelRoundTripTests`
+Expected: FAIL — refresh tally is 0 on the 401 case.
+
+- [ ] **Step 3: Add the notification**
+
+In `openAndStream`, replace lines 130-132:
+
+```swift
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            // A 401 is the credential being refused. Tell the provider so it can refresh and
+            // persist; the return is discarded because the reconnect below re-consults
+            // `credentialHeaders()` — the channel carries no credential state of its own.
+            if http.statusCode == 401 {
+                _ = await credentialProvider?.credentialHeaders(
+                    afterRejection: CredentialRejectedError(code: .invalid)
+                )
+            }
+
+            throw SSEStreamOpenError.badStatus(http.statusCode)
+        }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `swift test --filter ClientChannelRoundTripTests`
+Expected: PASS
+
+Run: `swift test`
+Expected: PASS
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+swiftformat . && swiftlint
+git add "Sources/FOSMVVM/SwiftUI Support/SSEInvalidationChannel.swift" Tests/FOSMVVMVaporTests/LiveInvalidation/ClientChannelRoundTripTests.swift
+git commit -m "feat(live): notify the credential seam when an SSE open is refused"
+```
+
+---
+
+## Task 5: Docs and catalog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: the API catalog, via skill
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Under a new `## 0.10.0` heading, following the format of the existing 0.9.0 entry. State the **contract**, never the representation:
+
+```markdown
+### Added
+
+- `ClientCredentialProvider.credentialHeaders(afterRejection:)` — a refresh seam that
+  lets a client recover from a server-side credential rotation. When a request is refused
+  with `CredentialRejectedError`, the provider may supply replacement headers and the
+  request is retried exactly once; returning `nil` (the default) preserves the previous
+  behavior of throwing to the caller. Providers must persist the refreshed credential —
+  later requests and live-channel reconnects consult `credentialHeaders()`.
+```
+
+- [ ] **Step 2: Update the API catalog**
+
+Run the `fosutilities-api-catalog-update` skill — public API changed, so the catalog audit will otherwise fail in CI.
+
+- [ ] **Step 3: Full verification**
+
+```bash
+swift build && swift test && swiftformat --lint . && swiftlint
+```
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md .claude/skills/shared/api-catalog/
+git commit -m "docs(changelog): stamp 0.10.0 credential refresh seam"
+```
+
+---
+
+## Out of Scope
+
+Per spec §8 — do not implement any of these in this plan:
+
+- The `ViewModelView.swift:517` bind swallow. Its own arc.
+- Any credential acquisition, storage, or refresh coalescing inside the framework.
+- Retry for anything other than `CredentialRejectedError`.
+- A credential bind edge (rejected in spec §1.2).
+- Any change to the 0.7.0 rethrow contract.

--- a/docs/superpowers/specs/2026-07-19-credential-refresh-seam-design.md
+++ b/docs/superpowers/specs/2026-07-19-credential-refresh-seam-design.md
@@ -1,0 +1,356 @@
+# Credential Refresh Seam — Design Spec
+
+**Date:** 2026-07-19
+**Status:** DRAFT — awaiting David's review.
+**Names arbitrated (David, 2026-07-19):** `credentialHeaders(afterRejection:)`,
+returning optional headers, non-throwing.
+**Version target:** 0.10.0 (additive, minor — default implementation preserves
+current behavior for every existing conformance).
+
+> **READ FIRST.** Successor to `2026-07-13-credential-rejection-typed-error-design.md`
+> (shipped 0.7.0). That design made rejection *typed and visible to the call site*.
+> This one gives the call site that FOSMVVM itself owns — the ViewModel bind — a way
+> to act on it. Section 8 lists what this design deliberately does **not** fix.
+
+---
+
+## 1. Problem
+
+A server rotates its bearer token. The client holds a cached one. Every subsequent
+`.live` ViewModel bind fails with `CredentialRejectedError(code: .invalid)` —
+permanently. The only remedy is deleting the client's cache file by hand and
+relaunching.
+
+Three facts compose into the trap.
+
+**(a) The rejection deliberately bypasses recovery.**
+`Sources/FOSMVVM/Protocols/ServerRequest+Fetch.swift:201`:
+
+```swift
+        } catch let rejection as CredentialRejectedError {
+            // A surface rejection always reaches the caller — recovery
+            // (refresh credential, retry) is a call-site decision.
+            throw rejection
+        } catch let error as ServerRequestError {
+            if let errorHandler = mvvmEnv.requestErrorHandler {
+                errorHandler(self, error)
+                return []
+            } else {
+                throw error
+            }
+        }
+```
+
+This is contract, not oversight — `MVVMEnvironment.swift:119` states it: *"Surface
+rejections (`CredentialRejectedError`) are never routed here — they always throw to
+the caller."* The 0.7.0 design ratified it under "Throw past `requestErrorHandler`."
+
+**(b) For a bound ViewModel, FOSMVVM *is* the call site — and it swallows.**
+`Sources/FOSMVVM/SwiftUI Support/ViewModelView.swift:517`:
+
+```swift
+        } catch { // fosmvvm-review:disable:this no-silent-failure -- Error handling is TBD
+            print("ViewModel Bind Error: \(error)")
+            // TODO: Error handling
+```
+
+The application never receives the decision point the contract promises it.
+
+**(c) The provider is never told, so it keeps returning the dead credential.**
+`ClientCredentialProvider` is consulted per request and documented to pick up
+rotation automatically (`ClientCredentialProvider.swift:22-26`). That promise holds
+only if something updates the credential. Nothing tells the provider its credential
+was refused, so it re-supplies the same dead value forever.
+
+### 1.1 Why notification alone is insufficient
+
+Every bind trigger in `ViewModelView.swift` is an **edge** — `onChange` of `query`
+(:418), of `fragment` (:422), of the invalidation and refresh signals (:429, :435,
+:448), or the first `.task` (:452). **Nothing observes the credential.**
+
+So a notify-only seam produces: bind fails → provider is told → app refreshes the
+token successfully → the view still holds `nil` and sits on `ProgressView`, because
+`resolveServerHostedRequest` already returned `(nil, [])` and no edge will fire
+again. The console then holds a *valid* credential and still shows nothing until
+the operator navigates away and back.
+
+The edge that would normally rescue it — `liveCoordinator.refreshSignal` — is
+exactly the one that is also dead, because SSE is reconnecting on the same stale
+token.
+
+**Some retry is therefore load-bearing, not a convenience.**
+
+### 1.2 Why the fix is not a new bind edge
+
+An earlier candidate was to publish a credential-refresh edge for resolvers to
+observe, composing onto `refreshSignal`. It does not compose.
+`LiveRegistrationCoordinator.swift:55` routes by identity, via a token the screen
+obtains only on a **successful** bind — `ViewModelView.swift:475`:
+
+```swift
+    private func loadAndBind() async {
+        let (vm, registrations) = await resolveServerHostedRequest()
+        viewModel = vm
+        guard vm != nil else { return }
+        registerLive(registrations)
+    }
+```
+
+A credential-rejected bind returns `(nil, [])`, hits that `guard`, and registers
+nothing. The stalled screens are precisely the ones the dispatcher cannot reach.
+Non-live screens never register at all and stall identically. A credential edge
+would have to be app-wide, identity-agnostic, and observed by every resolver — a
+new mechanism beside the dispatcher, not an extension of it. Rejected on cost and
+on the "compose onto the general, never a parallel door" rule.
+
+---
+
+## 2. Scope
+
+**In:** the notification/refresh seam and a single bounded retry.
+
+**Out:** the `ViewModelView.swift:517` swallow. It gets its own arc. Its own TODO
+asks for app-level out-of-band error surfacing rather than per-view error views;
+that is a real design pass and must not hold this fix hostage.
+
+Consequence to state plainly: after this change a rotation recovers **silently**.
+The operator sees a brief `ProgressView` and then live data. A rotation that
+recovery *cannot* fix still shows nothing but a console print — unchanged, and
+addressed only by the swallow arc.
+
+---
+
+## 3. Arbitrated decisions (David, 2026-07-19)
+
+**One call, not two.** Notification and supply are a single responsibility:
+*here is what was refused; give me what to send instead, or tell me you have
+nothing.* A separate notify-then-re-ask opens a window in which the provider may
+rotate again, letting the retry use headers the provider never sanctioned for this
+recovery.
+
+**Returns optional headers.** `nil` is an unambiguous "do not retry." The framework
+never asks a second question.
+
+**Non-throwing.** A failed refresh returns `nil` so the framework rethrows the
+*original* `CredentialRejectedError`. A throwing method would replace the real
+diagnosis with a refresh-plumbing error at the call site. The provider logs its own
+failure app-side.
+
+**Named as an overload of the existing supply method.** `credentialHeaders(afterRejection:)`
+roots on `credentialHeaders()` and adds no new name to the namespace — therefore no
+new confusable name shape. The argument label carries the disambiguation, which is
+the part that reads at a call site.
+
+Rejected names, recorded so they are not re-proposed: `credentialRejected(_:)`
+(notification framing this design rejects; also `credentialRejected`/`credentialHeaders`
+is a shared-leading-word, mid-token-differing pair), `refreshedCredentialHeaders(after:)`
+(`after:` does not say after *what*), `renewCredentialHeaders(afterRejection:)`
+(loses the rooting).
+
+---
+
+## 4. Surface (DocC first)
+
+Added to `ClientCredentialProvider`, `Sources/FOSMVVM/Protocols/ClientCredentialProvider.swift`:
+
+```swift
+    /// The replacement headers to retry with after the server refused the last set
+    ///
+    /// Called when a request fails with ``CredentialRejectedError``. Refresh your
+    /// credential and return its headers to have the request retried once with
+    /// them; return `nil` — the default — and the rejection throws to the caller
+    /// unchanged.
+    ///
+    /// ```swift
+    /// func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+    ///     guard afterRejection.code == .invalid else { return nil }
+    ///     guard let token = await SessionStore.shared.refreshAccessToken() else { return nil }
+    ///     return [(field: "Authorization", value: "Bearer \(token)")]
+    /// }
+    /// ```
+    ///
+    /// - Important: **Persist the refreshed credential** — returning it is not enough.
+    ///     The returned headers are used for this one retry; every later request, and
+    ///     every live-channel reconnect, calls ``credentialHeaders()`` instead. A
+    ///     provider that returns a fresh credential without storing it keeps handing
+    ///     out the refused one.
+    /// - Important: Several screens can be refused at once — each bound ViewModel
+    ///     issues its own request and is refused independently. Coalesce concurrent
+    ///     refreshes (single-flight) inside your provider; this method may be called
+    ///     several times in quick succession with the same rejection.
+    /// - Parameter afterRejection: The rejection the server returned, so a provider
+    ///     can distinguish a missing credential from an invalid one
+    /// - Returns: Headers to retry the request with once, or `nil` when no fresh
+    ///     credential is available — the rejection then throws to the caller
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]?
+```
+
+With a default implementation, which is what makes this additive:
+
+```swift
+public extension ClientCredentialProvider {
+    func credentialHeaders(afterRejection: CredentialRejectedError) async -> [(field: String, value: String)]? {
+        nil
+    }
+}
+```
+
+### 4.1 The persistence obligation
+
+The two overloads are not independent. `credentialHeaders(afterRejection:)` returns
+what *this* retry sends; `credentialHeaders()` answers every request after it. The
+design is only coherent if a refresh performed by the former becomes visible to the
+latter — **the provider must persist, not merely return.**
+
+A provider that returns fresh headers without storing them is legal as written and
+fails in two places, neither of which looks like a failure:
+
+- **Every later fetch** re-consults `credentialHeaders()`, gets the refused
+  credential, is rejected, and refreshes again — two round trips per request,
+  indefinitely. Every request still *succeeds*, so nothing surfaces.
+- **The live channel never recovers on an idle app** (§6), because its only path
+  back to a good credential is `credentialHeaders()` on reconnect.
+
+This is the hardest defect in the design to notice from the fetch path alone, which
+is why it is stated as a protocol-level obligation in the DocC above rather than as
+a note on the SSE arm.
+
+The alternative — have the SSE arm reuse the returned headers directly — was
+rejected. It fixes only the second symptom, leaves the per-request doubling in
+place, and requires the channel to carry credential state across a reconnect, which
+§6 exists to avoid.
+
+`BearerCredentialProvider` does **not** override it. It is constructed from a
+token-yielding closure with no refresh capability, and inventing one would put
+credential acquisition inside the framework. Its DocC gains a line pointing to a
+custom conformance for refresh-on-rejection.
+
+---
+
+## 5. Call site — the fetch path
+
+`processRequestCapturingRegistrations(mvvmEnv:)`, `ServerRequest+Fetch.swift:201`.
+The rejection arm gains one bounded retry before the existing rethrow:
+
+- catch `CredentialRejectedError`
+- if `mvvmEnv.clientCredentialProvider` is nil → rethrow (unchanged)
+- ask `credentialHeaders(afterRejection:)`; `nil` → rethrow the **original**
+  rejection (unchanged)
+- otherwise re-send **once**, with the static `requestHeaders` recomposed exactly as
+  on the first attempt and the returned credential headers appended last, preserving
+  the documented duplicate-field precedence at `ServerRequest+Fetch.swift:189-193`
+- a second `CredentialRejectedError` rethrows — the retry is never recursive
+- any non-rejection error from the retry follows the existing
+  `ServerRequestError` / `requestErrorHandler` arm
+
+**Exactly once, and only here.** The retry is not a general policy: it triggers only
+on `CredentialRejectedError`, only when a provider affirmatively supplies
+replacement headers.
+
+Header composition is shared between the first attempt and the retry rather than
+duplicated, so the two can never drift.
+
+### 5.1 Only a *server* rejection opens the seam
+
+The existing `:201` arm also catches a `CredentialRejectedError` thrown by the
+provider's own `credentialHeaders()` at `:193` — before any request is sent. The
+seam must **not** fire there: no server refused anything, and asking a provider that
+just failed to supply a credential to supply a replacement is circular. A rejection
+originating in header composition rethrows unchanged.
+
+### 5.2 Structural constraint the implementer will hit
+
+Swift `catch` clauses do not chain: an error thrown *inside* the
+`catch let rejection as CredentialRejectedError` block does not fall through to the
+sibling `catch let error as ServerRequestError`. So the retry cannot simply be
+inlined into the existing arm — the retry's non-rejection errors would escape
+`requestErrorHandler`, silently breaking the contract §7 pins.
+
+Both this and §5.1 resolve the same way: hoist header composition and the send into
+one private helper, and wrap **only the send** in the retry-aware `do`. Header
+composition then sits outside it (satisfying §5.1 by construction), and the retry
+routes its result back through the single error-handling arm rather than duplicating
+it (satisfying §5.2).
+
+---
+
+## 6. Call site — the SSE channel
+
+`SSEInvalidationChannel.openAndStream`, `SSEInvalidationChannel.swift:115-153`.
+
+SSE mostly rides along for free: it re-consults the provider on every reconnect, so
+once any fetch retry drives the refresh, the next reconnect picks up the good token.
+**This depends entirely on the §4.1 persistence obligation** — without it the
+reconnect re-reads the refused credential and the channel never recovers.
+
+The gap is an app idle enough that no fetch ever fires — SSE then reconnects forever
+on a dead token, back-off capped, never refreshing. Closing it: when the open fails
+with a 401, call `credentialHeaders(afterRejection:)` with
+`CredentialRejectedError(code: .invalid)` and discard the return, then continue into
+the existing drop-and-back-off path. The discard is deliberate — the reconnect
+re-consults `credentialHeaders()` and picks up the refreshed value; SSE gains no
+retry logic of its own.
+
+Only 401 maps this way. Every other non-2xx stays an anonymous drop, per the
+existing comment at `SSEInvalidationChannel.swift:125-129`.
+
+---
+
+## 7. Testing
+
+Contract, never representation.
+
+- provider without an override → one request, rejection throws (today's behavior,
+  proving additivity)
+- provider returning headers → exactly two requests, second carries the new
+  credential, call succeeds
+- provider returning `nil` → one request, original `CredentialRejectedError`
+  rethrown, error identity preserved
+- second rejection on the retry → exactly two requests, rethrown, no third
+- retry preserves static `requestHeaders`, and credential headers still win on a
+  duplicate field
+- a non-rejection error on the retry still reaches `requestErrorHandler`
+- concurrent refused requests each call the seam — asserts the documented
+  many-calls contract the DocC warns about
+- SSE 401 invokes the seam; a non-401 non-2xx does not
+
+Test-side providers must be able to count calls and vary their answer per call.
+
+**Not testable framework-side:** the §4.1 persistence obligation. It is a property of
+the conforming provider, and the framework cannot observe whether a refresh was
+stored. It is enforced by DocC only — which is why §4.1 states it as a contract
+rather than a suggestion.
+
+---
+
+## 8. Non-goals
+
+- **The bind swallow** (`ViewModelView.swift:517`) — own arc, §2.
+- **Credential acquisition.** The framework never mints, refreshes, or stores a
+  credential. It reports a refusal and re-sends what it is handed.
+- **Refresh coalescing.** Provider-side; documented, not enforced.
+- **Retry for anything but credential rejection.** No general retry policy enters
+  FOSMVVM by this door.
+- **A credential bind edge.** Rejected in §1.2.
+- **Changing the 0.7.0 rethrow contract.** A rejection that recovery cannot fix
+  still reaches the caller, unchanged.
+
+---
+
+## 9. Rotation, confirmed (client, 2026-07-19)
+
+Rotation is real: the server rotated its token on restart, and that is what broke
+the console. The client's agent processes survived it because they re-pull on a 426
+rejection; the SwiftUI console had no equivalent path. That missing path is exactly
+what this design adds.
+
+Whether restart-rotation is *intentional* remains open on the client's side. It does
+not gate this work: a rotated credential must be recoverable however rotation is
+triggered. Urgency is real; the design is independent of the answer.
+
+**Adoption cost, confirmed by the client:** a few lines. Their provider is backed by
+an actor fetcher whose `fetchFresh()` already single-flights, so the concurrent-refresh
+coalescing the §4 DocC warns about is satisfied by construction — and, being an actor
+holding the fetched credential, so is the §4.1 persistence obligation. That is one
+data point, not a general one; both obligations stay documented for providers that
+are not actor-backed.


### PR DESCRIPTION
## Summary
- Adds `ClientCredentialProvider.credentialHeaders(afterRejection:)` — a refresh seam (protocol requirement + `nil` default) that lets a client self-heal a rotated server credential instead of failing permanently.
- **Fetch path** retries the refused request exactly once when the provider supplies refreshed headers. Composition sits outside the retry, so a provider-thrown rejection never opens the seam; a non-rejection retry error still reaches `requestErrorHandler`.
- **SSE channel** nudges the same seam on a 401 open (discards the return; the reconnect re-consults `credentialHeaders()`).
- Acquisition/refresh/persistence stay **provider-side**; the 0.7.0 rethrow contract is unchanged; the `ViewModelView` bind swallow is explicitly out of scope.
- Docs: CHANGELOG under `[Unreleased]`, API catalog entry + reach-for index, plugin `2.16.0 → 2.17.0`.

## Test plan
- `swift test` green (255/51, 389/57, 63/16)
- New contract tests: retry-once, decline-rethrows-unretried, second-rejection-no-recursion, compose-outside-seam, non-rejection-routing (§5.2), 4-way concurrency, SSE-401-consults, SSE-500-does-not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124t5yFQuSsSTjh2aJVHoEs